### PR TITLE
feat(CoSigner): changing the native token transfer permission to the `native-token-recurring-allowance`

### DIFF
--- a/integration/sessions.test.ts
+++ b/integration/sessions.test.ts
@@ -10,6 +10,15 @@ const contractCallPermission = {
   }
 }
 
+const NativeTokenRecurringAllowancePermission = {
+  type: "native-token-recurring-allowance",
+  data: {
+    start: Math.floor(Date.now() / 1000),
+    period: 86400,
+    allowance: "0x00000000000000000000000000000000000000000000000000005AF3107A4000" // 0.0001
+  }
+}
+
 const permissionContext = "0x00"
 
 describe('Sessions/Permissions', () => {
@@ -27,7 +36,10 @@ describe('Sessions/Permissions', () => {
           type: "k256",
           data: "0x"
         },
-      permissions: [contractCallPermission],
+      permissions: [
+        contractCallPermission, 
+        NativeTokenRecurringAllowancePermission
+      ],
       policies: []
     }
 

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -12,7 +12,7 @@ use {
             },
             permissions::{
                 contract_call_permission_check, native_token_transfer_permission_check,
-                ContractCallPermissionData, NativeTokenTransferPermissionData, PermissionType,
+                ContractCallPermissionData, NativeTokenAllowancePermissionData, PermissionType,
             },
             sessions::extract_execution_batch_components,
         },
@@ -185,11 +185,11 @@ async fn handler_internal(
                         )?,
                     )?;
                 }
-                PermissionType::NativeTokenTransfer => {
+                PermissionType::NativeTokenRecurringAllowance => {
                     debug!("Executing native token transfer permission check");
                     native_token_transfer_permission_check(
                         execution_batch.clone(),
-                        serde_json::from_value::<NativeTokenTransferPermissionData>(
+                        serde_json::from_value::<NativeTokenAllowancePermissionData>(
                             permission.data.clone(),
                         )?,
                     )?;

--- a/src/utils/permissions.rs
+++ b/src/utils/permissions.rs
@@ -18,7 +18,7 @@ use {
 #[strum(serialize_all = "kebab-case")]
 pub enum PermissionType {
     ContractCall,
-    NativeTokenTransfer,
+    NativeTokenRecurringAllowance,
 }
 
 /// `contract-call` permission type data schema
@@ -33,7 +33,7 @@ pub struct ContractCallPermissionData {
 /// `native-token-transfer` permission type data schema
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NativeTokenTransferPermissionData {
+pub struct NativeTokenAllowancePermissionData {
     pub allowance: U256,
     pub start: usize,
     pub period: usize,
@@ -61,7 +61,7 @@ pub fn contract_call_permission_check(
 /// `native-token-transfer` permission type check
 pub fn native_token_transfer_permission_check(
     execution_batch: Vec<ExecutionTransaction>,
-    native_token_transfer_permission_data: NativeTokenTransferPermissionData,
+    native_token_transfer_permission_data: NativeTokenAllowancePermissionData,
 ) -> Result<(), RpcError> {
     let allowance = native_token_transfer_permission_data.allowance;
     let sum: U256 = extract_values_sum_from_execution_batch(execution_batch)?;


### PR DESCRIPTION
# Description

This PR changes the native token transfer permission name to the `native-token-recurring-allowance` to fit the current SDK name.
The context: [Slack thread](https://reown-inc.slack.com/archives/C06G97QSSUX/p1729604631318369?thread_ts=1728909115.959829&cid=C06G97QSSUX).

## How Has This Been Tested?

* The change passes the updated integration test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
