### PR TITLE
feat: wallet_getCallsStatus

### DIFF
--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -77,7 +77,7 @@ jobs:
       - run: docker tag ghcr.io/walletconnectfoundation/irn-node:sha-baef4e8 irn:master
       - run: cd irn && docker compose up -d
       - run: docker compose up -d redis postgres
-      # - run: cargo build --tests --features=test-mock-bundler # pre-build to parallelize container startup
+      - run: cargo build --tests --features=test-mock-bundler # pre-build to parallelize container startup
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
       - run: while ! curl localhost:4337/health; do sleep 1; done # Mock Bundler
       - run: while ! curl localhost:3000/ping; do sleep 1; done   # Mock Paymaster

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - run: rustup update stable && rustup default stable
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: WalletConnectBot
+          password: ${{ secrets.PRIVATE_GHCR_TOKEN_WCF }}
+      - run: docker pull ghcr.io/walletconnectfoundation/irn-node:sha-baef4e8
+      - run: docker tag ghcr.io/walletconnectfoundation/irn-node:sha-baef4e8 irn:master
       - run: cd irn && docker compose up -d
       - run: docker compose up -d redis postgres
       - run: docker compose -f docker-compose.mock-bundler.yaml up -d

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - run: rustup update stable && rustup default stable
+      - run: docker compose -f docker-compose.mock-bundler.yaml up -d # run this first since container startup takes foooorrrrrreeeeeeever
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -76,8 +77,9 @@ jobs:
       - run: docker tag ghcr.io/walletconnectfoundation/irn-node:sha-baef4e8 irn:master
       - run: cd irn && docker compose up -d
       - run: docker compose up -d redis postgres
-      - run: docker compose -f docker-compose.mock-bundler.yaml up -d
+      # - run: cargo build --tests --features=test-mock-bundler # pre-build to parallelize container startup
       - run: while ! curl localhost:5432/health; do sleep 1; done # Postgres
+        timeout-minutes: 2
       - run: while ! curl localhost:6379/health; do sleep 1; done # Redis
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
       - run: while ! curl localhost:4337/health; do sleep 1; done # Mock Bundler
@@ -91,6 +93,8 @@ jobs:
           RPC_PROXY_PROVIDER_PIMLICO_API_KEY: ""
           RPC_PROXY_PROVIDER_SOLSCAN_API_V1_TOKEN: ""
           RPC_PROXY_PROVIDER_SOLSCAN_API_V2_TOKEN: ""
+      - run: docker compose logs forked_state-anvil-1 forked_state-alto-1 forked_state-mock-paymaster-1
+        if: failure()
 
   merge_check:
     name: Merge Check

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -81,9 +81,7 @@ jobs:
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
       - run: while ! curl localhost:4337/health; do sleep 1; done # Mock Bundler
       - run: while ! curl localhost:3000/ping; do sleep 1; done   # Mock Paymaster
-      - run: |
-          env
-          cargo test --features=test-mock-bundler --lib --bins
+      - run: cargo test --features=test-mock-bundler --lib --bins
         env:
           RPC_PROXY_POSTGRES_URI: "postgres://postgres@localhost/postgres"
           RPC_PROXY_PROVIDER_INFURA_PROJECT_ID: ""

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -54,6 +54,35 @@ jobs:
       check-udeps: false
       rust-toolchain: stable
 
+  test_bundler:
+    name: Test with mock bundler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
+      - run: rustup update stable && rustup default stable
+      - run: cd irn && docker compose up -d
+      - run: docker compose up -d redis postgres
+      - run: docker compose -f docker-compose.mock-bundler.yaml up -d
+        working-directory: test/scripts/forked_state
+      - run: while ! curl localhost:5432/health; do sleep 1; done # Postgres
+      - run: while ! curl localhost:6379/health; do sleep 1; done # Redis
+      - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
+      - run: while ! curl localhost:4337/health; do sleep 1; done # Mock Bundler
+      - run: while ! curl localhost:3000/ping; do sleep 1; done   # Mock Paymaster
+      - run: cargo test --features=test-mock-bundler --lib --bins
+        env:
+          RPC_PROXY_POSTGRES_URI: "postgres://postgres@localhost/postgres"
+          RPC_PROXY_PROVIDER_INFURA_PROJECT_ID: ""
+          RPC_PROXY_PROVIDER_POKT_PROJECT_ID: ""
+          RPC_PROXY_PROVIDER_QUICKNODE_API_TOKENS: ""
+          RPC_PROXY_PROVIDER_PIMLICO_API_KEY: ""
+          RPC_PROXY_PROVIDER_SOLSCAN_API_V1_TOKEN: ""
+          RPC_PROXY_PROVIDER_SOLSCAN_API_V2_TOKEN: ""
+
   merge_check:
     name: Merge Check
     needs: [ check_pr, ci ]

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -99,6 +99,16 @@ jobs:
         if: failure()
       - run: docker logs mock-bundler-mock-paymaster-1
         if: failure()
+      - run: docker logs blockchain-api-postgres-1
+        if: failure()
+      - run: docker logs blockchain-api-redis-1
+        if: failure()
+      - run: docker logs irn-node-1
+        if: failure()
+      - run: docker logs irn-node-2
+        if: failure()
+      - run: docker logs irn-node-3
+        if: failure()
 
   merge_check:
     name: Merge Check

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - run: rustup update stable && rustup default stable
-      - run: docker compose -f docker-compose.mock-bundler.yaml up -d # run this first since container startup takes foooorrrrrreeeeeeever
+      - run: docker compose -p mock-bundler -f docker-compose.mock-bundler.yaml up -d # run this first since container startup takes foooorrrrrreeeeeeever
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -93,7 +93,7 @@ jobs:
           RPC_PROXY_PROVIDER_PIMLICO_API_KEY: ""
           RPC_PROXY_PROVIDER_SOLSCAN_API_V1_TOKEN: ""
           RPC_PROXY_PROVIDER_SOLSCAN_API_V2_TOKEN: ""
-      - run: docker compose logs forked_state-anvil-1 forked_state-alto-1 forked_state-mock-paymaster-1
+      - run: docker logs mock-bundler-anvil-1 mock-bundler-alto-1 mock-bundler-mock-paymaster-1
         if: failure()
 
   merge_check:

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - run: rustup update stable && rustup default stable

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -53,6 +53,7 @@ jobs:
       check-infra: ${{ needs.paths-filter.outputs.infra == 'true' }}
       check-udeps: false
       rust-toolchain: stable
