### PR TITLE
feat(ca_orchestration): adding the approval transaction if needed and checking the status

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -2,13 +2,15 @@ import { getTestSetup } from './init';
 import { ethers, Interface } from "ethers"
 
 describe('Chain abstraction orchestrator', () => {
-  const { baseUrl, projectId, httpClient } = getTestSetup();  
+  const { baseUrl, projectId, httpClient } = getTestSetup();
+
   const erc20Interface = new Interface([
     'function transfer(address to, uint256 amount)',
+    'function approve(address spender, uint256 amount) public returns (bool)'
   ]);
 
   // Address with 3 USDC on Base chain
-  const from_address_with_funds = "0x2Aae531A81461F029cD55Cb46703211c9227ba05";
+  const from_address_with_funds = "0x2aae531a81461f029cd55cb46703211c9227ba05";
   const usdc_funds_on_address = 3_000_000;
 
   const receiver_address = "0x739ff389c8eBd9339E69611d46Eec6212179BB67";
@@ -175,9 +177,19 @@ describe('Chain abstraction orchestrator', () => {
 
     const data = resp.data
     expect(typeof data.orchestrationId).toBe('string')
-    // First transaction expected to be the bridging to the Base
-    expect(data.transactions[0].chainId).toBe(chain_id_base)
-    // The second transaction expected to be the initial one
-    expect(data.transactions[1].chainId).toBe(chain_id_optimism)
+    // Expecting 3 transactions in the route
+    expect(data.transactions.length).toBe(3)
+
+    // First transaction expected to be the approval transaction
+    const approvalTransaction = data.transactions[0]
+    expect(approvalTransaction.chainId).toBe(chain_id_base)
+    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data);  
+    expect(decodedData.amount.toString()).toBe(amount_to_send_in_decimals.toString())
+
+    // Second transaction expected to be the bridging to the Base
+    expect(data.transactions[1].chainId).toBe(chain_id_base)
+
+    // Last transaction expected to be the initial one
+    expect(data.transactions[2]).toStrictEqual(transactionObj.transaction)
   })
 })

