### PR TITLE
fix(ci): bumping `ci_workflows` version

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -49,7 +49,7 @@ jobs:
     name: Lookup deployed version
     if: ${{ inputs.version-type == 'current' }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.2.14
     with:
       task-name-stage: prod
       task-name: ${{ vars.TASK_NAME }}

--- a/.github/workflows/dispatch_publish.yml
+++ b/.github/workflows/dispatch_publish.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.14
     secrets: inherit
     with:
       check-infra: false
@@ -34,7 +34,7 @@ jobs:
 
   release:
     name: Release
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.14
     secrets: inherit
     with:
       infra-changed: false

--- a/.github/workflows/dispatch_validate.yml
+++ b/.github/workflows/dispatch_validate.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.14
     secrets: inherit
     with:
       check-infra: ${{ inputs.check-infra }}

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -46,7 +46,7 @@ jobs:
   ci:
     name: CI
     needs: [ paths-filter ]
-    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.14
     secrets: inherit
     with:
       check-app: ${{ needs.paths-filter.outputs.app == 'true' }}

--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -41,7 +41,7 @@ jobs:
   release:
     name: Release
     needs: [ paths_filter ]
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.14
     secrets: inherit
     with:
       task-name: ${{ vars.TASK_NAME }}

--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -31,7 +31,7 @@ jobs:
   cd-staging:
     name: Staging
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.14
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
@@ -57,7 +57,7 @@ jobs:
     needs: [ validate-staging ]
     if: ${{ inputs.deploy-prod }}
     secrets: inherit
-    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.13
+    uses: WalletConnect/ci_workflows/.github/workflows/cd.yml@0.2.14
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}


### PR DESCRIPTION
# Description

This PR bumps the `ci_workflows` version `0.2.13`->`0.2.14`.

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
