### PR TITLE
fix(providers): swapping providers for the Optimism chain

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -121,7 +121,9 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:10".into(),
             (
                 "optimism-mainnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                // TODO: Temporary disabling Pokt until the issue
+                // with the flaky RPC response is resolved.
+                Weight::new(Priority::Disabled).unwrap(),
             ),
         ),
         // Arbitrum

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -123,6 +123,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Optimisim Mainnet
+        (
+            "eip155:10".into(),
+            (
+                "optimism-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Gnosis Chain mainnet
         (
             "eip155:100".into(),

--- a/src/env/quicknode.rs
+++ b/src/env/quicknode.rs
@@ -70,6 +70,10 @@ fn extract_supported_chains_and_subdomains(
             ("frequent-capable-putty.bera-bartio", Priority::Normal),
         ),
         (
+            "eip155:10",
+            ("convincing-dawn-smoke.optimism", Priority::Normal),
+        ),
+        (
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             ("indulgent-thrumming-bush.solana-mainnet", Priority::Normal),
         ),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -76,8 +76,9 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     .await;
 
     // Optimism
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
-        .await;
+    // Temporary removing Pokt for the Optimism until the issue with the flaky
+    // check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
+    //     .await;
 
     // Arbitrum
     check_if_rpc_is_responding_correctly_for_supported_chain(

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -123,6 +123,10 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     // Gnosis
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:100", "0x64")
         .await;
+
+    // Optimism mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
+        .await;
 }
 
 #[test_context(ServerContext)]

--- a/tests/functional/http/quicknode.rs
+++ b/tests/functional/http/quicknode.rs
@@ -41,6 +41,10 @@ async fn quicknode_provider(ctx: &mut ServerContext) {
         "0x138d4",
     )
     .await;
+
+    // Optimism Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
+        .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR removes Grove/Pokt provider (because of flaky RPC responses) and adds Publicnode and Quicknode providers instead for the Optimism chain `eip155:10`.

## How Has This Been Tested?

Integration tests were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
