### PR TITLE
feat(providers): adding Publicnode Bitcoin RPC support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -4,6 +4,8 @@ Chain name with associated `chainId` query param to use.
 
 ## HTTP RPC
 
+### Ethereum
+
 | Network                                                  | Chain ID             |
 |----------------------------------------------------------|----------------------|
 | Ethereum                                                 | eip155:1             |
@@ -40,9 +42,21 @@ Chain name with associated `chainId` query param to use.
 | Aurora <sup>[1](#footnote1)</sup>                        | eip155:1313161554    |
 | Aurora Testnet <sup>[1](#footnote1)</sup>                | eip155:1313161555    |
 | Near Mainnet                                             | near:mainnet         |
-| Solana Mainnet                                           | solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp |
-| Solana Devnet                                            | solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1 |
-| Solana Testnet                                           | solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z |
+
+### Solana
+
+| Network                               | Chain ID                                |
+|---------------------------------------|-----------------------------------------|
+| Solana Mainnet                        | solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp |
+| Solana Devnet                         | solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1 |
+| Solana Testnet                        | solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z |
+
+### Bitcoin
+
+| Network                               | Chain ID                                |
+|---------------------------------------|-----------------------------------------|
+| Bitcoin Mainnet                       | bip122:000000000019d6689c085ae165831e93 |
+| Bitcoin Testnet                       | bip122:000000000933ea01ad0ee984209779ba |
 
 <a id="footnote1"><sup>1</sup></a> The availability of this chain in our RPC is not guaranteed.
 

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -115,5 +115,18 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Bitcoin mainnet
+        (
+            "bip122:000000000019d6689c085ae165831e93".into(),
+            ("bitcoin-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // Bitcoin testnet
+        (
+            "bip122:000000000933ea01ad0ee984209779ba".into(),
+            (
+                "bitcoin-testnet-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -100,7 +100,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Sei mainnet
         (
             "eip155:1329".into(),
-            ("sei-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+            ("sei-evm-rpc".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Scroll
         (

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -1,6 +1,11 @@
 use {
-    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
-    rpc_proxy::providers::ProviderKind, test_context::test_context,
+    super::{
+        check_if_rpc_is_responding_correctly_for_bitcoin,
+        check_if_rpc_is_responding_correctly_for_supported_chain,
+    },
+    crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
+    test_context::test_context,
 };
 
 #[test_context(ServerContext)]
@@ -103,6 +108,29 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
         &provider,
         "eip155:534351",
         "0x8274f",
+    )
+    .await;
+}
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn publicnode_provider_bitcoin(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Publicnode;
+
+    // Bitcoin mainnet
+    check_if_rpc_is_responding_correctly_for_bitcoin(
+        ctx,
+        "000000000019d6689c085ae165831e93",
+        &provider,
+    )
+    .await;
+
+    // Bitcoin testnet
+    check_if_rpc_is_responding_correctly_for_bitcoin(
+        ctx,
+        "000000000933ea01ad0ee984209779ba",
+        &provider,
     )
     .await;
 }


### PR DESCRIPTION
# Description

This PR adds the Bitcoin RPC support for mainnet `bip122:000000000019d6689c085ae165831e93` and testnet `bip122:000000000933ea01ad0ee984209779ba` to the Publicnode provider.

## How Has This Been Tested?

* Integration tests for the Publicnode provider were updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