+      rust-test-args: --features=full,test-localhost --lib --bins
 
   test_bundler:
     name: Test with mock bundler

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -69,7 +69,6 @@ jobs:
       - run: cd irn && docker compose up -d
       - run: docker compose up -d redis postgres
       - run: docker compose -f docker-compose.mock-bundler.yaml up -d
-        working-directory: test/scripts/forked_state
       - run: while ! curl localhost:5432/health; do sleep 1; done # Postgres
       - run: while ! curl localhost:6379/health; do sleep 1; done # Redis
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -81,7 +81,9 @@ jobs:
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
       - run: while ! curl localhost:4337/health; do sleep 1; done # Mock Bundler
       - run: while ! curl localhost:3000/ping; do sleep 1; done   # Mock Paymaster
-      - run: cargo test --features=test-mock-bundler --lib --bins
+      - run: |
+          env
+          cargo test --features=test-mock-bundler --lib --bins
         env:
           RPC_PROXY_POSTGRES_URI: "postgres://postgres@localhost/postgres"
           RPC_PROXY_PROVIDER_INFURA_PROJECT_ID: ""

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -78,9 +78,6 @@ jobs:
       - run: cd irn && docker compose up -d
       - run: docker compose up -d redis postgres
       # - run: cargo build --tests --features=test-mock-bundler # pre-build to parallelize container startup
-      - run: while ! curl localhost:5432/health; do sleep 1; done # Postgres
-        timeout-minutes: 2
-      - run: while ! curl localhost:6379/health; do sleep 1; done # Redis
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
       - run: while ! curl localhost:4337/health; do sleep 1; done # Mock Bundler
       - run: while ! curl localhost:3000/ping; do sleep 1; done   # Mock Paymaster

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -93,7 +93,11 @@ jobs:
           RPC_PROXY_PROVIDER_PIMLICO_API_KEY: ""
           RPC_PROXY_PROVIDER_SOLSCAN_API_V1_TOKEN: ""
           RPC_PROXY_PROVIDER_SOLSCAN_API_V2_TOKEN: ""
-      - run: docker logs mock-bundler-anvil-1 mock-bundler-alto-1 mock-bundler-mock-paymaster-1
+      - run: docker logs mock-bundler-anvil-1
+        if: failure()
+      - run: docker logs mock-bundler-alto-1
+        if: failure()
+      - run: docker logs mock-bundler-mock-paymaster-1
         if: failure()
 
   merge_check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,7 +4226,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -6369,7 +6369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.77",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -4226,7 +4226,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -6369,7 +6369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.77",
