### PR TITLE
feat(provider): adding Morph native RPC endpoints

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -19,6 +19,8 @@ Chain name with associated `chainId` query param to use.
 | Polygon Zkevm                                            | eip155:1101          |
 | Unichain Sepolia <sup>[1](#footnote1)</sup>              | eip155:1301          |
 | Sei Network <sup>[1](#footnote1)</sup>                   | eip155:1329          |
+| Morph Holesky <sup>[1](#footnote1)</sup>                 | eip155:2810          |
+| Morph Mainnet <sup>[1](#footnote1)</sup>                 | eip155:2818          |
 | Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |
 | Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5003          |
 | Klaytn Mainnet                                           | eip155:8217          |

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -15,8 +15,8 @@ use {
 };
 pub use {
     arbitrum::*, aurora::*, base::*, berachain::*, binance::*, getblock::*, infura::*, lava::*,
-    mantle::*, near::*, pokt::*, publicnode::*, quicknode::*, server::*, unichain::*, zksync::*,
-    zora::*,
+    mantle::*, morph::*, near::*, pokt::*, publicnode::*, quicknode::*, server::*, unichain::*,
+    zksync::*, zora::*,
 };
 mod arbitrum;
 mod aurora;
@@ -27,6 +27,7 @@ mod getblock;
 mod infura;
 mod lava;
 mod mantle;
+mod morph;
 mod near;
 mod pokt;
 mod publicnode;

--- a/src/env/morph.rs
+++ b/src/env/morph.rs
@@ -1,0 +1,55 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct MorphConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for MorphConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for MorphConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Morph
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Morph Mainnet
+        (
+            "eip155:2818".into(),
+            (
+                "rpc-quicknode".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Morph Holesky
+        (
+            "eip155:2810".into(),
+            (
+                "rpc-quicknode-holesky".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ use {
     },
     env::{
         ArbitrumConfig, AuroraConfig, BaseConfig, BerachainConfig, BinanceConfig, GetBlockConfig,
-        InfuraConfig, LavaConfig, MantleConfig, NearConfig, PoktConfig, PublicnodeConfig,
-        QuicknodeConfig, UnichainConfig, ZKSyncConfig, ZoraConfig,
+        InfuraConfig, LavaConfig, MantleConfig, MorphConfig, NearConfig, PoktConfig,
+        PublicnodeConfig, QuicknodeConfig, UnichainConfig, ZKSyncConfig, ZoraConfig,
     },
     error::RpcResult,
     http::Request,
@@ -28,8 +28,8 @@ use {
     providers::{
         ArbitrumProvider, AuroraProvider, BaseProvider, BerachainProvider, BinanceProvider,
         GetBlockProvider, InfuraProvider, InfuraWsProvider, LavaProvider, MantleProvider,
-        NearProvider, PoktProvider, ProviderRepository, PublicnodeProvider, QuicknodeProvider,
-        UnichainProvider, ZKSyncProvider, ZoraProvider, ZoraWsProvider,
+        MorphProvider, NearProvider, PoktProvider, ProviderRepository, PublicnodeProvider,
+        QuicknodeProvider, UnichainProvider, ZKSyncProvider, ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -488,6 +488,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     providers.add_provider::<UnichainProvider, UnichainConfig>(UnichainConfig::default());
     providers
         .add_provider::<LavaProvider, LavaConfig>(LavaConfig::new(config.lava_api_key.clone()));
+    providers.add_provider::<MorphProvider, MorphConfig>(MorphConfig::default());
 
     if let Some(getblock_access_tokens) = &config.getblock_access_tokens {
         providers.add_provider::<GetBlockProvider, GetBlockConfig>(GetBlockConfig::new(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -59,6 +59,7 @@ mod infura;
 mod lava;
 mod mantle;
 pub mod mock_alto;
+mod morph;
 mod near;
 mod one_inch;
 mod pimlico;
@@ -84,6 +85,7 @@ pub use {
     infura::{InfuraProvider, InfuraWsProvider},
     lava::LavaProvider,
     mantle::MantleProvider,
+    morph::MorphProvider,
     near::NearProvider,
     one_inch::OneInchProvider,
     pimlico::PimlicoProvider,
@@ -511,6 +513,7 @@ pub enum ProviderKind {
     SolScan,
     Unichain,
     Lava,
+    Morph,
     Tenderly,
 }
 
@@ -541,6 +544,7 @@ impl Display for ProviderKind {
                 ProviderKind::SolScan => "SolScan",
                 ProviderKind::Unichain => "Unichain",
                 ProviderKind::Lava => "Lava",
+                ProviderKind::Morph => "Morph",
                 ProviderKind::Tenderly => "Tenderly",
             }
         )
@@ -572,6 +576,7 @@ impl ProviderKind {
             "SolScan" => Some(Self::SolScan),
             "Unichain" => Some(Self::Unichain),
             "Lava" => Some(Self::Lava),
+            "Morph" => Some(Self::Morph),
             "Tenderly" => Some(Self::Tenderly),
             _ => None,
         }

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -1,0 +1,98 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MorphConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct MorphProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for MorphProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Morph
+    }
+}
+
+#[async_trait]
+impl RateLimited for MorphProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for MorphProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let chain = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let uri = format!("https://{}.morphl2.io", chain);
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Morph: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<MorphConfig> for MorphProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &MorphConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        MorphProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -85,6 +85,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Berachain')     { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Unichain')      { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Lava')          { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Morph')         { gridPos: pos._4 },
 
   row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
@@ -103,6 +104,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'Berachain')   { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Unichain')    { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Lava')        { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Morph')       { gridPos: pos._4 },
 
   row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
@@ -121,6 +123,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Berachain')    { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Unichain')     { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Lava')         { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Morph')        { gridPos: pos._4 },
 
   row.new('RPC Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._3 },

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod getblock;
 pub(crate) mod infura;
 pub(crate) mod lava;
 pub(crate) mod mantle;
+pub(crate) mod morph;
 pub(crate) mod near;
 pub(crate) mod pokt;
 pub(crate) mod publicnode;

--- a/tests/functional/http/morph.rs
+++ b/tests/functional/http/morph.rs
@@ -1,0 +1,28 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn morph_provider(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Morph;
+    // Morph Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:2818",
+        "0xb02",
+    )
+    .await;
+
+    // Morph Holesky
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:2810",
+        "0xafa",
+    )
+    .await;
+}


### PR DESCRIPTION
# Description

This PR adds a Morph provider for native RPC endpoints for the following chains:

* Morph Mainnet `eip155:2818`,
* Morph Holesky `eip155:2810`.

## How Has This Been Tested?

A new integration test for the provider was added.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
