### PR TITLE
fix(providers): temporarily disabling Pokt for the Polygon

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -135,7 +135,12 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Polygon
         (
             "eip155:137".into(),
-            ("poly-mainnet".into(), Weight::new(Priority::High).unwrap()),
+            // Temporary removing Pokt for the Polygon mainnet until the issue with the flaky
+            // responses will be resolved.
+            (
+                "poly-mainnet".into(),
+                Weight::new(Priority::Disabled).unwrap(),
+            ),
         ),
         (
             "eip155:1101".into(),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -89,8 +89,10 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     .await;
 
     // Polygon mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
-        .await;
+    // Temporary removing Pokt for the Polygon mainnet until the issue with the flaky
+    // responses will be resolved.
+    // check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
+    //     .await;
 
     // Polygon zkevm
     check_if_rpc_is_responding_correctly_for_supported_chain(


### PR DESCRIPTION
# Description

This PR temporarily disables Pokt for the Polygon chain because of the flaky responses with the `execution reverted` even for the `eth_chainId`.

## How Has This Been Tested?

* Sending the `eth_chainId` request sometimes results in an `execution reverted` response.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
