### PR TITLE
feat(CA): adding timeout, insufficient bridged amount check, pinning to the exact bridge

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -189,44 +189,6 @@ describe('Chain abstraction orchestrator', () => {
     orchestration_id = data.orchestrationId;
   })
 
-  it('bridging routes (routes available, low topping up amount)', async () => {
-    // Sending USDC to Base, but having the USDC balance on Optimism
-    // with less then 1 USDC for topping up
-    const amount_to_send = usdc_funds_on_base + 900_000
-    const data_encoded = erc20Interface.encodeFunctionData('transfer', [
-      receiver_address,
-      amount_to_send,
-    ]);
-
-    let transactionObj = {
-      transaction: {
-        from: from_address_with_funds,
-        to: usdc_contract_base,
-        value: "0x00", // Zero native tokens
-        gas: "0x00",
-        gasPrice: "0x00",
-        data: data_encoded,
-        nonce: "0x00",
-        maxFeePerGas: "0x00",
-        maxPriorityFeePerGas: "0x00",
-        chainId: chain_id_base,
-      }
-    }
-
-    let resp: any = await httpClient.post(
-      `${baseUrl}/v1/ca/orchestrator/route?projectId=${projectId}`,
-      transactionObj
-    )
-    expect(resp.status).toBe(200)
-    const data = resp.data
-    // Expecting 2 transactions in the route
-    expect(data.transactions.length).toBe(2)
-    const approvalTransaction = data.transactions[0]
-    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data)
-    // Topup amount should be with the minimal bridging fees covering
-    expect(decodedData.amount.toString()).toBe((amount_to_send + minimal_bridging_fees_covering).toString())
-  })
-
   it('bridging status', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/ca/orchestrator/status?projectId=${projectId}&orchestrationId=${orchestration_id}`,

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -13,6 +13,9 @@ pub mod status;
 /// How much to multiply the amount by when bridging to cover bridging differences
 pub const BRIDGING_AMOUNT_MULTIPLIER: i8 = 5; // 5%
 
+/// Bridging timeout in seconds
+pub const BRIDGING_TIMEOUT: usize = 1800; // 30 minutes
+
 /// Available assets for Bridging
 pub static BRIDGING_AVAILABLE_ASSETS: phf::Map<&'static str, phf::Map<&'static str, &'static str>> = phf_map! {
   "USDC" => phf_map! {
@@ -36,6 +39,7 @@ pub struct StorageBridgingItem {
     chain_id: String,
     wallet: Address,
     contract: Address,
+    amount_current: U256,
     amount_expected: U256,
     status: BridgingStatus,
     error_reason: Option<String>,

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -332,6 +332,7 @@ async fn handler_internal(
         chain_id: request_payload.transaction.chain_id,
         wallet: from_address,
         contract: to_address,
+        amount_current: erc20_balance, // The current balance of the ERC20 token
         amount_expected: erc20_transfer_value, // The total transfer amount expected
         status: BridgingStatus::Pending,
         error_reason: None,

--- a/src/providers/bungee.rs
+++ b/src/providers/bungee.rs
@@ -148,6 +148,9 @@ impl ChainOrchestrationProvider for BungeeProvider {
             "defaultBridgeSlippage",
             BRIDGING_SLIPPAGE.to_string().as_str(),
         );
+        // Use only Across bridge for latency reason
+        url.query_pairs_mut()
+            .append_pair("includeBridges", "across");
 
         let response = self.send_get_request(url).await?;
         if !response.status().is_success() {


### PR DESCRIPTION
# Description

This PR adds the following changes: 
* Adds the briding timeout for `30` minutes because bridging can take ~20 minutes until funds are refunded; 
* Adds check if the initial address token amount was changed since the routes request and if it was changed, but less than expected after bridging;
* Pinning to the `Across` bridge when requesting quotes from the Bungee.

## How Has This Been Tested?

* Current test coverage.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
