### PR TITLE
feat(o11y): adding tracking of chain availability by ChainId

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -124,6 +124,7 @@ pub async fn rpc_call(
         }
     }
 
+    state.metrics.add_no_providers_for_chain(chain_id.clone());
     debug!("All providers failed for chain_id: {}", chain_id);
     Err(RpcError::ChainTemporarilyUnavailable(chain_id))
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,6 +27,7 @@ pub struct Metrics {
     pub http_call_counter: Counter<u64>,
     pub provider_finished_call_counter: Counter<u64>,
     pub provider_failed_call_counter: Counter<u64>,
+    pub no_providers_for_chain_counter: Counter<u64>,
     pub http_latency_tracker: Histogram<f64>,
     pub http_external_latency_tracker: Histogram<f64>,
     pub rejected_project_counter: Counter<u64>,
@@ -260,6 +261,11 @@ impl Metrics {
             .with_description("The latency of non-RPC providers cache lookups")
             .init();
 
+        let no_providers_for_chain_counter = meter
+            .u64_counter("no_providers_for_chain_counter")
+            .with_description("The number of chain RPC calls that had no available providers")
+            .init();
+
         Metrics {
             rpc_call_counter,
             rpc_call_retries,
@@ -272,6 +278,7 @@ impl Metrics {
             provider_failed_call_counter,
             provider_finished_call_counter,
             provider_status_code_counter,
+            no_providers_for_chain_counter,
             weights_value_recorder,
             identity_lookup_counter,
             identity_lookup_success_counter,
@@ -450,6 +457,14 @@ impl Metrics {
                 otel::KeyValue::new("chain_id", chain_id),
             ],
         )
+    }
+
+    pub fn add_no_providers_for_chain(&self, chain_id: String) {
+        self.no_providers_for_chain_counter.add(
+            &otel::Context::new(),
+            1,
+            &[otel::KeyValue::new("chain_id", chain_id)],
+        );
     }
 
     pub fn add_identity_lookup(&self) {

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -117,8 +117,9 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Unichain')     { gridPos: pos._4 },
 
   row.new('RPC Proxy Metrics'),
-    panels.proxy.calls(ds, vars)                     { gridPos: pos._2 },
-    panels.proxy.latency(ds, vars)                   { gridPos: pos._2 },
+    panels.proxy.calls(ds, vars)                     { gridPos: pos._3 },
+    panels.proxy.latency(ds, vars)                   { gridPos: pos._3 },
+    panels.proxy.chains_availability(ds, vars)       { gridPos: pos._3 },
     panels.proxy.errors_provider(ds, vars)           { gridPos: pos._3 },
     panels.proxy.provider_retries(ds, vars)          { gridPos: pos._3 },
     panels.proxy.http_codes(ds, vars)                { gridPos: pos._3 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -33,6 +33,7 @@ local redis  = panels.aws.redis;
     provider_retries:       (import 'proxy/rpc_retries.libsonnet'           ).new,
     rate_limited_counter:   (import 'proxy/rate_limited_counter.libsonnet'  ).new,
     http_codes:             (import 'proxy/http_codes.libsonnet'            ).new,
+    chains_availability:    (import 'proxy/chains_availability.libsonnet'   ).new,
   },
 
   projects: {

--- a/terraform/monitoring/panels/proxy/chains_availability.libsonnet
+++ b/terraform/monitoring/panels/proxy/chains_availability.libsonnet
@@ -7,14 +7,14 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Calls by Chain ID',
+      title       = 'ChainID Availability',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(chain_id) (increase(rpc_call_counter_total{}[$__rate_interval]))',
+      expr          = '((sum by(chain_id) (increase(rpc_call_counter_total{}[$__rate_interval])) – sum by(chain_id) (increase(no_providers_for_chain_counter{}[$__rate_interval]))) / sum by(chain_id) (increase(rpc_call_counter_total{}[$__rate_interval])) * 100)',
       exemplar      = false,
       legendFormat  = '__auto',
     ))


### PR DESCRIPTION
# Description

This PR adds tracking of chain availability by ChainId. The following changes were implemented:

* A new metric `no_providers_for_chain_counter` to track `no providers available` responses for chain IDs;
* Proxy endpoint updated to track the new `no_providers_for_chain_counter` metric;
* A new Grafana `Chains availability` panel was added.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
