### PR TITLE
feat(CoSigner): changing the get session context endpoint

### DIFF
--- a/integration/sessions.test.ts
+++ b/integration/sessions.test.ts
@@ -99,7 +99,7 @@ describe('Sessions/Permissions', () => {
 
   it('get session context by PCI', async () => {
     let resp = await httpClient.get(
-      `${baseUrl}/v1/sessions/${address}/${new_pci}?projectId=${projectId}`
+      `${baseUrl}/v1/sessions/${address}/getcontext?projectId=${projectId}&pci=${new_pci}`
     )
     expect(resp.status).toBe(200)
     expect(resp.data.context).toBe('0x00')

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -3,7 +3,6 @@ use {
     alloy::primitives::Bytes,
     serde::{Deserialize, Serialize},
     serde_json::Value,
-    uuid::Uuid,
 };
 
 pub mod context;
@@ -32,12 +31,6 @@ pub struct NewPermissionPayload {
 pub struct PermissionTypeData {
     pub r#type: String,
     pub data: Value,
-}
-// Payload to get permission by PCI
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GetPermissionsRequest {
-    address: String,
-    pci: Uuid,
 }
 
 /// Permissions Context item schema

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         // Sessions
         .route("/v1/sessions/:address", post(handlers::sessions::create::handler))
         .route("/v1/sessions/:address", get(handlers::sessions::list::handler))
-        .route("/v1/sessions/:address/:pci", get(handlers::sessions::get::handler))
+        .route("/v1/sessions/:address/getcontext", get(handlers::sessions::get::handler))
         .route("/v1/sessions/:address/activate", post(handlers::sessions::context::handler))
         .route("/v1/sessions/:address/revoke", post(handlers::sessions::revoke::handler))
         .route("/v1/sessions/:address/sign", post(handlers::sessions::cosign::handler))


### PR DESCRIPTION
# Description

This PR changed the session permission get context endpoint to be `GET /v1/sessions/:address/getcontext?projectId={projectId}&pci={pci}` instead of `GET /v1/sessions/:address/:pci` to reflect that we are getting only the PCI context and shorting the URL.

## How Has This Been Tested?

* The current integration test was updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
