### PR TITLE
fix: debug wallet service with new logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?branch=fix/logging#07b313c3c83fd6837992b7fedffc116f711d1e81"
+source = "git+https://github.com/reown-com/yttrium.git#983d5b98b74cf2ee89dc18f4a022b480c6da7059"
 dependencies = [
  "alloy",
  "alloy-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4630,7 +4630,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -4644,7 +4644,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.7",
 ]
 
 [[package]]
@@ -5095,6 +5095,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -6346,7 +6355,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6698,8 +6707,17 @@ checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -6710,7 +6728,7 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -6718,6 +6736,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8803,12 +8827,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -9707,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git#33621880a9a11881c7358e749aa65f8a53080c18"
+source = "git+https://github.com/reown-com/yttrium.git?branch=fix/logging#07b313c3c83fd6837992b7fedffc116f711d1e81"
 dependencies = [
  "alloy",
  "alloy-provider",
@@ -9721,6 +9749,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
-yttrium = { git = "https://github.com/reown-com/yttrium.git" }
+yttrium = { git = "https://github.com/reown-com/yttrium.git", branch = "fix/logging" }
 
 # Async
 async-trait = "0.1.82"
@@ -66,7 +66,7 @@ ipnet = "2.5"
 pnet_datalink = "0.31"
 
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json", "ansi"] }
+tracing-subscriber = { version = "0.3", features = ["json", "ansi", "env-filter"] }
 
 cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.13.1" }
 parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "99a1cc3", default-features = false, features = ["flate2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
-yttrium = { git = "https://github.com/reown-com/yttrium.git", branch = "fix/logging" }
+yttrium = { git = "https://github.com/reown-com/yttrium.git" }
 
 # Async
 async-trait = "0.1.82"

--- a/src/handlers/wallet/prepare_calls.rs
+++ b/src/handlers/wallet/prepare_calls.rs
@@ -12,12 +12,7 @@ use alloy::providers::{Provider, ReqwestProvider};
 use alloy::sol_types::SolCall;
 use alloy::sol_types::SolValue;
 use alloy::transports::Transport;
-use axum::{
-    extract::State,
-    response::{IntoResponse, Response},
-    Json,
-};
-use hyper::StatusCode;
+use axum::extract::State;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use thiserror::Error;
@@ -148,24 +143,6 @@ pub enum PrepareCallsInternalError {
 
     #[error("Get session context: {0}")]
     GetSessionContextError(InternalGetSessionContextError),
-}
-
-impl IntoResponse for PrepareCallsError {
-    fn into_response(self) -> Response {
-        match self {
-            Self::InternalError(e) => {
-                error!("HTTP server error: (prepare_calls) {e:?}");
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-            e => (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": e.to_string(),
-                })),
-            )
-                .into_response(),
-        }
-    }
 }
 
 pub async fn handler(

--- a/src/handlers/wallet/send_prepared_calls.rs
+++ b/src/handlers/wallet/send_prepared_calls.rs
@@ -17,13 +17,8 @@ use alloy::network::Ethereum;
 use alloy::primitives::{Bytes, U64};
 use alloy::providers::ReqwestProvider;
 use axum::extract::{Path, Query};
-use axum::{
-    extract::State,
-    response::{IntoResponse, Response},
-    Json,
-};
+use axum::{extract::State, response::IntoResponse, Json};
 use hyper::body::to_bytes;
-use hyper::StatusCode;
 use parquet::data_type::AsBytes;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -140,24 +135,6 @@ pub enum SendPreparedCallsInternalError {
     IsSessionEnabled(alloy::contract::Error),
     #[error("SendUserOperation: {0}")]
     SendUserOperation(eyre::Error),
-}
-
-impl IntoResponse for SendPreparedCallsError {
-    fn into_response(self) -> Response {
-        match self {
-            Self::InternalError(e) => {
-                error!("HTTP server error: (prepare_calls) {e:?}");
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-            e => (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": e.to_string(),
-                })),
-            )
-                .into_response(),
-        }
-    }
 }
 
 pub async fn handler(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use {
     dotenv::dotenv,
     rpc_proxy::{env::Config, error},
-    std::str::FromStr,
-    tracing_subscriber::fmt::format::FmtSpan,
+    tracing::level_filters::LevelFilter,
+    tracing_subscriber::{fmt::format::FmtSpan, EnvFilter},
 };
 
 #[global_allocator]
@@ -17,8 +17,11 @@ async fn main() -> error::RpcResult<()> {
         .expect("Failed to load config, please ensure all env variables are defined.");
 
     tracing_subscriber::fmt()
-        .with_max_level(
-            tracing::Level::from_str(config.server.log_level.as_str()).expect("Invalid log level"),
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::ERROR.into())
+                .parse(&config.server.log_level)
+                .expect("Invalid log level"),
         )
         .with_span_events(FmtSpan::CLOSE)
         .with_ansi(false)

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -76,6 +76,7 @@ resource "aws_ecs_task_definition" "app_task" {
       essential = true,
 
       environment = [
+        { name = "RPC_PROXY_LOG_LEVEL", value = var.log_level },
         { name = "RPC_PROXY_PORT", value = tostring(var.port) },
         { name = "RPC_PROXY_PROMETHEUS_PORT", value = tostring(local.otel_port) },
 


### PR DESCRIPTION
# Description

Debug errors e.g.:

- `rpc_proxy::handlers::wallet::handler: Internal server error handling wallet RPC request (prepareCalls): PrepareCalls(InternalError(Sponsorship(missing field `jsonrpc` at line 1 column 218`
- `rpc_proxy::handlers::wallet::handler: Internal server error handling wallet RPC request (sendPreparedCalls): SendPreparedCalls(InternalError(SendUserOperation(error decoding response body`

This modifies the logging configuration so that you can enable debug logs per-module e.g. how Terraform Cloud is now configured: `log_level = "info,yttrium=trace"`

Depends on https://github.com/reown-com/yttrium/pull/46

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
