### PR TITLE
fix(CA): fixing the topup amount and status check

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -17,6 +17,8 @@ describe('Chain abstraction orchestrator', () => {
   const amount_to_send = 3_000_000
   // How much needs to be topped up
   const amount_to_topup = amount_to_send - usdc_funds_on_optimism
+  // Default gas esimation is default with 4x increase
+  const gas_estimate = "0xa69ac";
 
   const receiver_address = "0x739ff389c8eBd9339E69611d46Eec6212179BB67";
   const chain_id_optimism = "eip155:10";
@@ -188,14 +190,19 @@ describe('Chain abstraction orchestrator', () => {
     // First transaction expected to be the approval transaction
     const approvalTransaction = data.transactions[0]
     expect(approvalTransaction.chainId).toBe(chain_id_base)
+    expect(approvalTransaction.nonce).not.toBe("0x00")
+    expect(approvalTransaction.gas).toBe(gas_estimate)
     const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data);  
     expect(decodedData.amount.toString()).toBe(amount_to_topup.toString())
 
+
     // Second transaction expected to be the bridging to the Base
     expect(data.transactions[1].chainId).toBe(chain_id_base)
+    expect(data.transactions[1].nonce).not.toBe("0x00")
+    expect(data.transactions[1].gas).toBe(gas_estimate)
 
     // Last transaction expected to be the initial one
-    expect(data.transactions[2]).toStrictEqual(transactionObj.transaction)
+    expect(data.transactions[2].data).toBe(transactionObj.transaction.data)
 
     // Set the Orchestration ID for the next test
     orchestration_id = data.orchestrationId;

--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -11,7 +11,12 @@ describe('Chain abstraction orchestrator', () => {
 
   // Address with 3 USDC on Base chain
   const from_address_with_funds = "0x2aae531a81461f029cd55cb46703211c9227ba05";
-  const usdc_funds_on_address = 3_000_000;
+  const usdc_funds_on_base = 3_000_000;
+  const usdc_funds_on_optimism = 1_057_151;
+  // Amount to send to Optimism
+  const amount_to_send = 3_000_000
+  // How much needs to be topped up
+  const amount_to_topup = amount_to_send - usdc_funds_on_optimism
 
   const receiver_address = "0x739ff389c8eBd9339E69611d46Eec6212179BB67";
   const chain_id_optimism = "eip155:10";
@@ -22,10 +27,9 @@ describe('Chain abstraction orchestrator', () => {
 
   it('bridging available', async () => {
     // Sending USDC to Optimism, but having the USDC balance on Base chain
-    const amount_to_send_in_decimals = usdc_funds_on_address - 1_000_000
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
-      amount_to_send_in_decimals,
+      amount_to_send,
     ]);
 
     let transactionObj = {
@@ -54,7 +58,7 @@ describe('Chain abstraction orchestrator', () => {
 
   it('bridging unavailable (insufficient funds)', async () => {
     // Having the USDC balance on Base chain less then the amount to send
-    const amount_to_send_in_decimals = usdc_funds_on_address + 1_000_000
+    const amount_to_send_in_decimals = usdc_funds_on_base + 10_000_000
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
       amount_to_send_in_decimals,
@@ -86,7 +90,7 @@ describe('Chain abstraction orchestrator', () => {
 
   it('bridging unavailable (empty wallet)', async () => {
     // Checking an empty wallet
-    const amount_to_send_in_decimals = usdc_funds_on_address
+    const amount_to_send_in_decimals = usdc_funds_on_base
     const empty_wallet_address = ethers.Wallet.createRandom().address
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
@@ -150,10 +154,9 @@ describe('Chain abstraction orchestrator', () => {
 
   it('bridging routes (routes available)', async () => {
     // Sending USDC to Optimism, but having the USDC balance on Base chain
-    const amount_to_send_in_decimals = usdc_funds_on_address - 1_000_000
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
-      amount_to_send_in_decimals,
+      amount_to_send,
     ]);
 
     let transactionObj = {
@@ -186,7 +189,7 @@ describe('Chain abstraction orchestrator', () => {
     const approvalTransaction = data.transactions[0]
     expect(approvalTransaction.chainId).toBe(chain_id_base)
     const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data);  
-    expect(decodedData.amount.toString()).toBe(amount_to_send_in_decimals.toString())
+    expect(decodedData.amount.toString()).toBe(amount_to_topup.toString())
 
     // Second transaction expected to be the bridging to the Base
     expect(data.transactions[1].chainId).toBe(chain_id_base)

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -30,6 +30,7 @@ pub struct StorageBridgingItem {
     created_at: usize,
     chain_id: String,
     wallet: Address,
+    contract: Address,
     amount_expected: U256,
     status: BridgingStatus,
 }

--- a/src/handlers/chain_agnostic/status.rs
+++ b/src/handlers/chain_agnostic/status.rs
@@ -2,7 +2,7 @@ use {
     super::{super::HANDLER_TASK_METRICS, BridgingStatus, StorageBridgingItem},
     crate::{
         analytics::MessageSource, error::RpcError, state::AppState, storage::irn::OperationType,
-        utils::crypto::get_balance,
+        utils::crypto::get_erc20_balance,
     },
     alloy::primitives::U256,
     axum::{
@@ -75,13 +75,15 @@ async fn handler_internal(
     }
 
     // Check the balance of the wallet and the amount expected
-    let wallet_balance = get_balance(
+    let wallet_balance = get_erc20_balance(
         &bridging_status_item.chain_id,
+        EthersH160::from(<[u8; 20]>::from(bridging_status_item.contract)),
         EthersH160::from(<[u8; 20]>::from(bridging_status_item.wallet)),
         &query_params.project_id,
         MessageSource::ChainAgnosticCheck,
     )
     .await?;
+
     if U256::from_be_bytes(wallet_balance.into()) < bridging_status_item.amount_expected {
         // The balance was not fullfilled return the same pending status
         return Ok(Json(StatusResponse {


### PR DESCRIPTION
# Description

This PR fixes the following issues in the Chain Orchestrator:
* Calculating the exact topup amount (current destination chain balance - expected transfer amount) instead of just using the transfer amount, in this case, the remaining balance will be used for the transfer;
* Fixing the status check endpoint by adding the right (destination) contract and chain ID instead of the bridging data;
* Checking the ERC20 token destination balance amount to skip bridging if it's sufficient.

## How Has This Been Tested?

* Integration tests for the chain orchestration were updated to catch this case.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
