### PR TITLE
feat(providers): adding Arbitrum native RPC endpoints

### DIFF
--- a/src/env/arbitrum.rs
+++ b/src/env/arbitrum.rs
@@ -1,0 +1,55 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct ArbitrumConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for ArbitrumConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for ArbitrumConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Arbitrum
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Arbitrum One
+        (
+            "eip155:42161".into(),
+            (
+                "https://arb1.arbitrum.io/rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Arbitrum Sepolia
+        (
+            "eip155:421614".into(),
+            (
+                "https://sepolia-rollup.arbitrum.io/rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -14,9 +14,10 @@ use {
     std::{collections::HashMap, fmt::Display},
 };
 pub use {
-    aurora::*, base::*, berachain::*, binance::*, getblock::*, infura::*, mantle::*, near::*,
-    pokt::*, publicnode::*, quicknode::*, server::*, unichain::*, zksync::*, zora::*,
+    arbitrum::*, aurora::*, base::*, berachain::*, binance::*, getblock::*, infura::*, mantle::*,
+    near::*, pokt::*, publicnode::*, quicknode::*, server::*, unichain::*, zksync::*, zora::*,
 };
+mod arbitrum;
 mod aurora;
 mod base;
 mod berachain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,17 @@ use {
         Router,
     },
     env::{
-        AuroraConfig, BaseConfig, BerachainConfig, BinanceConfig, GetBlockConfig, InfuraConfig,
-        MantleConfig, NearConfig, PoktConfig, PublicnodeConfig, QuicknodeConfig, UnichainConfig,
-        ZKSyncConfig, ZoraConfig,
+        ArbitrumConfig, AuroraConfig, BaseConfig, BerachainConfig, BinanceConfig, GetBlockConfig,
+        InfuraConfig, MantleConfig, NearConfig, PoktConfig, PublicnodeConfig, QuicknodeConfig,
+        UnichainConfig, ZKSyncConfig, ZoraConfig,
     },
     error::RpcResult,
     http::Request,
     hyper::{header::HeaderName, http, server::conn::AddrIncoming, Body, Server},
     providers::{
-        AuroraProvider, BaseProvider, BerachainProvider, BinanceProvider, GetBlockProvider,
-        InfuraProvider, InfuraWsProvider, MantleProvider, NearProvider, PoktProvider,
-        ProviderRepository, PublicnodeProvider, QuicknodeProvider, UnichainProvider,
+        ArbitrumProvider, AuroraProvider, BaseProvider, BerachainProvider, BinanceProvider,
+        GetBlockProvider, InfuraProvider, InfuraWsProvider, MantleProvider, NearProvider,
+        PoktProvider, ProviderRepository, PublicnodeProvider, QuicknodeProvider, UnichainProvider,
         ZKSyncProvider, ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
@@ -467,6 +467,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
     providers.add_provider::<AuroraProvider, AuroraConfig>(AuroraConfig::default());
+    providers.add_provider::<ArbitrumProvider, ArbitrumConfig>(ArbitrumConfig::default());
     providers
         .add_provider::<PoktProvider, PoktConfig>(PoktConfig::new(config.pokt_project_id.clone()));
 

--- a/src/providers/arbitrum.rs
+++ b/src/providers/arbitrum.rs
@@ -1,0 +1,96 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::ArbitrumConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct ArbitrumProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for ArbitrumProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Arbitrum
+    }
+}
+
+#[async_trait]
+impl RateLimited for ArbitrumProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for ArbitrumProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Arbitrum: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<ArbitrumConfig> for ArbitrumProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &ArbitrumConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        ArbitrumProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -47,6 +47,7 @@ use {
     wc::metrics::TaskMetrics,
 };
 
+mod arbitrum;
 mod aurora;
 mod base;
 mod berachain;
@@ -71,6 +72,7 @@ mod zksync;
 mod zora;
 
 pub use {
+    arbitrum::ArbitrumProvider,
     aurora::AuroraProvider,
     base::BaseProvider,
     berachain::BerachainProvider,
@@ -470,6 +472,7 @@ impl ProviderRepository {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderKind {
     Aurora,
+    Arbitrum,
     Infura,
     Pokt,
     Binance,
@@ -497,6 +500,7 @@ impl Display for ProviderKind {
             "{}",
             match self {
                 ProviderKind::Aurora => "Aurora",
+                ProviderKind::Arbitrum => "Arbitrum",
                 ProviderKind::Infura => "Infura",
                 ProviderKind::Pokt => "Pokt",
                 ProviderKind::Binance => "Binance",
@@ -525,6 +529,7 @@ impl ProviderKind {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "Aurora" => Some(Self::Aurora),
+            "Arbitrum" => Some(Self::Arbitrum),
             "Infura" => Some(Self::Infura),
             "Pokt" => Some(Self::Pokt),
             "Binance" => Some(Self::Binance),

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -70,6 +70,7 @@ dashboard.new(
 
   row.new('RPC Proxy Chain Usage'),
     panels.usage.provider(ds, vars, 'Aurora')        { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Arbitrum')      { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Base')          { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Binance')       { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Infura')        { gridPos: pos._4 },
@@ -86,6 +87,7 @@ dashboard.new(
 
   row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Arbitrum')    { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Base')        { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Binance')     { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Infura')      { gridPos: pos._4 },
@@ -102,6 +104,7 @@ dashboard.new(
 
   row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Arbitrum')     { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Base')         { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Binance')      { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Infura')       { gridPos: pos._4 },

--- a/tests/functional/http/arbitrum.rs
+++ b/tests/functional/http/arbitrum.rs
@@ -1,0 +1,29 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn arbitrum_provider(ctx: &mut ServerContext) {
+    let provider_kind = ProviderKind::Arbitrum;
+
+    // Arbitrum One
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider_kind,
+        "eip155:42161",
+        "0xa4b1",
+    )
+    .await;
+
+    // Arbitrum Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider_kind,
+        "eip155:421614",
+        "0x66eee",
+    )
+    .await
+}

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -6,6 +6,7 @@ use {
     test_context::test_context,
 };
 
+pub(crate) mod arbitrum;
 pub(crate) mod aurora;
 pub(crate) mod base;
 pub(crate) mod berachain;


### PR DESCRIPTION
# Description

This PR adds Arbitrum native endpoints for Arbitrum One `eip155:42161` and Arbitrum Sepolia `eip155:421614`.

## How Has This Been Tested?

A new integration test was created.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
