### PR TITLE
fix(providers): Removing Pokt provider from Base Sepolia chain support

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -79,11 +79,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         // Base Sepolia
+        // Todo: Temporary disabling Pokt for the Sepolia until the contract call
+        // flaky responses issue will be resolved.
         (
             "eip155:84532".into(),
             (
                 "base-testnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::Disabled).unwrap(),
             ),
         ),
         // Binance Smart Chain

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -38,13 +38,16 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     .await;
 
     // Base Sepolia
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &provider,
-        "eip155:84532",
-        "0x14a34",
-    )
-    .await;
+    // Todo: Temporary disabling Pokt for the Sepolia until the contract call
+    // flaky responses issue will be resolved.
+
+    // check_if_rpc_is_responding_correctly_for_supported_chain(
+    //     ctx,
+    //     &provider,
+    //     "eip155:84532",
+    //     "0x14a34",
+    // )
+    // .await;
 
     // Binance mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:56", "0x38")


### PR DESCRIPTION
# Description

This PR temporarily removes Pokt provide from the Base Sepolia `eip155:84532` chain support, because of the flaky responses from the JSON-RPC contract calls responding with the `0x` response with no any error.

## How Has This Been Tested?

* Flaky responses were received using the `eth_call` method.
* Updated integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
