### PR TITLE
fix: bump quicknode priority to handle berachain requests

### DIFF
--- a/src/env/quicknode.rs
+++ b/src/env/quicknode.rs
@@ -63,7 +63,7 @@ fn extract_supported_chains_and_subdomains(
         ),
         (
             "eip155:80084",
-            ("frequent-capable-putty.bera-bartio", Priority::Normal),
+            ("frequent-capable-putty.bera-bartio", Priority::High),
         ),
         (
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",


### PR DESCRIPTION
# Description

Changes QuickNode's priority from Normal to High when configuring it as a Berachain provider

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
