### PR TITLE
fix(o11y): removing 40x providers alerts

### DIFF
--- a/terraform/monitoring/panels/status/provider.libsonnet
+++ b/terraform/monitoring/panels/status/provider.libsonnet
@@ -16,33 +16,4 @@ local targets   = grafana.targets;
       expr          = 'sum by(status_code) (increase(provider_status_code_counter_total{provider="%s"}[$__rate_interval]))' % provider,
       legendFormat  = '__auto',
     ))
-
-    .addTarget(targets.prometheus(
-      datasource    = ds.prometheus,
-      expr          = 'sum by(status_code) (increase(provider_status_code_counter_total{provider="%s", status_code=~"401|402|403"}[$__rate_interval]))' % provider,
-      refId         = 'Provider4xxErrors',
-      hide          = true,
-    ))
-    .setAlert(
-      vars.environment,
-      grafana.alert.new(
-        namespace     = vars.namespace,
-        name          = "%(env)s - Provider 40[1-3] Errors alert" % { env: grafana.utils.strings.capitalize(vars.environment) },
-        message       = '%(env)s - Provider 40[1-3] Errors alert' % { env: grafana.utils.strings.capitalize(vars.environment) },
-        notifications = vars.notifications,
-        noDataState   = 'no_data',
-        period        = '0m',
-        conditions    = [
-          grafana.alertCondition.new(
-            evaluatorParams = [ 0 ],
-            evaluatorType   = 'gt',
-            operatorType    = 'or',
-            queryRefId      = 'Provider4xxErrors',
-            queryTimeStart  = '15m',
-            queryTimeEnd    = 'now',
-            reducerType     = grafana.alert_reducers.Avg
-          ),
-        ],
-      ),
-    )
 }


### PR DESCRIPTION
# Description

This PR removes the 40[1-3] errors alert since the alert must be tuned for the per-provider actions because some of the providers return 402, and 403 in case of the rate limiting.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