@@ -9356,7 +9356,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9707,9 +9707,11 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?rev=5b0c319#5b0c3196dbf203ec1b73cfdfb7cc41d6d82b2414"
+source = "git+https://github.com/reown-com/yttrium.git?branch=fix/support-get-calls-status#0bdf26ca269d585c576e067aa4abad8fc5e5cdc6"
 dependencies = [
  "alloy",
+ "alloy-provider",
+ "async-trait",
  "dotenvy",
  "eyre",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?branch=fix/support-get-calls-status#435d0b6204a110fb048bc0a38a877d71f42f1312"
+source = "git+https://github.com/reown-com/yttrium.git#33621880a9a11881c7358e749aa65f8a53080c18"
 dependencies = [
  "alloy",
  "alloy-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,7 +4226,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -6369,7 +6369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.77",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?branch=fix/support-get-calls-status#0bdf26ca269d585c576e067aa4abad8fc5e5cdc6"
+source = "git+https://github.com/reown-com/yttrium.git?branch=fix/support-get-calls-status#435d0b6204a110fb048bc0a38a877d71f42f1312"
 dependencies = [
  "alloy",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
-yttrium = { git = "https://github.com/reown-com/yttrium.git", branch = "fix/support-get-calls-status" }
+yttrium = { git = "https://github.com/reown-com/yttrium.git" }
 
 # Async
 async-trait = "0.1.82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
-yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "5b0c319" }
+yttrium = { git = "https://github.com/reown-com/yttrium.git", branch = "fix/support-get-calls-status" }
 
 # Async
 async-trait = "0.1.82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ vergen = { version = "6", default-features = false, features = ["build", "cargo"
 [features]
 full = []
 test-localhost = []
+test-mock-bundler = []
 
 [profile.release-debug]
 inherits = "release"

--- a/docker-compose.mock-bundler.yaml
+++ b/docker-compose.mock-bundler.yaml
@@ -1,0 +1,23 @@
+services:
+  anvil:
+    image: ghcr.io/foundry-rs/foundry:nightly-96105b4d240681c336e063eac0e250cc51a84414
+    restart: unless-stopped
+    ports: ["8545:8545"]
+    entrypoint: [ "anvil", "--fork-url", "https://gateway.tenderly.co/public/sepolia", "--host", "0.0.0.0", "--block-time", "0.1", "--gas-price", "1", "--silent", "--hardfork", "prague" ]
+    platform: linux/amd64
+ 
+  mock-paymaster:
+    image: ghcr.io/pimlicolabs/mock-verifying-paymaster:main
+    restart: unless-stopped
+    ports: ["3000:3000"]
+    environment:
+      - ALTO_RPC=http://alto:4337
+      - ANVIL_RPC=http://anvil:8545
+ 
+  alto:
+    image: ghcr.io/pimlicolabs/mock-alto-bundler:main
+    restart: unless-stopped
+    ports: ["4337:4337"]
+    environment:
+      - ANVIL_RPC=http://anvil:8545
+      - SKIP_DEPLOYMENTS=true

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -69,6 +69,7 @@ pub enum MessageSource {
     SessionCoSignSigValidate,
     WalletPrepareCalls,
     WalletSendPreparedCalls,
+    WalletGetCallsStatus,
 }
 
 #[cfg(test)]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -273,6 +273,7 @@ mod test {
                     pimlico_api_key: "PIMLICO_API_KEY".to_string(),
                     solscan_api_v1_token: "SOLSCAN_API_V1_TOKEN".to_string(),
                     solscan_api_v2_token: "SOLSCAN_API_V2_TOKEN".to_string(),
+                    override_bundler_urls: None,
                 },
                 rate_limiting: RateLimitingConfig {
                     max_tokens: Some(100),

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -57,6 +57,7 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> error::RpcResult<Config> {
+        println!("RPC_PROXY_POSTGRES_URI: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         Ok(Self {
             server: from_env("RPC_PROXY_")?,
             registry: from_env("RPC_PROXY_REGISTRY_")?,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -57,7 +57,7 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> error::RpcResult<Config> {
-        println!("RPC_PROXY_POSTGRES_URI: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
+        println!("RPC_PROXY_POSTGRES_URI 0: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         Ok(Self {
             server: from_env("RPC_PROXY_")?,
             registry: from_env("RPC_PROXY_REGISTRY_")?,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -101,6 +101,7 @@ mod test {
     };
 
     #[test]
+    #[cfg(not(feature = "test-mock-bundler"))] // These tests depend on environment variables
     fn ensure_env_var_config() {
         let values = [
             // Server config.

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -57,7 +57,6 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> error::RpcResult<Config> {
-        println!("RPC_PROXY_POSTGRES_URI 0: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         Ok(Self {
             server: from_env("RPC_PROXY_")?,
             registry: from_env("RPC_PROXY_REGISTRY_")?,
@@ -84,6 +83,7 @@ pub trait ProviderConfig {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "test-mock-bundler"))] // These tests depend on environment variables
 mod test {
     use {
         crate::{
@@ -101,7 +101,6 @@ mod test {
     };
 
     #[test]
-    #[cfg(not(feature = "test-mock-bundler"))] // These tests depend on environment variables
     fn ensure_env_var_config() {
         let values = [
             // Server config.

--- a/src/env/server.rs
+++ b/src/env/server.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{utils, utils::network::NetworkInterfaceError},
+    crate::utils::{self, network::NetworkInterfaceError},
     serde::Deserialize,
     serde_piecewise_default::DeserializePiecewiseDefault,
     std::net::IpAddr,

--- a/src/handlers/bundler.rs
+++ b/src/handlers/bundler.rs
@@ -4,6 +4,7 @@ use {
         error::RpcError, providers::SupportedBundlerOps, state::AppState,
         utils::crypto::disassemble_caip2,
     },
+    alloy::rpc::json_rpc::Id,
     axum::{
         extract::{Query, State},
         response::{IntoResponse, Response},
@@ -30,8 +31,8 @@ pub struct BundlerQueryParams {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BundlerJsonRpcRequest {
-    pub id: u64,
-    pub jsonrpc: String,
+    pub id: Id,
+    pub jsonrpc: Arc<str>,
     pub method: SupportedBundlerOps,
     pub params: serde_json::Value,
 }
@@ -62,7 +63,7 @@ async fn handler_internal(
         .bundler_rpc_call(
             &evm_chain_id,
             request_payload.id,
-            &request_payload.jsonrpc,
+            request_payload.jsonrpc,
             &request_payload.method,
             request_payload.params,
         )

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -517,7 +517,7 @@ impl JsonRpcClient for SelfProvider {
             self.query.clone(),
             self.headers.clone(),
             serde_json::to_vec(&crypto::JsonRpcRequest {
-                id,
+                id: id.into(),
                 jsonrpc: crypto::JSON_RPC_VERSION.clone(),
                 method: method.to_owned().into(),
                 params,

--- a/src/handlers/wallet/call_id.rs
+++ b/src/handlers/wallet/call_id.rs
@@ -1,0 +1,26 @@
+use alloy::primitives::{Bytes, B256, U64};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallId(pub CallIdInner);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CallIdInner {
+    pub chain_id: U64,
+    pub user_op_hash: B256,
+}
+
+impl Serialize for CallId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Bytes::from(serde_json::to_vec(&self.0).map_err(serde::ser::Error::custom)?)
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CallId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes = Bytes::deserialize(deserializer)?;
+        let inner = serde_json::from_slice(&bytes).map_err(serde::de::Error::custom)?;
+        Ok(Self(inner))
+    }
+}

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -315,6 +315,11 @@ mod tests {
             std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
         );
         let faucet = LocalSigner::random();
+        std::env::vars().for_each(|(k, v)| println!("{}: {}", k, v));
+        println!(
+            "RPC_PROXY_POSTGRES_URI b.2: {:?}",
+            std::env::var_os("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
         println!(
             "RPC_PROXY_POSTGRES_URI b.2: {}",
             std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -310,7 +310,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_calls_status() {
-        println!("RPC_PROXY_POSTGRES_URI: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
+        println!("RPC_PROXY_POSTGRES_URI -1: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         // let anvil = Anvil::new().spawn();
         let config = Config::local();
         let faucet = anvil_faucet(config.endpoints.rpc.base_url.clone()).await;

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -331,7 +331,7 @@ mod tests {
         config::Config,
         smart_accounts::safe::{get_account_address, Owners},
         test_helpers::{anvil_faucet, use_faucet},
-        transaction::{send::safe_test::send_transaction, Transaction},
+        transaction::{send::safe_test::send_transactions, Transaction},
     };
 
     #[tokio::test]
@@ -371,7 +371,7 @@ mod tests {
             data: Bytes::new(),
         }];
 
-        let receipt = send_transaction(transaction, owner.clone(), None, None, config.clone())
+        let receipt = send_transactions(transaction, owner.clone(), None, None, config.clone())
             .await
             .unwrap();
         assert!(receipt.success);

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -298,15 +298,42 @@ mod tests {
     use alloy::{
         network::Ethereum,
         primitives::{Bytes, Uint, U256, U64, U8},
-        providers::{Provider, ReqwestProvider},
-        signers::local::LocalSigner,
+        providers::{ext::AnvilApi, Provider, ReqwestProvider},
+        signers::{k256::ecdsa::SigningKey, local::LocalSigner},
     };
+    use reqwest::IntoUrl;
     use yttrium::{
         config::Config,
         smart_accounts::safe::{get_account_address, Owners},
-        test_helpers::{anvil_faucet, use_faucet},
+        test_helpers::use_faucet,
         transaction::{send::safe_test::send_transactions, Transaction},
     };
+
+    pub async fn anvil_faucet<T: IntoUrl>(url: T) -> LocalSigner<SigningKey> {
+        println!(
+            "RPC_PROXY_POSTGRES_URI b.1: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
+        let faucet = LocalSigner::random();
+        println!(
+            "RPC_PROXY_POSTGRES_URI b.2: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
+        let provider = ReqwestProvider::<Ethereum>::new_http(url.into_url().unwrap());
+        println!(
+            "RPC_PROXY_POSTGRES_URI b.3: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
+        provider
+            .anvil_set_balance(faucet.address(), U256::MAX)
+            .await
+            .unwrap();
+        println!(
+            "RPC_PROXY_POSTGRES_URI b.4: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
+        faucet
+    }
 
     #[tokio::test]
     async fn test_get_calls_status() {

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -1,0 +1,411 @@
+use super::call_id::CallId;
+use crate::{
+    analytics::MessageSource,
+    handlers::{RpcQueryParams, HANDLER_TASK_METRICS},
+    state::AppState,
+};
+use alloy::{
+    network::Ethereum,
+    primitives::{Address, BlockHash, Bytes, TxHash, B256, U128, U64, U8},
+    providers::RootProvider,
+    rpc::client::RpcClient,
+};
+use axum::{
+    extract::{ConnectInfo, State},
+    response::{IntoResponse, Response},
+    Json,
+};
+use hyper::{HeaderMap, StatusCode};
+use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, sync::Arc};
+use thiserror::Error;
+use tracing::error;
+use wc::future::FutureExt;
+use yttrium::{
+    bundler::{client::CustomErc4337Api, models::user_operation_receipt::UserOperationReceipt},
+    chain::ChainId,
+};
+
+pub type GetCallsStatusParams = (CallId,);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetCallsStatusResult {
+    status: CallStatus,
+    // TODO use tagged enum to avoid this Option
+    receipts: Option<Vec<CallReceipt>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CallStatus {
+    Pending,
+    Confirmed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallReceipt {
+    logs: Vec<CallReceiptLog>,
+    status: U8,
+    chain_id: U64,
+    block_hash: BlockHash,
+    block_number: U64,
+    gas_used: U128,
+    transaction_hash: TxHash,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallReceiptLog {
+    address: Address,
+    data: Bytes,
+    topics: Vec<B256>,
+}
+
+#[derive(Error, Debug)]
+pub enum GetCallsStatusError {
+    #[error("Internal error")]
+    InternalError(GetCallsStatusInternalError),
+}
+
+#[derive(Error, Debug)]
+pub enum GetCallsStatusInternalError {}
+
+impl IntoResponse for GetCallsStatusError {
+    fn into_response(self) -> Response {
+        #[allow(unreachable_patterns)] // TODO remove
+        match self {
+            Self::InternalError(e) => {
+                error!("HTTP server error: (get_calls_status) {e:?}");
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+            e => (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": e.to_string(),
+                })),
+            )
+                .into_response(),
+        }
+    }
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    project_id: String,
+    request: GetCallsStatusParams,
+    connect_info: ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<GetCallsStatusResult, GetCallsStatusError> {
+    handler_internal(state, project_id, request, connect_info, headers)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("wallet_prepare_calls"))
+        .await
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    project_id: String,
+    request: GetCallsStatusParams,
+    ConnectInfo(connect_info): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<GetCallsStatusResult, GetCallsStatusError> {
+    let chain_id = ChainId::new_eip155(request.0 .0.chain_id.to());
+    let provider = RootProvider::<_, Ethereum>::new(RpcClient::new(
+        self_transport::SelfTransport {
+            state: state.0.clone(),
+            connect_info,
+            headers,
+            query: RpcQueryParams {
+                chain_id: chain_id.caip2_identifier(),
+                project_id,
+                provider_id: None,
+                source: Some(MessageSource::WalletGetCallsStatus),
+            },
+            chain_id,
+        },
+        false,
+    ));
+
+    let receipt = provider
+        .get_user_operation_receipt(request.0 .0.user_op_hash)
+        .await
+        .unwrap();
+    // TODO handle None as CallStatus::Pending
+
+    Ok(GetCallsStatusResult {
+        status: if receipt.receipt.status == U8::from(1) {
+            CallStatus::Confirmed
+        } else {
+            CallStatus::Pending
+        },
+        receipts: Some(vec![user_operation_receipt_to_call_receipt(
+            request.0 .0.chain_id,
+            receipt,
+        )]),
+    })
+}
+
+fn user_operation_receipt_to_call_receipt(
+    chain_id: U64,
+    receipt: UserOperationReceipt,
+) -> CallReceipt {
+    CallReceipt {
+        logs: receipt
+            .logs
+            .into_iter()
+            .map(|log| CallReceiptLog {
+                address: log.address,
+                topics: log.topics,
+                data: log.data,
+            })
+            .collect(),
+        status: receipt.receipt.status,
+        chain_id,
+        block_hash: receipt.receipt.block_hash,
+        block_number: receipt.receipt.block_number,
+        gas_used: receipt.receipt.gas_used,
+        transaction_hash: receipt.receipt.transaction_hash,
+    }
+}
+
+mod self_transport {
+    use {
+        crate::{
+            handlers::RpcQueryParams, json_rpc::JSON_RPC_VERSION, providers::SupportedBundlerOps,
+            state::AppState,
+        },
+        alloy::{
+            rpc::json_rpc::{RequestPacket, Response, ResponsePacket},
+            transports::{TransportError, TransportFut},
+        },
+        hyper::HeaderMap,
+        std::{net::SocketAddr, sync::Arc, task::Poll},
+        tower::Service,
+        yttrium::chain::ChainId,
+    };
+
+    #[derive(Clone)]
+    pub struct SelfTransport {
+        pub state: Arc<AppState>,
+        pub connect_info: SocketAddr,
+        pub query: RpcQueryParams,
+        pub headers: HeaderMap,
+        pub chain_id: ChainId,
+    }
+
+    impl Service<RequestPacket> for SelfTransport {
+        type Error = TransportError;
+        type Future = TransportFut<'static>;
+        type Response = ResponsePacket;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: RequestPacket) -> Self::Future {
+            let state = self.state.clone();
+            let _connect_info = self.connect_info;
+            let _query = self.query.clone();
+            let _headers = self.headers.clone();
+            let caip2_identifier = self.chain_id.caip2_identifier();
+
+            Box::pin(async move {
+                // TODO handle batch
+                let req = match req {
+                    RequestPacket::Single(req) => req,
+                    RequestPacket::Batch(_) => unimplemented!(),
+                };
+
+                // let id = SystemTime::now()
+                //     .duration_since(UNIX_EPOCH)
+                //     .expect("Time should't go backwards")
+                //     .as_millis()
+                //     .to_string();
+
+                // let body = req.serialized().to_string().into_bytes().into();
+
+                // let response = rpc_call(state, connect_info, query, headers, body)
+                //     .await
+                //     // .map_err(SelfProviderError::RpcError)?;
+                //     .unwrap();
+                let response = state
+                    .providers
+                    .bundler_ops_provider
+                    .bundler_rpc_call(
+                        &caip2_identifier,
+                        req.id().clone(),
+                        JSON_RPC_VERSION.clone(),
+                        &serde_json::from_value::<SupportedBundlerOps>(serde_json::json!(
+                            req.method()
+                        ))
+                        .unwrap(),
+                        serde_json::from_str(req.params().unwrap().get()).unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                let body = serde_json::to_string(response.get("result").unwrap()).unwrap();
+
+                // TODO handle error response status
+                // if response.status() != StatusCode::OK {
+                //     return Err(SelfProviderError::ProviderError {
+                //         status: response.status(),
+                //         body: format!("{:?}", response.body()),
+                //     });
+                // }
+                // response.body().
+
+                // let bytes = to_bytes(response.into_body()).await.unwrap();
+                // .map_err(SelfProviderError::ProviderBody)?;
+
+                // let body = String::from_utf8(bytes.to_vec()).unwrap();
+                // let response = serde_json::from_slice::<JsonRpcResponse>(&bytes)
+                // .unwrap();
+                //     // .map_err(SelfProviderError::ProviderBodySerde)?;
+
+                // let result = match response {
+                //     JsonRpcResponse::Error(e) => return
+                // Err(SelfProviderError::JsonRpcError(e)),
+                //     JsonRpcResponse::Result(r) => {
+                //         // We shouldn't process with `0x` result because this leads to the
+                // ethers-rs         // panic when looking for an avatar
+                //         if r.result == EMPTY_RPC_RESPONSE {
+                //             return Err(SelfProviderError::ProviderError {
+                //                 status: StatusCode::METHOD_NOT_ALLOWED,
+                //                 body: format!("JSON-RPC result is {}", EMPTY_RPC_RESPONSE),
+                //             });
+                //         } else {
+                //             r.result
+                //         }
+                //     }
+                // };
+
+                // let result = serde_json::from_value(result).unwrap();
+                // // .map_err(|_| {
+                // //     SelfProviderError::GenericParameterError(
+                // //         "Caller always provides generic parameter R=Bytes".into(),
+                // //     )
+                // // })?;
+                // Ok(result)
+
+                Ok(ResponsePacket::Single(Response {
+                    id: req.id().clone(),
+                    payload: alloy::rpc::json_rpc::ResponsePayload::Success(
+                        serde_json::value::RawValue::from_string(body).unwrap(),
+                    ),
+                }))
+            })
+        }
+    }
+}
+
+// TODO test case:
+// - anvil node bindings
+// - run normal safe_test transaction
+// - check "call status" with above code
+// - check receipt contents, e.g. confirmed, pending. Unsuccessful txn
+// - what about missing Option in alloy's getUserOperationReceipt
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        handlers::wallet::{
+            call_id::{CallId, CallIdInner},
+            get_calls_status::{CallStatus, GetCallsStatusResult},
+            handler::WALLET_GET_CALLS_STATUS,
+        },
+        providers::mock_alto::MockAltoUrls,
+        test_helpers::spawn_blockchain_api_with_params,
+    };
+    use alloy::{
+        network::Ethereum,
+        primitives::{Bytes, Uint, U256, U64, U8},
+        providers::{Provider, ReqwestProvider},
+        signers::local::LocalSigner,
+    };
+    use yttrium::{
+        config::Config,
+        smart_accounts::safe::{get_account_address, Owners},
+        test_helpers::{anvil_faucet, use_faucet},
+        transaction::{send::safe_test::send_transaction, Transaction},
+    };
+
+    #[tokio::test]
+    async fn test_get_calls_status() {
+        // let anvil = Anvil::new().spawn();
+        let config = Config::local();
+        let faucet = anvil_faucet(config.endpoints.rpc.base_url.clone()).await;
+
+        let provider =
+            ReqwestProvider::<Ethereum>::new_http(config.endpoints.rpc.base_url.parse().unwrap());
+
+        let destination = LocalSigner::random();
+        let balance = provider.get_balance(destination.address()).await.unwrap();
+        assert_eq!(balance, Uint::from(0));
+
+        let owner = LocalSigner::random();
+        let sender_address = get_account_address(
+            provider.clone(),
+            Owners {
+                owners: vec![owner.address()],
+                threshold: 1,
+            },
+        )
+        .await;
+
+        use_faucet(
+            provider.clone(),
+            faucet.clone(),
+            U256::from(2),
+            sender_address.into(),
+        )
+        .await;
+
+        let transaction = vec![Transaction {
+            to: destination.address(),
+            value: Uint::from(1),
+            data: Bytes::new(),
+        }];
+
+        let receipt = send_transaction(transaction, owner.clone(), None, None, config.clone())
+            .await
+            .unwrap();
+        assert!(receipt.success);
+
+        let balance = provider.get_balance(destination.address()).await.unwrap();
+        assert_eq!(balance, Uint::from(1));
+
+        let url = spawn_blockchain_api_with_params(crate::test_helpers::Params {
+            validate_project_id: false,
+            override_bundler_urls: Some(MockAltoUrls {
+                bundler_url: config.endpoints.bundler.base_url.parse().unwrap(),
+                paymaster_url: config.endpoints.paymaster.base_url.parse().unwrap(),
+            }),
+        })
+        .await;
+        let mut endpoint = url.join("/v1/wallet").unwrap();
+        endpoint.query_pairs_mut().append_pair("projectId", "test");
+        let provider = ReqwestProvider::<Ethereum>::new_http(endpoint);
+        let result = provider
+            .client()
+            .request::<_, GetCallsStatusResult>(
+                WALLET_GET_CALLS_STATUS,
+                (CallId(CallIdInner {
+                    chain_id: U64::from(11155111),
+                    user_op_hash: receipt.user_op_hash,
+                }),),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.status, CallStatus::Confirmed);
+        let receipts = result.receipts.unwrap();
+        assert_eq!(receipts.len(), 1);
+        let receipt = receipts.first().unwrap();
+        assert_eq!(receipt.status, U8::from(1));
+        assert_eq!(receipt.chain_id, U64::from(11155111));
+    }
+}

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -310,6 +310,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_calls_status() {
+        println!("RPC_PROXY_POSTGRES_URI: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         // let anvil = Anvil::new().spawn();
         let config = Config::local();
         let faucet = anvil_faucet(config.endpoints.rpc.base_url.clone()).await;

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -298,80 +298,28 @@ mod tests {
     use alloy::{
         network::Ethereum,
         primitives::{Bytes, Uint, U256, U64, U8},
-        providers::{ext::AnvilApi, Provider, ReqwestProvider},
-        signers::{k256::ecdsa::SigningKey, local::LocalSigner},
+        providers::{Provider, ReqwestProvider},
+        signers::local::LocalSigner,
     };
-    use reqwest::IntoUrl;
     use yttrium::{
         config::Config,
         smart_accounts::safe::{get_account_address, Owners},
-        test_helpers::use_faucet,
+        test_helpers::{anvil_faucet, use_faucet},
         transaction::{send::safe_test::send_transactions, Transaction},
     };
 
-    pub async fn anvil_faucet<T: IntoUrl>(url: T) -> LocalSigner<SigningKey> {
-        println!(
-            "RPC_PROXY_POSTGRES_URI b.1: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
-        let faucet = LocalSigner::random();
-        std::env::vars().for_each(|(k, v)| println!("{}: {}", k, v));
-        println!(
-            "RPC_PROXY_POSTGRES_URI b.2: {:?}",
-            std::env::var_os("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
-        println!(
-            "RPC_PROXY_POSTGRES_URI b.2: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
-        let provider = ReqwestProvider::<Ethereum>::new_http(url.into_url().unwrap());
-        println!(
-            "RPC_PROXY_POSTGRES_URI b.3: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
-        provider
-            .anvil_set_balance(faucet.address(), U256::MAX)
-            .await
-            .unwrap();
-        println!(
-            "RPC_PROXY_POSTGRES_URI b.4: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
-        faucet
-    }
-
     #[tokio::test]
     async fn test_get_calls_status() {
-        println!(
-            "RPC_PROXY_POSTGRES_URI -1: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
         // let anvil = Anvil::new().spawn();
         let config = Config::local();
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.2: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
         let faucet = anvil_faucet(config.endpoints.rpc.base_url.clone()).await;
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.3: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
 
         let provider =
             ReqwestProvider::<Ethereum>::new_http(config.endpoints.rpc.base_url.parse().unwrap());
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.4: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
 
         let destination = LocalSigner::random();
         let balance = provider.get_balance(destination.address()).await.unwrap();
         assert_eq!(balance, Uint::from(0));
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.5: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
 
         let owner = LocalSigner::random();
         let sender_address = get_account_address(
@@ -382,10 +330,6 @@ mod tests {
             },
         )
         .await;
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.6: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
 
         use_faucet(
             provider.clone(),
@@ -394,10 +338,6 @@ mod tests {
             sender_address.into(),
         )
         .await;
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.7: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
 
         let transaction = vec![Transaction {
             to: destination.address(),
@@ -409,18 +349,10 @@ mod tests {
             .await
             .unwrap();
         assert!(receipt.success);
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.8: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
 
         let balance = provider.get_balance(destination.address()).await.unwrap();
         assert_eq!(balance, Uint::from(1));
 
-        println!(
-            "RPC_PROXY_POSTGRES_URI a.199: {}",
-            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
-        );
         let url = spawn_blockchain_api_with_params(crate::test_helpers::Params {
             validate_project_id: false,
             override_bundler_urls: Some(MockAltoUrls {

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -310,17 +310,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_calls_status() {
-        println!("RPC_PROXY_POSTGRES_URI -1: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
+        println!(
+            "RPC_PROXY_POSTGRES_URI -1: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
         // let anvil = Anvil::new().spawn();
         let config = Config::local();
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.2: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
         let faucet = anvil_faucet(config.endpoints.rpc.base_url.clone()).await;
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.3: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
 
         let provider =
             ReqwestProvider::<Ethereum>::new_http(config.endpoints.rpc.base_url.parse().unwrap());
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.4: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
 
         let destination = LocalSigner::random();
         let balance = provider.get_balance(destination.address()).await.unwrap();
         assert_eq!(balance, Uint::from(0));
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.5: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
 
         let owner = LocalSigner::random();
         let sender_address = get_account_address(
@@ -331,6 +350,10 @@ mod tests {
             },
         )
         .await;
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.6: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
 
         use_faucet(
             provider.clone(),
@@ -339,6 +362,10 @@ mod tests {
             sender_address.into(),
         )
         .await;
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.7: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
 
         let transaction = vec![Transaction {
             to: destination.address(),
@@ -350,10 +377,18 @@ mod tests {
             .await
             .unwrap();
         assert!(receipt.success);
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.8: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
 
         let balance = provider.get_balance(destination.address()).await.unwrap();
         assert_eq!(balance, Uint::from(1));
 
+        println!(
+            "RPC_PROXY_POSTGRES_URI a.199: {}",
+            std::env::var("RPC_PROXY_POSTGRES_URI").unwrap()
+        );
         let url = spawn_blockchain_api_with_params(crate::test_helpers::Params {
             validate_project_id: false,
             override_bundler_urls: Some(MockAltoUrls {

--- a/src/handlers/wallet/mod.rs
+++ b/src/handlers/wallet/mod.rs
@@ -1,3 +1,5 @@
+pub mod call_id;
+pub mod get_calls_status;
 pub mod handler;
 pub mod prepare_calls;
 pub mod send_prepared_calls;

--- a/src/handlers/wallet/prepare_calls.rs
+++ b/src/handlers/wallet/prepare_calls.rs
@@ -1,6 +1,5 @@
 use super::types::PreparedCalls;
 use crate::analytics::MessageSource;
-use crate::error::RpcError;
 use crate::handlers::sessions::get::{
     get_session_context, GetSessionContextError, InternalGetSessionContextError,
 };
@@ -87,9 +86,6 @@ pub struct SignatureRequest {
 
 #[derive(Error, Debug)]
 pub enum PrepareCallsError {
-    #[error("Invalid project ID: {0}")]
-    InvalidProjectId(RpcError),
-
     #[error("Invalid address")]
     InvalidAddress,
 

--- a/src/handlers/wallet/send_prepared_calls.rs
+++ b/src/handlers/wallet/send_prepared_calls.rs
@@ -1,3 +1,4 @@
+use super::call_id::{CallId, CallIdInner};
 use super::prepare_calls::{
     decode_smart_session_signature, encode_use_or_enable_smart_session_signature,
     split_permissions_context_and_check_validator, AccountType, DecodedSmartSessionSignature,
@@ -5,7 +6,6 @@ use super::prepare_calls::{
 };
 use super::types::PreparedCalls;
 use crate::analytics::MessageSource;
-use crate::error::RpcError;
 use crate::handlers::sessions::cosign::{self, CoSignQueryParams};
 use crate::handlers::sessions::get::{
     get_session_context, GetSessionContextError, InternalGetSessionContextError,
@@ -14,7 +14,7 @@ use crate::handlers::sessions::CoSignRequest;
 use crate::utils::crypto::UserOperation;
 use crate::{handlers::HANDLER_TASK_METRICS, state::AppState};
 use alloy::network::Ethereum;
-use alloy::primitives::{Bytes, B256};
+use alloy::primitives::{Bytes, U64};
 use alloy::providers::ReqwestProvider;
 use axum::extract::{Path, Query};
 use axum::{
@@ -49,13 +49,10 @@ pub struct SendPreparedCallsRequestItem {
     context: Uuid,
 }
 
-pub type SendPreparedCallsResponse = Vec<B256>;
+pub type SendPreparedCallsResponse = Vec<CallId>;
 
 #[derive(Error, Debug)]
 pub enum SendPreparedCallsError {
-    #[error("Invalid project ID: {0}")]
-    InvalidProjectId(RpcError),
-
     #[error("Invalid address")]
     InvalidAddress,
 
@@ -453,7 +450,10 @@ async fn handler_internal(
                 )
             })?;
 
-        response.push(user_op_hash);
+        response.push(CallId(CallIdInner {
+            chain_id: U64::from(chain_id.eip155_chain_id()),
+            user_op_hash,
+        }));
     }
 
     Ok(response)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@ mod storage;
 pub mod utils;
 mod ws;
 
+#[cfg(test)]
+pub mod test_helpers;
+
 pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ServiceMetrics::init_with_name("rpc-proxy");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,9 @@ mod project;
 pub mod providers;
 mod state;
 mod storage;
+pub mod test_helpers;
 pub mod utils;
 mod ws;
-
-#[cfg(test)]
-pub mod test_helpers;
 
 pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ServiceMetrics::init_with_name("rpc-proxy");

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -27,7 +27,7 @@ pub async fn spawn_blockchain_api() -> Url {
 }
 
 pub async fn spawn_blockchain_api_with_params(params: Params) -> Url {
-    dotenv::dotenv().ok();
+    // dotenv::dotenv().ok();
 
     let public_port = get_random_port();
     let prometheus_port = get_random_port();

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -35,8 +35,11 @@ pub async fn spawn_blockchain_api_with_params(params: Params) -> Url {
     let rt = Handle::current();
     let public_addr = SocketAddr::new(IpAddr::V4(hostname), public_port);
 
+    println!("RPC_PROXY_POSTGRES_URI 1: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
     std::thread::spawn(move || {
+        println!("RPC_PROXY_POSTGRES_URI 2: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         rt.block_on(async move {
+            println!("RPC_PROXY_POSTGRES_URI 3: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
             let mut config = Config::from_env()?;
             config.server = ServerConfig {
                 port: public_port,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,85 @@
+use crate::env::{Config, ServerConfig};
+use crate::providers::mock_alto::MockAltoUrls;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream},
+    time::Duration,
+};
+use tokio::runtime::Handle;
+use url::Url;
+
+pub struct Params {
+    pub validate_project_id: bool,
+    pub override_bundler_urls: Option<MockAltoUrls>,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            validate_project_id: true,
+            override_bundler_urls: None,
+        }
+    }
+}
+
+pub async fn spawn_blockchain_api() -> Url {
+    spawn_blockchain_api_with_params(Default::default()).await
+}
+
+pub async fn spawn_blockchain_api_with_params(params: Params) -> Url {
+    dotenv::dotenv().ok();
+
+    let public_port = get_random_port();
+    let prometheus_port = get_random_port();
+    let hostname = Ipv4Addr::UNSPECIFIED;
+    let rt = Handle::current();
+    let public_addr = SocketAddr::new(IpAddr::V4(hostname), public_port);
+
+    std::thread::spawn(move || {
+        rt.block_on(async move {
+            let mut config = Config::from_env()?;
+            config.server = ServerConfig {
+                port: public_port,
+                prometheus_port,
+                host: hostname.to_string(),
+                log_level: "NONE".to_string(),
+                validate_project_id: params.validate_project_id,
+                ..Default::default()
+            };
+            config.providers.override_bundler_urls = params.override_bundler_urls;
+
+            crate::bootstrap(config).await
+        })
+        .unwrap();
+    });
+
+    wait_for_server_to_start(public_port).await;
+
+    format!("http://{public_addr}").parse().unwrap()
+}
+
+fn get_random_port() -> u16 {
+    static NEXT_PORT: AtomicU16 = AtomicU16::new(9000);
+    loop {
+        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
+        if is_port_available(port) {
+            return port;
+        }
+    }
+}
+
+fn is_port_available(port: u16) -> bool {
+    TcpStream::connect(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_err()
+}
+
+async fn wait_for_server_to_start(port: u16) {
+    let poll_fut = async {
+        while is_port_available(port) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), poll_fut)
+        .await
+        .unwrap()
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -27,7 +27,7 @@ pub async fn spawn_blockchain_api() -> Url {
 }
 
 pub async fn spawn_blockchain_api_with_params(params: Params) -> Url {
-    // dotenv::dotenv().ok();
+    dotenv::dotenv().ok();
 
     let public_port = get_random_port();
     let prometheus_port = get_random_port();
@@ -35,11 +35,8 @@ pub async fn spawn_blockchain_api_with_params(params: Params) -> Url {
     let rt = Handle::current();
     let public_addr = SocketAddr::new(IpAddr::V4(hostname), public_port);
 
-    println!("RPC_PROXY_POSTGRES_URI 1: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
     std::thread::spawn(move || {
-        println!("RPC_PROXY_POSTGRES_URI 2: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
         rt.block_on(async move {
-            println!("RPC_PROXY_POSTGRES_URI 3: {}", std::env::var("RPC_PROXY_POSTGRES_URI").unwrap());
             let mut config = Config::from_env()?;
             config.server = ServerConfig {
                 port: public_port,

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -1,6 +1,6 @@
 use {
     crate::{analytics::MessageSource, error::RpcError},
-    alloy::primitives::Address,
+    alloy::{primitives::Address, rpc::json_rpc::Id},
     base64::prelude::*,
     bs58,
     ethers::{
@@ -79,7 +79,7 @@ pub enum CryptoUitlsError {
 /// JSON-RPC request schema
 #[derive(Serialize, Clone, Debug)]
 pub struct JsonRpcRequest<T: Serialize + Send + Sync> {
-    pub id: u64,
+    pub id: Id,
     pub jsonrpc: Arc<str>,
     pub method: Arc<str>,
     pub params: T,

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -17,8 +17,10 @@ impl AsyncTestContext for ServerContext {
 
         #[cfg(not(feature = "test-localhost"))]
         let server = {
-            let public_addr =
-                env::var("RPC_URL").unwrap_or("https://staging.rpc.walletconnect.com".to_owned());
+            let public_addr = env::var("RPC_URL")
+                .unwrap_or("https://staging.rpc.walletconnect.com".to_owned())
+                .parse()
+                .unwrap();
 
             {
                 let project_id = env::var("PROJECT_ID").expect("PROJECT_ID must be set");
@@ -31,16 +33,4 @@ impl AsyncTestContext for ServerContext {
 
         Self { server }
     }
-}
-
-#[cfg(feature = "test-localhost")]
-pub type TestResult<T> = Result<T, TestError>;
-
-#[derive(Debug, thiserror::Error)]
-pub enum TestError {
-    #[error(transparent)]
-    Elapsed(#[from] tokio::time::error::Elapsed),
-
-    #[error(transparent)]
-    RpcProxy(#[from] rpc_proxy::error::RpcError),
 }

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "test-localhost")]
 use std::net::SocketAddr;
 
+use url::Url;
+
 #[cfg(feature = "test-localhost")]
 use {
     super::TestResult,
@@ -12,7 +14,7 @@ use {
 };
 
 pub struct RpcProxy {
-    pub public_addr: String,
+    pub public_addr: Url,
     pub project_id: String,
 }
 
@@ -22,70 +24,14 @@ pub enum Error {}
 #[cfg(feature = "test-localhost")]
 impl RpcProxy {
     pub async fn start() -> Self {
-        let public_port = get_random_port();
-        let prometheus_port = get_random_port();
-        let hostname = Ipv4Addr::UNSPECIFIED;
-        let rt = Handle::current();
-        let public_addr = SocketAddr::new(IpAddr::V4(hostname), public_port);
+        let public_addr = spawn_blockchain_api().await;
 
         let project_id =
             env::var("TEST_RPC_PROXY_PROJECT_ID").expect("TEST_RPC_PROXY_PROJECT_ID must be set");
 
-        std::thread::spawn(move || {
-            rt.block_on(async move {
-                let mut config: Config = Config::from_env()?;
-                config.server = ServerConfig {
-                    port: public_port,
-                    prometheus_port,
-                    host: hostname.to_string(),
-                    log_level: "NONE".to_string(),
-                    ..Default::default()
-                };
-
-                rpc_proxy::bootstrap(config).await
-            })
-            .unwrap();
-        });
-
-        if let Err(e) = wait_for_server_to_start(public_port).await {
-            panic!("Failed to start server with error: {e:?}")
-        }
-
         Self {
-            public_addr: format!("http://{public_addr}"),
+            public_addr,
             project_id,
         }
     }
-}
-
-// Finds a free port.
-#[cfg(feature = "test-localhost")]
-fn get_random_port() -> u16 {
-    use std::sync::atomic::{AtomicU16, Ordering};
-
-    static NEXT_PORT: AtomicU16 = AtomicU16::new(9000);
-
-    loop {
-        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
-
-        if is_port_available(port) {
-            return port;
-        }
-    }
-}
-
-#[cfg(feature = "test-localhost")]
-fn is_port_available(port: u16) -> bool {
-    TcpStream::connect(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_err()
-}
-
-#[cfg(feature = "test-localhost")]
-async fn wait_for_server_to_start(port: u16) -> TestResult<()> {
-    let poll_fut = async {
-        while is_port_available(port) {
-            sleep(Duration::from_millis(10)).await;
-        }
-    };
-
-    Ok(tokio::time::timeout(Duration::from_secs(5), poll_fut).await?)
 }

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -1,17 +1,7 @@
-#[cfg(feature = "test-localhost")]
-use std::net::SocketAddr;
-
 use url::Url;
 
 #[cfg(feature = "test-localhost")]
-use {
-    super::TestResult,
-    rpc_proxy::env::{Config, ServerConfig},
-    std::net::{Ipv4Addr, SocketAddrV4, TcpStream},
-    std::time::Duration,
-    std::{env, net::IpAddr},
-    tokio::{runtime::Handle, time::sleep},
-};
+use {rpc_proxy::test_helpers::spawn_blockchain_api, std::env};
 
 pub struct RpcProxy {
     pub public_addr: Url,


### PR DESCRIPTION
# Description

Adds support for `wallet_getCallsStatus` to Wallet Service according to [the spec](https://www.notion.so/walletconnect/API-specs-for-Wallet-Services-0c4b70a397e2435691f9bb1f20bc652d?pvs=4#5c4f865af7b24308920b13bae94da5ef).

This adds a basic happy-path test case to test this method. It mocks the call ID input with a "normal" Safe execution which we already have code for. However, going forward we will have code that will be able to test the other 2 `wallet_*` endpoints and we will be able to update this test case to be more E2E.

Depends on https://github.com/reown-com/yttrium/pull/37

## How Has This Been Tested?

New test case

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
