### PR TITLE
fix(Tenderly): making `decimals` optional in the simulation schema

### DIFF
--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -60,8 +60,7 @@ pub enum AssetChangeType {
 pub struct TokenInfo {
     pub standard: TokenStandard,
     pub contract_address: Address,
-    pub decimals: u8,
-    // TODO: Add more fields for the metadata
+    pub decimals: Option<u8>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]


### PR DESCRIPTION
# Description

This PR makes `decimals` optional according to the Tenderly simulation result schema. This will fix the deserialization error on some requests.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
