### PR TITLE
feat(providers): adding `Scroll` chain support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -30,6 +30,8 @@ Chain name with associated `chainId` query param to use.
 | Berachain bArtio <sup>[1](#footnote1)</sup>              | eip155:80084         |
 | Base Sepolia                                             | eip155:84532         |
 | Arbitrum Sepolia                                         | eip155:421614        |
+| Scroll Mainnet <sup>[1](#footnote1)</sup>                | eip155:534352        |
+| Scroll Sepolia Testnet <sup>[1](#footnote1)</sup>        | eip155:534351        |
 | Zora <sup>[1](#footnote1)</sup>                          | eip155:7777777       |
 | Ethereum Sepolia                                         | eip155:11155111      |
 | Optimism Sepolia                                         | eip155:11155420      |

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -178,5 +178,21 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Scroll
+        (
+            "eip155:534352".into(),
+            (
+                "scroll-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Scroll sepolia testnet
+        (
+            "eip155:534351".into(),
+            (
+                "scroll-sepolia-testnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -102,5 +102,18 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:1329".into(),
             ("sei-rpc".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Scroll
+        (
+            "eip155:534352".into(),
+            ("scroll-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // Scroll sepolia testnet
+        (
+            "eip155:534351".into(),
+            (
+                "scroll-sepolia-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -128,6 +128,24 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     // zkSync era
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:324", "0x144")
         .await;
+
+    // Scroll
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:534352",
+        "0x82750",
+    )
+    .await;
+
+    // Scroll Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:534351",
+        "0x8274f",
+    )
+    .await;
 }
 
 #[test_context(ServerContext)]

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -7,19 +7,16 @@ use {
 #[tokio::test]
 #[ignore]
 async fn publicnode_provider(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Publicnode;
+
     // Ethereum mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Publicnode,
-        "eip155:1",
-        "0x1",
-    )
-    .await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:1", "0x1")
+        .await;
 
     // Ethereum holesky
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:17000",
         "0x4268",
     )
@@ -28,34 +25,24 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     // Base mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:8453",
         "0x2105",
     )
     .await;
 
     // BSC mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Publicnode,
-        "eip155:56",
-        "0x38",
-    )
-    .await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:56", "0x38")
+        .await;
 
     // BSC testnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Publicnode,
-        "eip155:97",
-        "0x61",
-    )
-    .await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:97", "0x61")
+        .await;
 
     // Avalanche c chain
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:43114",
         "0xa86a",
     )
@@ -64,25 +51,20 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     // Avalanche fuji testnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:43113",
         "0xa869",
     )
     .await;
 
     // Polygon mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Publicnode,
-        "eip155:137",
-        "0x89",
-    )
-    .await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
+        .await;
 
     // Polygon amoy testnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:80002",
         "0x13882",
     )
@@ -91,7 +73,7 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     // Mantle mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:5000",
         "0x1388",
     )
@@ -100,9 +82,27 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     // Sei
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        &ProviderKind::Publicnode,
+        &provider,
         "eip155:1329",
         "0x531",
+    )
+    .await;
+
+    // Scroll
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:534352",
+        "0x82750",
+    )
+    .await;
+
+    // Scroll Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:534351",
+        "0x8274f",
     )
     .await;
 }


### PR DESCRIPTION
# Description

This PR adds support for the Scroll Mainnet `eip155: 534352 ` and Scroll Sepolia testnet `eip155: 534351` chains to the RPC.

## How Has This Been Tested?

* New integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
