### PR TITLE
feat(CA): adding topup amount multiplier

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -15,8 +15,10 @@ describe('Chain abstraction orchestrator', () => {
   const usdc_funds_on_optimism = 1_057_151;
   // Amount to send to Optimism
   const amount_to_send = 3_000_000
+  // Amount bridging multiplier
+  const amount_multiplier = 5; // +5% topup
   // How much needs to be topped up
-  const amount_to_topup = amount_to_send - usdc_funds_on_optimism
+  const amount_to_topup = (amount_to_send - usdc_funds_on_optimism) * (100 + amount_multiplier) / 100;
   // Default gas esimation is default with 4x increase
   const gas_estimate = "0xa69ac";
 
@@ -193,7 +195,7 @@ describe('Chain abstraction orchestrator', () => {
     expect(approvalTransaction.nonce).not.toBe("0x00")
     expect(approvalTransaction.gas).toBe(gas_estimate)
     const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data);  
-    expect(decodedData.amount.toString()).toBe(amount_to_topup.toString())
+    expect(decodedData.amount.toString()).toBe(amount_to_topup.toString().split('.')[0])
 
 
     // Second transaction expected to be the bridging to the Base

--- a/src/handlers/chain_agnostic/check.rs
+++ b/src/handlers/chain_agnostic/check.rs
@@ -1,5 +1,7 @@
 use {
-    super::{super::HANDLER_TASK_METRICS, check_bridging_for_erc20_transfer},
+    super::{
+        super::HANDLER_TASK_METRICS, check_bridging_for_erc20_transfer, BRIDGING_AMOUNT_MULTIPLIER,
+    },
     crate::{
         analytics::MessageSource,
         error::RpcError,
@@ -138,6 +140,9 @@ async fn handler_internal(
         .into_response());
     }
     let erc20_topup_value = erc20_transfer_value - erc20_balance;
+    // Multiply the topup value by the bridging percent multiplier
+    let erc20_topup_value = erc20_topup_value
+        + (erc20_topup_value * U256::from(BRIDGING_AMOUNT_MULTIPLIER)) / U256::from(100);
 
     // Check for possible bridging by iterating over supported assets
     if let Some((bridge_chain_id, bridge_contract)) =

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -11,6 +11,9 @@ pub mod check;
 pub mod route;
 pub mod status;
 
+/// How much to multiply the amount by when bridging to cover bridging differences
+pub const BRIDGING_AMOUNT_MULTIPLIER: i8 = 5; // 5%
+
 /// Available assets for Bridging
 pub static BRIDGING_AVAILABLE_ASSETS: phf::Map<&'static str, phf::Map<&'static str, &'static str>> = phf_map! {
   "USDC" => phf_map! {

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         super::HANDLER_TASK_METRICS, check_bridging_for_erc20_transfer, BridgingStatus,
-        StorageBridgingItem,
+        StorageBridgingItem, BRIDGING_AMOUNT_MULTIPLIER,
     },
     crate::{
         analytics::MessageSource,
@@ -142,6 +142,9 @@ async fn handler_internal(
         return Err(RpcError::NoBridgingNeeded);
     }
     let erc20_topup_value = erc20_transfer_value - erc20_balance;
+    // Multiply the topup value by the bridging percent multiplier
+    let erc20_topup_value = erc20_topup_value
+        + (erc20_topup_value * U256::from(BRIDGING_AMOUNT_MULTIPLIER)) / U256::from(100);
 
     // Check for possible bridging by iterating over supported assets
     if let Some((bridge_chain_id, bridge_contract)) = check_bridging_for_erc20_transfer(


### PR DESCRIPTION
# Description

This PR adds an amount top-up multiplier for the bridging to cover the bridging fees. This change will fix the bug when the check status is pending even after the bridging was done.
The default multiplier is 5%, which is the same as [in the sample](https://github.com/reown-com/web-examples/blob/9e94417090cfdd7e4bdc44ee181865530379fc23/advanced/wallets/react-wallet-v2/src/utils/MultibridgeUtil.ts#L11).

## How Has This Been Tested?

The integration test was updated to check the bridging amount * multiplier.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
