### PR TITLE
fix(tests): changing the Ethereum address for tests

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -3,7 +3,7 @@ import { getTestSetup } from './init';
 describe('Account balance', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
 
-  const fulfilled_eth_address = '0xf3ea39310011333095CFCcCc7c4Ad74034CABA63'
+  const fulfilled_eth_address = '0x2aae531a81461f029cd55cb46703211c9227ba05'
   const fulfilled_solana_address = '5PUrktzVvJPNFYpxNzFkGp4a5Dcj1Dduif5dAzuUUhsr'
 
   const empty_eth_address = '0x5b6262592954B925B510651462b63ddEbcc22eaD'

--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -9,8 +9,8 @@ describe('Token conversion (single chain)', () => {
 
   const srcAsset = `${namespace}:${chainId}:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`;
   const destAsset = `${namespace}:${chainId}:0x111111111117dc0aa78b770fa6a738034120c302`;
-  const userAddress = `${namespace}:${chainId}:0xf3ea39310011333095cfcccc7c4ad74034caba63`;
-  const amount = "100000";
+  const userAddress = `${namespace}:${chainId}:0x2aae531a81461f029cd55cb46703211c9227ba05`;
+  const amount = "1000000";
 
   it('available tokens list', async () => {
     let resp: any = await httpClient.get(

--- a/integration/middlewares.test.ts
+++ b/integration/middlewares.test.ts
@@ -5,7 +5,7 @@ describe('Middlewares', () => {
 
   it('OK response should contain x-request-id header', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63/history?projectId=${projectId}`,
+      `${baseUrl}/v1/account/0x2aae531a81461f029cd55cb46703211c9227ba05/history?projectId=${projectId}`,
     )
     expect(resp.headers).toBeDefined();
     expect(resp.status).toBe(200);

--- a/integration/portfolio.test.ts
+++ b/integration/portfolio.test.ts
@@ -5,7 +5,7 @@ describe('Portfolio', () => {
 
   it('finds portfolio items', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63/portfolio?projectId=${projectId}`,
+      `${baseUrl}/v1/account/0x2aae531a81461f029cd55cb46703211c9227ba05/portfolio?projectId=${projectId}`,
     )
     expect(resp.status).toBe(200)
     const first = resp.data.data[0]


### PR DESCRIPTION
# Description

This PR changes the Ethereum address in integration tests to the special tests-purposed address.

## How Has This Been Tested?

Current tests were passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
