### PR TITLE
feat(providers): updating Infura provider endpoints

### DIFF
--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -88,6 +88,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::High).unwrap(),
             ),
         ),
+        // Polygon Amoy
+        (
+            "eip155:80002".into(),
+            (
+                "polygon-amoy".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Celo
         (
             "eip155:42220".into(),
@@ -125,6 +133,32 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:84532".into(),
             (
                 "base-sepolia".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // BSC Mainnet
+        (
+            "eip155:56".into(),
+            ("bsc-mainnet".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // BSC Testnet
+        (
+            "eip155:97".into(),
+            ("bsc-testnet".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // ZkSync Mainnet
+        (
+            "eip155:324".into(),
+            (
+                "zksync-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Unichain Sepolia
+        (
+            "eip155:1301".into(),
+            (
+                "unichain-sepolia".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -25,6 +25,15 @@ async fn infura_provider(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
         .await;
 
+    // Polygin Amoy
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:80002",
+        "0x13882",
+    )
+    .await;
+
     // Optimism mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
         .await;
@@ -98,6 +107,27 @@ async fn infura_provider(ctx: &mut ServerContext) {
         &provider,
         "eip155:84532",
         "0x14a34",
+    )
+    .await;
+
+    // BSC Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:56", "0x38")
+        .await;
+
+    // BSC Testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:97", "0x61")
+        .await;
+
+    // ZkSync Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:324", "0x144")
+        .await;
+
+    // Unichain Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:1301",
+        "0x515",
     )
     .await;
 }


### PR DESCRIPTION
# Description

This PR updates the Infura RPC endpoints by adding the following chains:

* BSC Mainnet and Testnet,
* zkSync Mainnet,
* Polygon Amoy,
* Unichain Sepolia.

## How Has This Been Tested?

Integration tests were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