--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -18,6 +18,8 @@ describe('Chain abstraction orchestrator', () => {
   const chain_id_base = "eip155:8453";
   const usdc_contract_optimism = "0x0b2c639c533813f4aa9d7837caf62653d097ff85";
 
+  let orchestration_id = "";
+
   it('bridging available', async () => {
     // Sending USDC to Optimism, but having the USDC balance on Base chain
     const amount_to_send_in_decimals = usdc_funds_on_address - 1_000_000
@@ -191,5 +193,18 @@ describe('Chain abstraction orchestrator', () => {
 
     // Last transaction expected to be the initial one
     expect(data.transactions[2]).toStrictEqual(transactionObj.transaction)
+
+    // Set the Orchestration ID for the next test
+    orchestration_id = data.orchestrationId;
+  })
+
+  it('bridging status', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/ca/orchestrator/status?projectId=${projectId}&orchestrationId=${orchestration_id}`,
+    )
+    expect(resp.status).toBe(200)
+    const data = resp.data
+    expect(typeof data.status).toBe('string')
+    expect(data.status).toBe('pending')
   })
 })

--- a/src/error.rs
+++ b/src/error.rs
@@ -247,6 +247,9 @@ pub enum RpcError {
 
     #[error("No routes available for the bridging")]
     NoBridgingRoutesAvailable,
+
+    #[error("Orchestration ID is not found: {0}")]
+    OrchestrationIdNotFound(String),
 }
 
 impl IntoResponse for RpcError {
@@ -652,6 +655,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response(
                     "".to_string(),
                     "No bridging routes available".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::OrchestrationIdNotFound(id) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "orchestrationId".to_string(),
+                    format!("Orchestration ID is not found: {}", id),
                 )),
             )
                 .into_response(),

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -3,11 +3,13 @@ use {
     alloy::primitives::{Address, U256},
     ethers::types::H160 as EthersH160,
     phf::phf_map,
+    serde::{Deserialize, Serialize},
     std::{collections::HashMap, str::FromStr},
 };
 
 pub mod check;
 pub mod route;
+pub mod status;
 
 /// Available assets for Bridging
 pub static BRIDGING_AVAILABLE_ASSETS: phf::Map<&'static str, phf::Map<&'static str, &'static str>> = phf_map! {
@@ -20,6 +22,26 @@ pub static BRIDGING_AVAILABLE_ASSETS: phf::Map<&'static str, phf::Map<&'static s
       "eip155:42161" => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
   },
 };
+
+/// Serialized bridging request item schema to store it in the IRN database
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageBridgingItem {
+    created_at: usize,
+    chain_id: String,
+    wallet: Address,
+    amount_expected: U256,
+    status: BridgingStatus,
+}
+
+/// Bridging status
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BridgingStatus {
+    Pending,
+    Completed,
+    Error,
+}
 
 /// Checking ERC20 balances for given address for provided ERC20 contracts
 pub async fn check_erc20_balances(

--- a/src/handlers/chain_agnostic/status.rs
+++ b/src/handlers/chain_agnostic/status.rs
@@ -1,0 +1,112 @@
+use {
+    super::{super::HANDLER_TASK_METRICS, BridgingStatus, StorageBridgingItem},
+    crate::{
+        analytics::MessageSource, error::RpcError, state::AppState, storage::irn::OperationType,
+        utils::crypto::get_balance,
+    },
+    alloy::primitives::U256,
+    axum::{
+        extract::{Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    ethers::types::H160 as EthersH160,
+    serde::{Deserialize, Serialize},
+    std::{sync::Arc, time::SystemTime},
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryParams {
+    pub project_id: String,
+    pub orchestration_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusResponse {
+    status: BridgingStatus,
+    created_at: usize,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query_params: Query<QueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query_params)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("ca_status"))
+        .await
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Query(query_params): Query<QueryParams>,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query_params.project_id.clone())
+        .await?;
+
+    let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
+
+    // Get the bridging request status from the IRN
+    let irn_call_start = SystemTime::now();
+    let irn_result = irn_client
+        .get(query_params.orchestration_id.clone())
+        .await?
+        .ok_or(RpcError::OrchestrationIdNotFound(
+            query_params.orchestration_id.clone(),
+        ))?;
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Get);
+    let mut bridging_status_item = serde_json::from_str::<StorageBridgingItem>(&irn_result)?;
+
+    // Return without checking the balance if the status is completed or errored
+    if bridging_status_item.status == BridgingStatus::Completed
+        || bridging_status_item.status == BridgingStatus::Error
+    {
+        return Ok(Json(StatusResponse {
+            status: bridging_status_item.status,
+            created_at: bridging_status_item.created_at,
+        })
+        .into_response());
+    }
+
+    // Check the balance of the wallet and the amount expected
+    let wallet_balance = get_balance(
+        &bridging_status_item.chain_id,
+        EthersH160::from(<[u8; 20]>::from(bridging_status_item.wallet)),
+        &query_params.project_id,
+        MessageSource::ChainAgnosticCheck,
+    )
+    .await?;
+    if U256::from_be_bytes(wallet_balance.into()) < bridging_status_item.amount_expected {
+        // The balance was not fullfilled return the same pending status
+        return Ok(Json(StatusResponse {
+            status: bridging_status_item.status,
+            created_at: bridging_status_item.created_at,
+        })
+        .into_response());
+    } else {
+        // The balance was fullfilled, update the status to completed
+        bridging_status_item.status = BridgingStatus::Completed;
+        let irn_call_start = SystemTime::now();
+        irn_client
+            .set(
+                query_params.orchestration_id,
+                serde_json::to_string(&bridging_status_item)?.into(),
+            )
+            .await?;
+        state
+            .metrics
+            .add_irn_latency(irn_call_start, OperationType::Set);
+    }
+
+    return Ok(Json(StatusResponse {
+        status: bridging_status_item.status,
+        created_at: bridging_status_item.created_at,
+    })
+    .into_response());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         // Chain agnostic orchestration
         .route("/v1/ca/orchestrator/check", post(handlers::chain_agnostic::check::handler))
         .route("/v1/ca/orchestrator/route", post(handlers::chain_agnostic::route::handler))
+        .route("/v1/ca/orchestrator/status", get(handlers::chain_agnostic::status::handler))
         // Health
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_and_metrics_layer)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -807,4 +807,21 @@ pub trait ChainOrchestrationProvider: Send + Sync + Debug {
     ) -> Result<Vec<Value>, RpcError>;
 
     async fn build_bridging_tx(&self, route: Value) -> Result<bungee::BungeeBuildTx, RpcError>;
+
+    async fn check_allowance(
+        &self,
+        chain_id: String,
+        owner: Address,
+        target: Address,
+        token_address: Address,
+    ) -> Result<U256, RpcError>;
+
+    async fn build_approval_tx(
+        &self,
+        chain_id: String,
+        owner: Address,
+        target: Address,
+        token_address: Address,
+        amount: U256,
+    ) -> Result<bungee::BungeeApprovalTx, RpcError>;
 }

--- a/src/storage/irn/mod.rs
+++ b/src/storage/irn/mod.rs
@@ -22,6 +22,8 @@ pub enum OperationType {
     Hget,
     Hfields,
     Hdel,
+    Set,
+    Get,
 }
 
 impl OperationType {
@@ -31,6 +33,8 @@ impl OperationType {
             OperationType::Hget => "hget",
             OperationType::Hfields => "hfields",
             OperationType::Hdel => "hdel",
+            OperationType::Set => "set",
+            OperationType::Get => "get",
         }
     }
 }


### PR DESCRIPTION
# Description

This PR adds the approval transaction to the transactions list if required.
We are checking the allowance for the bridging transaction first and requesting the approval transaction data if the allowance is less than the minimum required. 
The approval transaction is added as the first transaction to the list.

Also, the `status` for the orchestration ID is added by checking if the amount in the wallet is greater than expected.

## How Has This Been Tested?

* Integration tests were updated, and local tests were successfully passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
