### PR TITLE
fix(WalletService): fixing HTTP 400 error when internal expected

### DIFF
--- a/src/handlers/wallet/handler.rs
+++ b/src/handlers/wallet/handler.rs
@@ -58,7 +58,13 @@ async fn handler_internal(
         )))
         .into_response(),
         Err(e) => {
-            let is_internal = matches!(e, Error::Internal(_));
+            let is_internal = matches!(e, Error::Internal(_))
+                || matches!(
+                    e,
+                    Error::SendPreparedCalls(SendPreparedCallsError::InternalError(_))
+                )
+                || matches!(e, Error::PrepareCalls(PrepareCallsError::InternalError(_)));
+
             if is_internal {
                 error!("Internal server error handling wallet RPC request: {e:?}");
             }


### PR DESCRIPTION
# Description

This PR updates the `is_internal` cases to return HTTP 500.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
