### PR TITLE
feat(providers): adding Ethereum Sepolia to the Publicnode

### DIFF
--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -40,6 +40,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:1".into(),
             ("ethereum".into(), Weight::new(Priority::High).unwrap()),
         ),
+        // Ethereum Sepolia
+        (
+            "eip155:11155111".into(),
+            (
+                "ethereum-sepolia-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Ethereum Holesky
         (
             "eip155:17000".into(),

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -18,6 +18,15 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:1", "0x1")
         .await;
 
+    // Ethereum Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:11155111",
+        "0xaa36a7",
+    )
+    .await;
+
     // Ethereum holesky
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,


### PR DESCRIPTION
# Description

This PR adds Ethereum Sepolia `eip155:11155111` to the Publicnode provider.

## How Has This Been Tested?

Integration tests were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
