### PR TITLE
feat(o11y): adding HTTP 40[1-3] alerts for providers

### DIFF
--- a/terraform/monitoring/panels/status/provider.libsonnet
+++ b/terraform/monitoring/panels/status/provider.libsonnet
@@ -11,10 +11,38 @@ local targets   = grafana.targets;
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)
-
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
+      datasource    = ds.prometheus,
       expr          = 'sum by(status_code) (increase(provider_status_code_counter_total{provider="%s"}[$__rate_interval]))' % provider,
       legendFormat  = '__auto',
     ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(status_code) (increase(provider_status_code_counter_total{provider="%s", status_code=~"401|402|403"}[$__rate_interval]))' % provider,
+      refId         = 'Provider4xxErrors',
+      hide          = true,
+    ))
+    .setAlert(
+      vars.environment,
+      grafana.alert.new(
+        namespace     = vars.namespace,
+        name          = "%(env)s - Provider 40[1-3] Errors alert" % { env: grafana.utils.strings.capitalize(vars.environment) },
+        message       = '%(env)s - Provider 40[1-3] Errors alert' % { env: grafana.utils.strings.capitalize(vars.environment) },
+        notifications = vars.notifications,
+        noDataState   = 'no_data',
+        period        = '0m',
+        conditions    = [
+          grafana.alertCondition.new(
+            evaluatorParams = [ 0 ],
+            evaluatorType   = 'gt',
+            operatorType    = 'or',
+            queryRefId      = 'Provider4xxErrors',
+            queryTimeStart  = '15m',
+            queryTimeEnd    = 'now',
+            reducerType     = grafana.alert_reducers.Avg
+          ),
+        ],
+      ),
+    )
 }


### PR DESCRIPTION
# Description

This PR adds an alert in case the provider responds with HTTP 40[1-3] errors. 
We should track these responses since they reflect paid providers' payment or plan issues and we should take action on this. 
Only 40[1-3] were included, because of:
* HTTP 400 Bad Request - reflecting the client request error,
* HTTP 404 Not Found - some providers (like 1Inch) use this response as a client error request (requested token not found, etc).

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
