### PR TITLE
feat(network): using different CIDR for the prod and staging environments

### DIFF
--- a/terraform/res_network.tf
+++ b/terraform/res_network.tf
@@ -1,5 +1,5 @@
 locals {
-  vpc_cidr                = "10.0.0.0/16"
+  vpc_cidr                = module.this.stage == "prod" ? "10.0.0.0/16" : "13.0.0.0/16"
   vpc_azs                 = slice(data.aws_availability_zones.available.names, 0, 3)
   vpc_flow_s3_bucket_name = substr("vpc-flow-logs-${module.this.id}-${random_pet.this.id}", 0, 63)
 }


### PR DESCRIPTION
# Description

This PR adds using of different CIDR networks for the production and staging environments.
Depending on the stage:
* `10.0.0.0/16` for production (same as at the moment),
* `13.0.0.0/16` for staging.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
