### PR TITLE
feat(CoSigner): returning all PCIs at the list endpoint

### DIFF
--- a/src/handlers/sessions/context.rs
+++ b/src/handlers/sessions/context.rs
@@ -1,11 +1,13 @@
 use {
-    super::{super::HANDLER_TASK_METRICS, ActivatePermissionPayload, StoragePermissionsItem},
+    super::{
+        super::HANDLER_TASK_METRICS, ActivatePermissionPayload, QueryParams, StoragePermissionsItem,
+    },
     crate::{
         error::RpcError, state::AppState, storage::irn::OperationType,
         utils::crypto::disassemble_caip10,
     },
     axum::{
-        extract::{Path, State},
+        extract::{Path, Query, State},
         response::{IntoResponse, Response},
         Json,
     },
@@ -16,9 +18,10 @@ use {
 pub async fn handler(
     state: State<Arc<AppState>>,
     address: Path<String>,
+    query_params: Query<QueryParams>,
     Json(request_payload): Json<ActivatePermissionPayload>,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, address, request_payload)
+    handler_internal(state, address, query_params, request_payload)
         .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_context_update"))
         .await
 }
@@ -27,8 +30,12 @@ pub async fn handler(
 async fn handler_internal(
     state: State<Arc<AppState>>,
     Path(address): Path<String>,
+    query_params: Query<QueryParams>,
     request_payload: ActivatePermissionPayload,
 ) -> Result<Response, RpcError> {
+    let project_id = query_params.project_id.clone();
+    state.validate_project_access_and_quota(&project_id).await?;
+
     let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
 
     // Checking the CAIP-10 address format

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -53,6 +53,7 @@ pub struct SendUserOpResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CoSignQueryParams {
+    pub project_id: String,
     /// CoSigner version for testing purposes
     pub version: Option<u8>,
 }
@@ -75,6 +76,9 @@ async fn handler_internal(
     request_payload: CoSignRequest,
     query_payload: Query<CoSignQueryParams>,
 ) -> Result<Response, RpcError> {
+    let project_id = query_payload.project_id.clone();
+    state.validate_project_access_and_quota(&project_id).await?;
+
     // Checking the CAIP-10 address format
     let (namespace, chain_id, address) = disassemble_caip10(&caip10_address)?;
     if namespace != CaipNamespaces::Eip155 {

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -25,7 +25,7 @@ pub struct NewPermissionResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-
+#[serde(rename_all = "lowercase")]
 pub enum KeyType {
     Secp256k1,
 }
@@ -78,7 +78,7 @@ async fn handler_internal(
 
     // Store the permission item in the IRN database
     let storage_permissions_item = StoragePermissionsItem {
-        expiration: request_payload.expiry,
+        expiry: request_payload.expiry,
         created_at: SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or(std::time::Duration::new(0, 0))

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -26,7 +26,7 @@ struct ListPermissionResponse {
 struct Pci {
     pub project: ProjectItem,
     pub pci: String,
-    pub expiration: usize,
+    pub expiry: usize,
     pub created_at: usize,
     pub permissions: Vec<PermissionTypeData>,
     pub policies: Vec<PermissionTypeData>,
@@ -102,7 +102,7 @@ async fn handler_internal(
                 icon_url: None,
             },
             pci,
-            expiration: storage_permissions_item.expiration,
+            expiry: storage_permissions_item.expiry,
             created_at: storage_permissions_item.created_at,
             permissions: storage_permissions_item.permissions,
             policies: storage_permissions_item.policies,

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -1,11 +1,12 @@
 use {
-    super::super::HANDLER_TASK_METRICS,
+    super::{super::HANDLER_TASK_METRICS, PermissionTypeData, QueryParams, StoragePermissionsItem},
     crate::{
         error::RpcError, state::AppState, storage::irn::OperationType,
         utils::crypto::disassemble_caip10,
     },
+    alloy::primitives::Bytes,
     axum::{
-        extract::{Path, State},
+        extract::{Path, Query, State},
         response::{IntoResponse, Response},
         Json,
     },
@@ -15,15 +16,39 @@ use {
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ListPermissionResponse {
-    pci: Vec<String>,
+#[serde(rename_all = "camelCase")]
+struct ListPermissionResponse {
+    pcis: Vec<Pci>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Pci {
+    pub project: ProjectItem,
+    pub pci: String,
+    pub expiration: usize,
+    pub created_at: usize,
+    pub permissions: Vec<PermissionTypeData>,
+    pub policies: Vec<PermissionTypeData>,
+    pub context: Option<Bytes>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+
+struct ProjectItem {
+    pub id: String,
+    pub name: String,
+    pub url: Option<String>,
+    pub icon_url: Option<String>,
 }
 
 pub async fn handler(
     state: State<Arc<AppState>>,
     address: Path<String>,
+    query_params: Query<QueryParams>,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, address)
+    handler_internal(state, address, query_params)
         .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_list"))
         .await
 }
@@ -32,19 +57,58 @@ pub async fn handler(
 async fn handler_internal(
     state: State<Arc<AppState>>,
     Path(address): Path<String>,
+    query_params: Query<QueryParams>,
 ) -> Result<Response, RpcError> {
+    let project_id = query_params.project_id.clone();
+    state.validate_project_access_and_quota(&project_id).await?;
+
     let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
 
     // Checking the CAIP-10 address format
-    disassemble_caip10(&address)?;
+    disassemble_caip10(&address.clone())?;
 
     // get all permission control identifiers for the address
     let irn_call_start = SystemTime::now();
-    let pci = irn_client.hfields(address).await?;
+    let pcis = irn_client.hfields(address.clone()).await?;
     state
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hfields);
-    let response = ListPermissionResponse { pci };
 
-    Ok(Json(response).into_response())
+    // get all permissions data for the pcis
+    let mut result_pcis: Vec<Pci> = Vec::new();
+    for pci in pcis {
+        let irn_call_start = SystemTime::now();
+        let storage_permissions_item = irn_client
+            .hget(address.clone(), pci.clone())
+            .await?
+            .ok_or_else(|| RpcError::PermissionNotFound(address.clone(), pci.clone()))?;
+        state
+            .metrics
+            .add_irn_latency(irn_call_start, OperationType::Hget);
+        let storage_permissions_item =
+            serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
+
+        // Get project data
+        let project = state
+            .registry
+            .project_data(&storage_permissions_item.project_id)
+            .await?;
+
+        result_pcis.push(Pci {
+            project: ProjectItem {
+                id: storage_permissions_item.project_id.clone(),
+                name: project.project_data.name,
+                url: None,
+                icon_url: None,
+            },
+            pci,
+            expiration: storage_permissions_item.expiration,
+            created_at: storage_permissions_item.created_at,
+            permissions: storage_permissions_item.permissions,
+            policies: storage_permissions_item.policies,
+            context: storage_permissions_item.context,
+        });
+    }
+
+    Ok(Json(ListPermissionResponse { pcis: result_pcis }).into_response())
 }

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -62,7 +62,7 @@ pub struct PermissionSubContextSignerData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StoragePermissionsItem {
-    expiration: usize,
+    expiry: usize,
     created_at: usize,
     project_id: String,
     signer: PermissionTypeData,

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -13,6 +13,12 @@ pub mod get;
 pub mod list;
 pub mod revoke;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryParams {
+    pub project_id: String,
+}
+
 /// Payload to create a new permission
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NewPermissionPayload {
@@ -56,7 +62,9 @@ pub struct PermissionSubContextSignerData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StoragePermissionsItem {
-    expiry: usize,
+    expiration: usize,
+    created_at: usize,
+    project_id: String,
     signer: PermissionTypeData,
     permissions: Vec<PermissionTypeData>,
     policies: Vec<PermissionTypeData>,

--- a/src/handlers/wallet/send_prepared_calls.rs
+++ b/src/handlers/wallet/send_prepared_calls.rs
@@ -199,7 +199,10 @@ async fn handler_internal(
                                 .to_checksum(None)
                         )
                     }),
-                    Query(CoSignQueryParams { version: None }),
+                    Query(CoSignQueryParams {
+                        project_id: project_id.clone(),
+                        version: None,
+                    }),
                     Json(CoSignRequest {
                         pci: request.context.to_string(),
                         user_op: UserOperation {


### PR DESCRIPTION
# Description

This PR implements changes for the CoSigner PCI list endpoint according to [the recent API proposal](https://github.com/WalletConnect/walletconnect-specs/pull/242/commits/e471921e3fd2aed2a39c19b2b08f4bc685e19884).
The following changes were made:
* PCI item IRN storage schema was changed to store the projectID, expiration and creation timestamp.
* Returning all PCI data for the address instead of just the PCI uuid,
* Adding `created_at` PCI field,
* Adding project object with the project ID and project name. The project URL and icon URL should be added as a follow-up since the changes to the explorer client are needed to fetch the data.
* Adding `ProjectId` validation for all endpoints.

## How Has This Been Tested?

* [Integration tests were updated](https://github.com/reown-com/blockchain-api/pull/805/files#diff-d2b6bfa16ff410867b43a05eebec7cf74f434e26320f85fdf4681537ebb32372).

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
