### PR TITLE
feat(providers): adding Sei network support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -15,6 +15,7 @@ Chain name with associated `chainId` query param to use.
 | zkSync Era Sepolia Testnet <sup>[1](#footnote1)</sup>    | eip155:300           |
 | zkSync Era                                               | eip155:324           |
 | Polygon Zkevm                                            | eip155:1101          |
+| Sei Network <sup>[1](#footnote1)</sup>                   | eip155:1329          |
 | Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |
 | Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5003          |
 | Klaytn Mainnet                                           | eip155:8217          |

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -97,5 +97,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:5000".into(),
             ("mantle-rpc".into(), Weight::new(Priority::High).unwrap()),
         ),
+        // Sei mainnet
+        (
+            "eip155:1329".into(),
+            ("sei-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
     ])
 }

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -96,4 +96,13 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
         "0x1388",
     )
     .await;
+
+    // Sei
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:1329",
+        "0x531",
+    )
+    .await;
 }


### PR DESCRIPTION
# Description

This PR adds [Sei network](https://www.sei.io) support `eip155:1329` for RPC calls by extending the Publicnode provider.
The full [context thread](https://walletconnect.slack.com/archives/C03SCF66K2T/p1727382378579079?thread_ts=1727376353.788319&cid=C03SCF66K2T).

## How Has This Been Tested?

* A new integration test was added.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
