### PR TITLE
fix(CA): increasing the default gas estimation multiplier

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -19,8 +19,8 @@ describe('Chain abstraction orchestrator', () => {
   const amount_multiplier = 5; // +5% topup
   // How much needs to be topped up
   const amount_to_topup = (amount_to_send - usdc_funds_on_optimism) * (100 + amount_multiplier) / 100;
-  // Default gas esimation is default with 2x increase
-  const gas_estimate = "0x534d6";
+  // Default gas esimation is default with 6x increase
+  const gas_estimate = "0xf9e82";
 
   const receiver_address = "0x739ff389c8eBd9339E69611d46Eec6212179BB67";
   const chain_id_optimism = "eip155:10";

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -201,9 +201,9 @@ async fn handler_internal(
         .await?;
 
         // Default gas estimate
-        // Using default with 2x increase
+        // Using default with 6x increase
         // Todo: Implement gas estimation using `eth_estimateGas`
-        let gas = 0x029a6b * 0x2;
+        let gas = 0x029a6b * 0x6;
 
         // Check for the allowance
         if let Some(approval_data) = bridge_tx.approval_data {


### PR DESCRIPTION
# Description

This PR increases the gas estimation multiplier from the default to `6`.

## How Has This Been Tested?

* The integration test was updated.


<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
