### PR TITLE
feat(CA): adding `metadata` into the route endpoint response

### DIFF
--- a/src/handlers/chain_agnostic/check.rs
+++ b/src/handlers/chain_agnostic/check.rs
@@ -145,7 +145,7 @@ async fn handler_internal(
         + (erc20_topup_value * U256::from(BRIDGING_AMOUNT_MULTIPLIER)) / U256::from(100);
 
     // Check for possible bridging by iterating over supported assets
-    if let Some((bridge_chain_id, bridge_contract)) =
+    if let Some((bridge_chain_id, _, bridge_contract)) =
         check_bridging_for_erc20_transfer(query_params.project_id, erc20_topup_value, from_address)
             .await?
     {


### PR DESCRIPTION
# Description

This PR adds the `metadata` object to the `/route` chain orchestrator endpoint to reflect the funding information.
The following schema was added:
```
"metadata": {
	  "fundingFrom": [
	     {
		     "symbol": "USDC", // Funding token symbol
		     "tokenContract": "0xxxxxxxxxxxx", //  Funding token contract address
		     "chainId": "eip155:xxx" // Chain ID of the funding token contract address
		     "amount":"0x00" // Hex representation of the amount sourcing
	     }
	  ]
  }
```

## How Has This Been Tested?

* Integration test was updated to check new fields.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
