### PR TITLE
fix(fungibles): adding `address` field to the fungibles price response schema

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -28,6 +28,7 @@ describe('Fungible price', () => {
       expect(item.symbol).toBe('SHIB')
       expect(typeof item.iconUrl).toBe('string')
       expect(typeof item.price).toBe('number')
+      expect(typeof item.address).toBe(shib_token_address)
     }
   })
 
@@ -51,6 +52,7 @@ describe('Fungible price', () => {
       expect(item.symbol).toBe('SOL')
       expect(typeof item.iconUrl).toBe('string')
       expect(typeof item.price).toBe('number')
+      expect(typeof item.address).toBe(wsol_token_address)
     }
   })
 

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -30,6 +30,7 @@ pub struct PriceResponseBody {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FungiblePriceItem {
+    pub address: String,
     pub name: String,
     pub symbol: String,
     pub icon_url: String,

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -778,6 +778,12 @@ impl FungiblePriceProvider for OneInchProvider {
 
         let response = PriceResponseBody {
             fungibles: vec![FungiblePriceItem {
+                address: format!(
+                    "{}:{}:{}",
+                    crypto::CaipNamespaces::Eip155,
+                    chain_id,
+                    address
+                ),
                 name: info.name,
                 symbol: info.symbol,
                 icon_url: info.logo_uri.unwrap_or_default(),

--- a/src/providers/solscan.rs
+++ b/src/providers/solscan.rs
@@ -17,7 +17,7 @@ use {
         },
         providers::ProviderKind,
         storage::error::StorageError,
-        utils::crypto::SOLANA_NATIVE_TOKEN_ADDRESS,
+        utils::crypto::{CaipNamespaces, SOLANA_NATIVE_TOKEN_ADDRESS},
         Metrics,
     },
     async_trait::async_trait,
@@ -620,6 +620,7 @@ impl FungiblePriceProvider for SolScanProvider {
         let price = self.token_price_request(address, metrics).await?;
         let response = PriceResponseBody {
             fungibles: vec![FungiblePriceItem {
+                address: format!("{}:{}:{}", CaipNamespaces::Solana, chain_id, address),
                 name: info.name,
                 symbol: info.symbol,
                 icon_url: info.icon.unwrap_or_default(),


### PR DESCRIPTION
# Description

According to [the SPEC](https://specs.walletconnect.com/2.0/specs/servers/blockchain/blockchain-api#success-response-body-6), this PR adds the missing `address` field to the fungibles price response.

## How Has This Been Tested?

Integration tests were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
