### PR TITLE
feat(providers): adding Solana mainnet to the Publicnode

### DIFF
--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -165,5 +165,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Solana mainnet
+        (
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into(),
+            ("solana-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
     ])
 }

--- a/terraform/monitoring/panels/proxy/chains_unavailability.libsonnet
+++ b/terraform/monitoring/panels/proxy/chains_unavailability.libsonnet
@@ -21,10 +21,10 @@ local alertCondition  = grafana.alertCondition;
         message       = '%(env)s - RPC chain unavailability alert'  % { env: grafana.utils.strings.capitalize(vars.environment) },
         notifications = vars.notifications,
         noDataState   = 'no_data',
-        period        = '0m',
+        period        = '5m',
         conditions    = [
           grafana.alertCondition.new(
-            evaluatorParams = [ 100 ],
+            evaluatorParams = [ 10 ],
             evaluatorType   = 'gt',
             operatorType    = 'or',
             queryRefId      = 'ChainsUnavailability',

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -1,6 +1,7 @@
 use {
     super::{
         check_if_rpc_is_responding_correctly_for_bitcoin,
+        check_if_rpc_is_responding_correctly_for_solana,
         check_if_rpc_is_responding_correctly_for_supported_chain,
     },
     crate::context::ServerContext,
@@ -165,6 +166,20 @@ async fn publicnode_provider_bitcoin(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_bitcoin(
         ctx,
         "000000000933ea01ad0ee984209779ba",
+        &provider,
+    )
+    .await;
+}
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn quicknode_provider_solana(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Publicnode;
+    // Solana mainnet
+    check_if_rpc_is_responding_correctly_for_solana(
+        ctx,
+        "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
         &provider,
     )
     .await;


### PR DESCRIPTION
# Description

This PR adds the Solana Mainnet RPC endpoint to the Publicnode RPC provider and tunes the chain unavailability alarm to fire on 10 requests in 10 minutes instead of 100 requests burst.

## How Has This Been Tested?

* Publicnode tests were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
