### PR TITLE
fix(ci): adding CA tests to the staging ignore list

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -98,10 +98,10 @@ jobs:
       - name: Yarn Install
         run: yarn install
 
-      # Temporary ignoring `Sessions tests` for staging until IRN peering for staging is ready
+      # Temporary ignoring `Sessions and CA tests` for staging until IRN peering for staging is ready
       - name: Run Yarn Integration Tests (no IRN tests)
         if: ${{ inputs.stage == 'staging' }}
-        run: yarn integration --testPathIgnorePatterns='sessions.test.ts'
+        run: yarn integration --testPathIgnorePatterns='(sessions.test.ts|chain_orchestrator.test.ts)'
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           RPC_URL: ${{ inputs.stage-url }}


### PR DESCRIPTION
# Description

This PR adds the CA integration test to the ignoring list for staging since the CA uses the IRN, and we don't have IRN support for staging yet.

## How Has This Been Tested?

Tested by running the `yarn integration --testPathIgnorePatterns='(sessions.test.ts|chain_orchestrator.test.ts)'` command locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
