### PR TITLE
fix(walletService): fixing get_call_status bundler call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git#7b5481458f1326b9755b0af9fe768296402f37ad"
+source = "git+https://github.com/reown-com/yttrium.git#9f9fd6cb465f6c9e9279cb870564217bcc39ae7b"
 dependencies = [
  "alloy",
  "alloy-provider",


### PR DESCRIPTION
# Description

This PR fixes the `wallet_getCallsStatus` call by removing the CAIP-2 chain ID when passing it to the bundler provider.
Also, the [yttrium version is bumping to the](https://github.com/reown-com/yttrium/pull/54) fix of the `entryPoint` deserialization error.

## How Has This Been Tested?

* Tested manually by passing the `wallet_getCallsStatus` request to the local instance.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [x] Update the yttrium branch to the latest version
