### PR TITLE
fix(CA): adding an exclusion into the bridging assets search

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -101,11 +101,19 @@ pub async fn check_bridging_for_erc20_transfer(
     rpc_project_id: String,
     value: U256,
     sender: Address,
+    exclude_chain_id: String,
+    exclude_contract_address: Address,
 ) -> Result<Option<BridgingAsset>, RpcError> {
     // Check ERC20 tokens balance for each of supported assets
     let mut contracts_per_chain: HashMap<(String, String), Vec<String>> = HashMap::new();
     for (token_symbol, chain_map) in BRIDGING_AVAILABLE_ASSETS.entries() {
         for (chain_id, contract_address) in chain_map.entries() {
+            if *chain_id == exclude_chain_id
+                && Address::from_str(contract_address).unwrap_or_default()
+                    == exclude_contract_address
+            {
+                continue;
+            }
             contracts_per_chain
                 .entry((token_symbol.to_string(), (*chain_id).to_string()))
                 .or_default()

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -128,6 +128,8 @@ async fn handler_internal(
         query_params.project_id.as_ref().to_string(),
         erc20_topup_value,
         from_address,
+        initial_transaction.chain_id.clone(),
+        to_address,
     )
     .await?
     else {
@@ -140,11 +142,6 @@ async fn handler_internal(
     let bridge_token_symbol = bridging_asset.token_symbol;
     let bridge_contract = bridging_asset.contract_address;
     let current_bridging_asset_balance = bridging_asset.current_balance;
-
-    // Skip bridging if that's the same chainId and contract address
-    if bridge_chain_id == request_payload.transaction.chain_id && bridge_contract == to_address {
-        return Ok(no_bridging_needed_response.into_response());
-    }
 
     // Get Quotes for the bridging
     let quotes = state


### PR DESCRIPTION
# Description

This PR fixes the bug with the flaky route responses (empty routes) even when funds and bridging are available by adding the initial asset exclusion from the assets searching for the bridging. This causes a `no bridging needed` response when the initial asset is found.

## How Has This Been Tested?

Tested multiple times by requesting and reproducing the flaky issue.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
