### PR TITLE
feat(providers): adding Unichain and Berachain to the Quicknode provider

### DIFF
--- a/src/env/quicknode.rs
+++ b/src/env/quicknode.rs
@@ -58,6 +58,14 @@ fn extract_supported_chains_and_subdomains(
             ("snowy-chaotic-hill.zksync-mainnet", Priority::High),
         ),
         (
+            "eip155:1301",
+            ("blissful-side-log.unichain-sepolia", Priority::Normal),
+        ),
+        (
+            "eip155:80084",
+            ("frequent-capable-putty.bera-bartio", Priority::Normal),
+        ),
+        (
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             ("indulgent-thrumming-bush.solana-mainnet", Priority::Normal),
         ),

--- a/tests/functional/http/quicknode.rs
+++ b/tests/functional/http/quicknode.rs
@@ -20,6 +20,22 @@ async fn quicknode_provider(ctx: &mut ServerContext) {
         "0x144",
     )
     .await;
+    // Unichain Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Quicknode,
+        "eip155:1301",
+        "0x515",
+    )
+    .await;
+    // Berachain Bartio
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Quicknode,
+        "eip155:80084",
+        "0x138d4",
+    )
+    .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR adds Unichain Sepolia and Berachain chains to the Quicknode provider.

## How Has This Been Tested?

Integration test for Quicknode updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
