### PR TITLE
feat(CA): implementing cached gas estimation for the initial transaction

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -199,11 +199,11 @@ pub struct Erc20AssetChange {
     pub receiver: Address,
 }
 
-/// Get the ERC20 assets changes from the transaction simulation result
+/// Get the ERC20 assets changes and gas used from the transaction simulation result
 pub async fn get_assets_changes_from_simulation(
     simulation_provider: Arc<dyn SimulationProvider>,
     transaction: &Transaction,
-) -> Result<Vec<Erc20AssetChange>, RpcError> {
+) -> Result<(Vec<Erc20AssetChange>, u64), RpcError> {
     // Fill the state overrides for the source address for each of the supported
     // assets on the initial tx chain
     let state_overrides = {
@@ -235,6 +235,7 @@ pub async fn get_assets_changes_from_simulation(
             state_overrides,
         )
         .await?;
+    let gas_used = simulation_result.transaction.gas_used;
 
     if simulation_result
         .transaction
@@ -243,7 +244,7 @@ pub async fn get_assets_changes_from_simulation(
         .is_none()
     {
         debug!("The transaction does not change any assets");
-        return Ok(vec![]);
+        return Ok((vec![], gas_used));
     }
 
     let mut asset_changes = Vec::new();
@@ -266,5 +267,5 @@ pub async fn get_assets_changes_from_simulation(
         }
     }
 
-    Ok(asset_changes)
+    Ok((asset_changes, gas_used))
 }

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -43,6 +43,9 @@ use {
 // Using default with 6x increase
 const DEFAULT_GAS: i64 = 0x029a6b * 0x6;
 
+// Slippage for the gas estimation
+const ESTIMATED_GAS_SLIPPAGE: i8 = 3;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct QuoteRoute {
@@ -184,7 +187,8 @@ async fn handler_internal(
                 )
             }
         };
-    initial_transaction.gas = U64::from(gas_used);
+    // Estimated gas multiplied by the slippage
+    initial_transaction.gas = U64::from((gas_used * (100 + ESTIMATED_GAS_SLIPPAGE as u64)) / 100);
 
     // Check if the destination address is supported ERC20 asset contract
     // Attempt to destructure the result into symbol and decimals using a match expression

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -283,6 +283,7 @@ impl ProviderRepository {
             config.tenderly_api_key.clone(),
             config.tenderly_account_id.clone(),
             config.tenderly_project_id.clone(),
+            redis_pool.clone(),
         ));
 
         Self {
@@ -869,7 +870,7 @@ pub trait ChainOrchestrationProvider: Send + Sync + Debug {
 
 /// Provider for the transaction simulation
 #[async_trait]
-pub trait SimulationProvider: Send + Sync + Debug {
+pub trait SimulationProvider: Send + Sync {
     async fn simulate_transaction(
         &self,
         chain_id: String,
@@ -878,4 +879,21 @@ pub trait SimulationProvider: Send + Sync + Debug {
         input: Bytes,
         state_overrides: HashMap<Address, HashMap<B256, B256>>,
     ) -> Result<tenderly::SimulationResponse, RpcError>;
+
+    /// Get the cached gas estimation for ERC20 transfer
+    /// for the token contract and chain_id
+    async fn get_cached_erc20_gas_estimation(
+        &self,
+        chain_id: &str,
+        contract_address: Address,
+    ) -> Result<Option<u64>, RpcError>;
+
+    /// Save to the cahce the gas estimation
+    /// for ERC20 transfer for the token contract and chain_id
+    async fn set_cached_erc20_gas_estimation(
+        &self,
+        chain_id: &str,
+        contract_address: Address,
+        gas: u64,
+    ) -> Result<(), RpcError>;
 }


### PR DESCRIPTION
# Description

This PR implements the cached gas estimation for the initial transaction by using the following flow:

* If the transaction is an ERC20 transfer, check the cached gas used value for the ERC20 token contract and ChainID,
* If the cached value is found - update the initial transaction `gas` with the cached value,
* If the cached value was not found - simulate the initial transaction, save the resulting gas used value to the cache by using the token contract and ChainID, and update the initial transaction `gas` with the cached value.

The cache record TTL for the gas estimated value is 24 hours.

The slippage of 3% is added to the gas estimation to cover gas changes.

## How Has This Been Tested?

Manually the integration test was updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
