### PR TITLE
feat(CoSigner): implementing `contract-call` and `native-token-transfer` permissions check

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -218,6 +218,9 @@ pub enum RpcError {
     #[error("Permission context was not updated yet: {0}")]
     PermissionContextNotUpdated(String),
 
+    #[error("Permission is revoked: {0}")]
+    RevokedPermission(String),
+
     #[error("Cosigner permission denied: {0}")]
     CosignerPermissionDenied(String),
 
@@ -489,7 +492,15 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response()
-        },
+            },
+            Self::RevokedPermission(pci) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "pci".to_string(),
+                    format!("Permission is revoked: {}", pci),
+                )),
+            )
+                .into_response(),
             Self::WrongBase64Format(e) => (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(

--- a/src/error.rs
+++ b/src/error.rs
@@ -217,6 +217,12 @@ pub enum RpcError {
 
     #[error("Permission context was not updated yet: {0}")]
     PermissionContextNotUpdated(String),
+
+    #[error("Cosigner permissions denied: {0}")]
+    CosignerPermissionsDenied(String),
+
+    #[error("ABI decoding error: {0}")]
+    AbiDecodingError(String),
 }
 
 impl IntoResponse for RpcError {
@@ -505,6 +511,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::AbiDecodingError(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "calldata".to_string(),
+                    format!("ABI signature decoding error: {}", e),
+                )),
+            )
+                .into_response(),
             Self::TransactionProviderError => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
@@ -553,6 +567,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::CosignerPermissionsDenied(e) => (
+                    StatusCode::UNAUTHORIZED,
+                    Json(new_error_response(
+                        "".to_string(),
+                        format!("Cosigner permission denied: {}", e),
+                    )),
+                )
+                    .into_response(),
             // Any other errors considering as 500
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/error.rs
+++ b/src/error.rs
@@ -218,8 +218,11 @@ pub enum RpcError {
     #[error("Permission context was not updated yet: {0}")]
     PermissionContextNotUpdated(String),
 
-    #[error("Cosigner permissions denied: {0}")]
-    CosignerPermissionsDenied(String),
+    #[error("Cosigner permission denied: {0}")]
+    CosignerPermissionDenied(String),
+
+    #[error("Cosigner unsupported permission: {0}")]
+    CosignerUnsupportedPermission(String),
 
     #[error("ABI decoding error: {0}")]
     AbiDecodingError(String),
@@ -567,7 +570,7 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
-            Self::CosignerPermissionsDenied(e) => (
+            Self::CosignerPermissionDenied(e) => (
                     StatusCode::UNAUTHORIZED,
                     Json(new_error_response(
                         "".to_string(),
@@ -575,6 +578,14 @@ impl IntoResponse for RpcError {
                     )),
                 )
                     .into_response(),
+            Self::CosignerUnsupportedPermission(e) => (
+                StatusCode::UNAUTHORIZED,
+                Json(new_error_response(
+                    "".to_string(),
+                    format!("Unsupported permission in CoSigner: {}", e),
+                )),
+            )
+                .into_response(),
             // Any other errors considering as 500
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -16,14 +16,16 @@ use {
         Json,
     },
     ethers::{
+        abi::{Abi, Token},
         core::k256::ecdsa::SigningKey,
         signers::LocalWallet,
-        types::{H160, H256},
+        types::{Bytes, H160, H256},
         utils::keccak256,
     },
     serde::{Deserialize, Serialize},
-    serde_json::json,
+    serde_json::{json, Value},
     std::{sync::Arc, time::SystemTime},
+    tracing::error,
     wc::future::FutureExt,
 };
 
@@ -58,6 +60,14 @@ pub struct CoSignQueryParams {
     pub version: Option<u8>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractCallPermissionData {
+    pub address: H160,
+    pub abi: Value,
+    pub functions: Value,
+}
+
 pub async fn handler(
     state: State<Arc<AppState>>,
     address: Path<String>,
@@ -67,6 +77,148 @@ pub async fn handler(
     handler_internal(state, address, request_payload, query_payload)
         .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_co_sign"))
         .await
+}
+
+fn extract_target_from_calldata_using_abi(call_data_bytes: Vec<u8>) -> Result<H160, RpcError> {
+    // 1. Define the execute function ABI
+    let execute_abi_json = r#"
+    [
+      {
+        "type": "function",
+        "name": "execute",
+        "inputs": [
+          {
+            "name": "execMode",
+            "type": "bytes32",
+            "internalType": "ExecMode"
+          },
+          {
+            "name": "executionCalldata",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+      }
+    ]
+    "#;
+
+    // 2. Parse the execute ABI
+    let execute_abi: Abi = serde_json::from_str(execute_abi_json)?;
+    let execute_function = execute_abi.function("execute").map_err(|e| {
+        RpcError::AbiDecodingError(format!("Failed to parse execute function: {}", e))
+    })?;
+
+    // 4. Verify the function selector
+    let function_selector = &call_data_bytes[0..4];
+    let expected_selector = execute_function.short_signature();
+
+    if function_selector != expected_selector {
+        return Err(RpcError::AbiDecodingError(
+            "Function selector does not match `execute`".into(),
+        ));
+    }
+
+    // 5. Decode the calldata
+    let decoded_params = execute_function
+        .decode_input(&call_data_bytes[4..])
+        .map_err(|e| RpcError::AbiDecodingError(format!("Failed to decode calldata: {}", e)))?;
+
+    // 6. Extract executionCalldata
+    let execution_calldata = match &decoded_params[1] {
+        Token::Bytes(bytes) => bytes,
+        _ => {
+            return Err(RpcError::AbiDecodingError(
+                "executionCalldata is not bytes".into(),
+            ))
+        }
+    };
+
+    // 7. Define the executionCalldata ABI
+    // Since ethers-rs requires function definitions to parse parameters,
+    // we wrap the executionCalldata parameter into a dummy function.
+    let execution_calldata_abi_json = r#"
+    [
+      {
+        "type": "function",
+        "name": "decodeExecutionCalldata",
+        "inputs": [
+          {
+            "name": "executionBatch",
+            "type": "tuple[]",
+            "components": [
+              {
+                "name": "target",
+                "type": "address"
+              },
+              {
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "name": "callData",
+                "type": "bytes"
+              }
+            ]
+          }
+        ],
+        "outputs": []
+      }
+    ]
+    "#;
+
+    // 8. Parse the executionCalldata ABI
+    let execution_calldata_abi: Abi = serde_json::from_str(execution_calldata_abi_json)?;
+    let decode_function = execution_calldata_abi
+        .function("decodeExecutionCalldata")
+        .map_err(|e| {
+            RpcError::AbiDecodingError(format!(
+                "Failed to parse decodeExecutionCalldata function: {}",
+                e
+            ))
+        })?;
+
+    // 9. Decode executionCalldata
+    let tokens = decode_function
+        .decode_input(execution_calldata)
+        .map_err(|e| {
+            RpcError::AbiDecodingError(format!("Failed to decode executionCalldata: {}", e))
+        })?;
+
+    // 10. Extract the target address
+    let execution_batch = match &tokens[0] {
+        Token::Array(arr) => arr,
+        _ => {
+            return Err(RpcError::AbiDecodingError(
+                "Expected an array for executionBatch".into(),
+            ))
+        }
+    };
+
+    if execution_batch.is_empty() {
+        return Err(RpcError::AbiDecodingError("executionBatch is empty".into()));
+    }
+
+    let first_tx = match &execution_batch[0] {
+        Token::Tuple(tuple) => tuple,
+        _ => {
+            return Err(RpcError::AbiDecodingError(
+                "Expected a tuple for transaction".into(),
+            ))
+        }
+    };
+
+    let target = match &first_tx[0] {
+        Token::Address(addr) => *addr,
+        _ => {
+            return Err(RpcError::AbiDecodingError(
+                "Expected address for target".into(),
+            ))
+        }
+    };
+
+    Ok(target)
 }
 
 #[tracing::instrument(skip(state), level = "debug")]
@@ -95,6 +247,12 @@ async fn handler_internal(
     if !ChainId::is_supported(chain_id_uint) {
         return Err(RpcError::UnsupportedChain(chain_id.clone()));
     }
+
+    // json stringify request_payload
+    error!(
+        "request_payload: {:?}",
+        serde_json::to_string(&request_payload)
+    );
 
     let chain_id_caip2 = format!("{}:{}", namespace, chain_id);
     let mut user_op = request_payload.user_op.clone();
@@ -139,6 +297,35 @@ async fn handler_internal(
         .add_irn_latency(irn_call_start, OperationType::Hget);
     let storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
+
+    error!(
+        "storage_permissions_item: {:?}",
+        serde_json::to_string(&storage_permissions_item)
+    );
+
+    // Check the permission type
+    for permission in storage_permissions_item.permissions {
+        if permission.r#type == "contract-call" {
+            let call_data = request_payload.user_op.call_data.clone();
+            let contract_address = extract_target_from_calldata_using_abi(call_data.to_vec())?;
+
+            println!("Extracted Contract Address: {:?}", contract_address);
+            println!(
+                "Permission Data: {:?}",
+                serde_json::to_string(&permission.data)
+            );
+
+            let contract_call_permission_data =
+                serde_json::from_value::<ContractCallPermissionData>(permission.data)?;
+            if contract_call_permission_data.address != contract_address {
+                error!("Contract address does not match the target address in the permission data. UserOp Address: {:?}, Permission Target: {:?}", contract_address, contract_call_permission_data.address);
+                return Err(RpcError::CosignerPermissionsDenied(format!(
+                    "Contract address does not match the target address in the permission data. UserOp Address: {:?}, Permission Target: {:?}",
+                    contract_address, contract_call_permission_data.address.to_string()
+                )));
+            }
+        }
+    }
 
     // Check and get the permission context if it's updated
     let _permission_context = storage_permissions_item

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -90,6 +90,7 @@ async fn handler_internal(
         context: None,
         verification_key: public_key_der_hex.clone(),
         signing_key: private_key_der_hex.clone(),
+        revoked_at: None,
     };
 
     let irn_call_start = SystemTime::now();

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -31,6 +31,7 @@ struct Pci {
     pub permissions: Vec<PermissionTypeData>,
     pub policies: Vec<PermissionTypeData>,
     pub context: Option<Bytes>,
+    pub revoked_at: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -107,6 +108,7 @@ async fn handler_internal(
             permissions: storage_permissions_item.permissions,
             policies: storage_permissions_item.policies,
             context: storage_permissions_item.context,
+            revoked_at: storage_permissions_item.revoked_at,
         });
     }
 

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -64,6 +64,7 @@ pub struct StoragePermissionsItem {
     context: Option<Bytes>,
     verification_key: String,
     signing_key: String,
+    revoked_at: Option<usize>,
 }
 
 /// Permission revoke request schema

--- a/src/handlers/sessions/revoke.rs
+++ b/src/handlers/sessions/revoke.rs
@@ -1,12 +1,14 @@
 use {
-    super::{super::HANDLER_TASK_METRICS, PermissionRevokeRequest, QueryParams},
+    super::{
+        super::HANDLER_TASK_METRICS, PermissionRevokeRequest, QueryParams, StoragePermissionsItem,
+    },
     crate::{
         error::RpcError, state::AppState, storage::irn::OperationType,
         utils::crypto::disassemble_caip10,
     },
     axum::{
         extract::{Path, Query, State},
-        response::Response,
+        response::{IntoResponse, Response},
         Json,
     },
     std::{sync::Arc, time::SystemTime},
@@ -39,12 +41,44 @@ async fn handler_internal(
     // Checking the CAIP-10 address format
     disassemble_caip10(&address)?;
 
-    // Remove the session/permission item from the IRN
+    // Get the PCI object from the IRN
     let irn_call_start = SystemTime::now();
-    irn_client.hdel(address, request_payload.pci).await?;
+    let storage_permissions_item = irn_client
+        .hget(address.clone(), request_payload.pci.clone())
+        .await?
+        .ok_or_else(|| {
+            RpcError::PermissionNotFound(address.clone(), request_payload.pci.clone())
+        })?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hdel);
+        .add_irn_latency(irn_call_start, OperationType::Hget);
+    let mut storage_permissions_item =
+        serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 
-    Ok(Response::default())
+    if storage_permissions_item.revoked_at.is_some() {
+        return Err(RpcError::RevokedPermission(request_payload.pci.clone()));
+    }
+
+    // Update the revoked_at field
+    storage_permissions_item.revoked_at = Some(
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or(std::time::Duration::new(0, 0))
+            .as_secs() as usize,
+    );
+
+    // Store it back to the IRN database
+    let irn_call_start = SystemTime::now();
+    irn_client
+        .hset(
+            address,
+            request_payload.pci,
+            serde_json::to_string(&storage_permissions_item)?.into(),
+        )
+        .await?;
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hset);
+
+    Ok(().into_response())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,7 +3,9 @@ use rand::{distributions::Alphanumeric, Rng};
 pub mod build;
 pub mod crypto;
 pub mod network;
+pub mod permissions;
 pub mod rate_limit;
+pub mod sessions;
 
 pub fn generate_random_string(len: usize) -> String {
     let rng = rand::thread_rng();

--- a/src/utils/permissions.rs
+++ b/src/utils/permissions.rs
@@ -1,0 +1,86 @@
+use {
+    crate::{
+        error::RpcError,
+        utils::sessions::{
+            extract_addresses_from_execution_batch, extract_values_from_execution_batch,
+        },
+    },
+    ethers::{
+        abi::Token,
+        types::{H160, U256},
+    },
+    serde::{Deserialize, Serialize},
+    serde_json::Value,
+    strum_macros::{Display, EnumIter, EnumString},
+    tracing::error,
+};
+
+/// Supported permission types
+#[derive(Clone, Copy, Debug, EnumString, EnumIter, Display, PartialEq)]
+#[strum(serialize_all = "kebab-case")]
+pub enum PermissionType {
+    ContractCall,
+    NativeTokenTransfer,
+}
+
+/// `contract-call` permission type data schema
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractCallPermissionData {
+    pub address: H160,
+    pub abi: Value,
+    pub functions: Value,
+}
+
+/// `native-token-transfer` permission type data schema
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTokenTransferPermissionData {
+    pub allowance: U256,
+    pub start: usize,
+    pub period: usize,
+}
+
+/// `contract-call` permission type check
+pub fn contract_call_permission_check(
+    execution_batch: Vec<Token>,
+    contract_call_permission_data: ContractCallPermissionData,
+) -> Result<(), RpcError> {
+    let execution_addresses = extract_addresses_from_execution_batch(execution_batch.clone())?;
+    let call_address = contract_call_permission_data.address;
+
+    for address in execution_addresses {
+        if address != call_address {
+            error!("Execution address does not match the contract address in the permission data. Execution Address: {:?}, Contract Address: {:?}", address, call_address);
+            return Err(RpcError::CosignerPermissionDenied(format!(
+              "Execution address does not match the contract address in the permission data. Execution Address: {:?}, Contract Address: {:?}", address, call_address
+          )));
+        }
+    }
+    Ok(())
+}
+
+/// `native-token-transfer` permission type check
+pub fn native_token_transfer_permission_check(
+    execution_batch: Vec<Token>,
+    native_token_transfer_permission_data: NativeTokenTransferPermissionData,
+) -> Result<(), RpcError> {
+    let execution_values = extract_values_from_execution_batch(execution_batch.clone())?;
+    let allowance = native_token_transfer_permission_data.allowance;
+    // summ execution values from the execution batch and check if it is less than or equal to the allowance
+    let sum: U256 = execution_values
+        .iter()
+        .fold(U256::zero(), |acc, &x| acc + x);
+    if sum > allowance {
+        error!(
+            "Execution value is greater than the allowance. Execution Value: {:?}, Allowance: {:?}",
+            sum, allowance
+        );
+        return Err(RpcError::CosignerPermissionDenied(format!(
+            "Execution value is greater than the allowance. Execution Value: {:?}, Allowance: {:?}",
+            sum, allowance
+        )));
+    }
+
+    Ok(())
+}

--- a/src/utils/sessions.rs
+++ b/src/utils/sessions.rs
@@ -134,7 +134,7 @@ pub fn extract_execution_batch_components(
 pub fn extract_addresses_from_execution_batch(
     execution_batch: Vec<Token>,
 ) -> Result<Vec<H160>, RpcError> {
-    let mut targets = Vec::new();
+    let mut targets = Vec::with_capacity(execution_batch.len());
     for tx in execution_batch {
         let tx = match &tx {
             Token::Tuple(tuple) => tuple,
@@ -163,7 +163,7 @@ pub fn extract_addresses_from_execution_batch(
 pub fn extract_values_from_execution_batch(
     execution_batch: Vec<Token>,
 ) -> Result<Vec<U256>, RpcError> {
-    let mut values = Vec::new();
+    let mut values = Vec::with_capacity(execution_batch.len());
     for tx in execution_batch {
         let tx = match &tx {
             Token::Tuple(tuple) => tuple,

--- a/src/utils/sessions.rs
+++ b/src/utils/sessions.rs
@@ -1,0 +1,189 @@
+use {
+    crate::error::RpcError,
+    ethers::{
+        abi::{Abi, Token},
+        types::{H160, U256},
+    },
+};
+
+// Extract the execution batch components from the calldata
+// from bundler's `execute` function ABI
+pub fn extract_execution_batch_components(
+    call_data_bytes: Vec<u8>,
+) -> Result<Vec<Token>, RpcError> {
+    let execute_abi_json = r#"
+    [
+      {
+          "type": "function",
+          "name": "execute",
+          "inputs": [
+            {
+                "name": "execMode",
+                "type": "bytes32",
+                "internalType": "ExecMode"
+            },
+            {
+                "name": "executionCalldata",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "payable"
+      }
+    ]
+    "#;
+
+    let execute_abi: Abi = serde_json::from_str(execute_abi_json)?;
+    let execute_function = execute_abi.function("execute").map_err(|e| {
+        RpcError::AbiDecodingError(format!("Failed to parse execute function: {}", e))
+    })?;
+
+    // Verify the function selector
+    let function_selector = &call_data_bytes[0..4];
+    let expected_selector = execute_function.short_signature();
+
+    if function_selector != expected_selector {
+        return Err(RpcError::AbiDecodingError(
+            "Function selector does not match `execute`".into(),
+        ));
+    }
+
+    // Decode the calldata
+    let decoded_params = execute_function
+        .decode_input(&call_data_bytes[4..])
+        .map_err(|e| RpcError::AbiDecodingError(format!("Failed to decode calldata: {}", e)))?;
+
+    // Extract executionCalldata
+    let execution_calldata = match &decoded_params[1] {
+        Token::Bytes(bytes) => bytes,
+        _ => {
+            return Err(RpcError::AbiDecodingError(
+                "executionCalldata is not bytes".into(),
+            ))
+        }
+    };
+
+    // Define the executionCalldata ABI
+    let execution_calldata_abi_json = r#"
+    [
+      {
+        "type": "function",
+        "name": "decodeExecutionCalldata",
+        "inputs": [
+          {
+            "name": "executionBatch",
+            "type": "tuple[]",
+            "components": [
+              {
+                  "name": "target",
+                  "type": "address"
+              },
+              {
+                  "name": "value",
+                  "type": "uint256"
+              },
+              {
+                  "name": "callData",
+                  "type": "bytes"
+              }
+            ]
+          }
+        ],
+        "outputs": []
+      }
+    ]
+    "#;
+
+    // Parse the executionCalldata ABI
+    let execution_calldata_abi: Abi = serde_json::from_str(execution_calldata_abi_json)?;
+    let decode_function = execution_calldata_abi
+        .function("decodeExecutionCalldata")
+        .map_err(|e| {
+            RpcError::AbiDecodingError(format!(
+                "Failed to parse decodeExecutionCalldata function: {}",
+                e
+            ))
+        })?;
+
+    // Decode executionCalldata
+    let tokens = decode_function
+        .decode_input(execution_calldata)
+        .map_err(|e| {
+            RpcError::AbiDecodingError(format!("Failed to decode executionCalldata: {}", e))
+        })?;
+
+    // Extract the execution batch
+    let execution_batch = match &tokens[0] {
+        Token::Array(arr) => arr,
+        _ => {
+            return Err(RpcError::AbiDecodingError(
+                "Expected an array for executionBatch".into(),
+            ))
+        }
+    };
+
+    if execution_batch.is_empty() {
+        return Err(RpcError::AbiDecodingError("executionBatch is empty".into()));
+    }
+
+    Ok(execution_batch.clone())
+}
+
+/// Extract addresses from the bundler's execute calldata execution batch
+pub fn extract_addresses_from_execution_batch(
+    execution_batch: Vec<Token>,
+) -> Result<Vec<H160>, RpcError> {
+    let mut targets = Vec::new();
+    for tx in execution_batch {
+        let tx = match &tx {
+            Token::Tuple(tuple) => tuple,
+            _ => {
+                return Err(RpcError::AbiDecodingError(
+                    "Expected a tuple for execution batch transaction".into(),
+                ))
+            }
+        };
+        let target = match &tx[0] {
+            Token::Address(addr) => *addr,
+            _ => {
+                return Err(RpcError::AbiDecodingError(
+                    "Expected address as a first field for target in the execution batch item"
+                        .into(),
+                ))
+            }
+        };
+        targets.push(target);
+    }
+
+    Ok(targets)
+}
+
+/// Exract values from the bundler's execute calldata execution batch
+pub fn extract_values_from_execution_batch(
+    execution_batch: Vec<Token>,
+) -> Result<Vec<U256>, RpcError> {
+    let mut values = Vec::new();
+    for tx in execution_batch {
+        let tx = match &tx {
+            Token::Tuple(tuple) => tuple,
+            _ => {
+                return Err(RpcError::AbiDecodingError(
+                    "Expected a tuple for execution batch transaction".into(),
+                ))
+            }
+        };
+
+        let value = match &tx[1] {
+            Token::Uint(value) => *value,
+            _ => {
+                return Err(RpcError::AbiDecodingError(
+                    "Expected value as a second field for value in the execution batch item".into(),
+                ))
+            }
+        };
+
+        values.push(value);
+    }
+    Ok(values)
+}


### PR DESCRIPTION
# Description

This PR introduces the draft testing implementation for the following permissions check during the CoSign process:

* `contract-call` permission:
Extracting the contract call address from the bundler's execution operation and comparing it to the permissions allowed for the address call.

* `native-token-transfer` permission:
Extracted values from the bundler's execution batch are summarized and checked with the allowance.

Currently missing:
* Check for the period, start, and expiration,
* Tracking the already spent amount.

## How Has This Been Tested?

* Manual testing only, integration tests will be added before merging.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
