### PR TITLE
feat(providers): adding Publicnode provider for the Arbitrum chain

### DIFF
--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -136,6 +136,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:100".into(),
             ("gnosis-rpc".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Arbitrum One
+        (
+            "eip155:42161".into(),
+            (
+                "arbitrum-one-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Bitcoin mainnet
         (
             "bip122:000000000019d6689c085ae165831e93".into(),

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -127,6 +127,15 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     // Optimism mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
         .await;
+
+    // Arbitrum One
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:42161",
+        "0xa4b1",
+    )
+    .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR adds Publicnode provider for the Arbitrum `eip155:42161` chain.

## How Has This Been Tested?

Updated integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
