### PR TITLE
fix(providers): swaping Unichain to Arbitrum in the Quicknode

### DIFF
--- a/src/env/quicknode.rs
+++ b/src/env/quicknode.rs
@@ -58,12 +58,15 @@ fn extract_supported_chains_and_subdomains(
             ("snowy-chaotic-hill.zksync-mainnet", Priority::High),
         ),
         (
-            "eip155:1301",
-            ("blissful-side-log.unichain-sepolia", Priority::Normal),
-        ),
-        (
             "eip155:1101",
             ("clean-few-meme.zkevm-mainnet", Priority::Normal),
+        ),
+        (
+            "eip155:42161",
+            (
+                "divine-special-snowflake.arbitrum-mainnet",
+                Priority::Normal,
+            ),
         ),
         (
             "eip155:80084",

--- a/tests/functional/http/quicknode.rs
+++ b/tests/functional/http/quicknode.rs
@@ -25,14 +25,6 @@ async fn quicknode_provider(ctx: &mut ServerContext) {
         "0x44d",
     )
     .await;
-    // Unichain Sepolia
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &provider,
-        "eip155:1301",
-        "0x515",
-    )
-    .await;
     // Berachain Bartio
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
@@ -45,6 +37,15 @@ async fn quicknode_provider(ctx: &mut ServerContext) {
     // Optimism Mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
         .await;
+
+    // Arbitrum One
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:42161",
+        "0xa4b1",
+    )
+    .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR swaps the Unichain endpoint to the Arbitrum for the Quicknode.

## How Has This Been Tested?

Test updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
