### PR TITLE
fix(tests): removing JSON-RPC bad request test

### DIFF
--- a/integration/proxy.test.ts
+++ b/integration/proxy.test.ts
@@ -30,21 +30,4 @@ describe('Proxy', () => {
     )
     expect(resp.status).toBe(401)
   })
-
-  it('Bad JSON-RPC request', async () => {
-    // Missing the id field
-    const payload = {
-      jsonrpc: "2.0",
-      method: "eth_chainId",
-      params: [],
-    };
-    const chainId = "eip155:11155111";
-
-    let resp: any = await httpClient.post(
-      `${baseUrl}/v1?chainId=${chainId}&projectId=${projectId}`,
-      payload
-    )
-    expect(resp.status).toBe(400)
-    expect(typeof resp.data).toBe('object')
-  })
 })


### PR DESCRIPTION
# Description

This PR removes the bad JSON-RPC request integration test since we are just proxying requests to the provider and shouldn't check this. Also, some providers are allowing the `id` to be optional making this test flaky.

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
