### PR TITLE
fix(ecs): increasing the cluster max capacity

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,7 +46,7 @@ variable "app_autoscaling_min_capacity" {
 variable "app_autoscaling_max_capacity" {
   description = "The maximum number of tasks to run when autoscaling"
   type        = number
-  default     = 8
+  default     = 10
 }
 
 variable "ofac_blocked_countries" {


### PR DESCRIPTION
# Description

This PR increases `autoscaling_max_capacity` to `10` for the ECS cluster to handle the load under the flood.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
