### PR TITLE
feat(o11y): adding Tenderly provider monitoring

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -7,6 +7,7 @@ use {
             SimulationProvider,
         },
         utils::crypto::get_erc20_contract_balance,
+        Metrics,
     },
     alloy::primitives::{address, Address, B256, U256},
     ethers::{types::H160 as EthersH160, utils::keccak256},
@@ -203,6 +204,7 @@ pub struct Erc20AssetChange {
 pub async fn get_assets_changes_from_simulation(
     simulation_provider: Arc<dyn SimulationProvider>,
     transaction: &Transaction,
+    metrics: Arc<Metrics>,
 ) -> Result<(Vec<Erc20AssetChange>, u64), RpcError> {
     // Fill the state overrides for the source address for each of the supported
     // assets on the initial tx chain
@@ -233,6 +235,7 @@ pub async fn get_assets_changes_from_simulation(
             transaction.to,
             transaction.data.clone(),
             state_overrides,
+            metrics,
         )
         .await?;
     let gas_used = simulation_result.transaction.gas_used;

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -131,6 +131,7 @@ async fn handler_internal(
                         let (_, simulated_gas_used) = get_assets_changes_from_simulation(
                             state.providers.simulation_provider.clone(),
                             &initial_transaction,
+                            state.metrics.clone(),
                         )
                         .await?;
                         state
@@ -156,6 +157,7 @@ async fn handler_internal(
                 let (simulation_assets_changes, gas_used) = get_assets_changes_from_simulation(
                     state.providers.simulation_provider.clone(),
                     &initial_transaction,
+                    state.metrics.clone(),
                 )
                 .await?;
                 let mut asset_transfer_value = U256::ZERO;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -878,6 +878,7 @@ pub trait SimulationProvider: Send + Sync {
         to: Address,
         input: Bytes,
         state_overrides: HashMap<Address, HashMap<B256, B256>>,
+        metrics: Arc<Metrics>,
     ) -> Result<tenderly::SimulationResponse, RpcError>;
 
     /// Get the cached gas estimation for ERC20 transfer

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -139,6 +139,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'OneInch')      { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Coinbase')     { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Bungee')       { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Tenderly')     { gridPos: pos._4 },
   
   row.new('Non-RPC providers Latency'),
     panels.non_rpc.endpoints_latency(ds, vars, 'Zerion')       { gridPos: pos._4 },
@@ -146,6 +147,7 @@ dashboard.new(
     panels.non_rpc.endpoints_latency(ds, vars, 'OneInch')      { gridPos: pos._4 },
     panels.non_rpc.endpoints_latency(ds, vars, 'Coinbase')     { gridPos: pos._4 },
     panels.non_rpc.endpoints_latency(ds, vars, 'Bungee')       { gridPos: pos._4 },
+    panels.non_rpc.endpoints_latency(ds, vars, 'Tenderly')     { gridPos: pos._4 },
 
   row.new('Non-RPC providers Cache'),
     panels.non_rpc.cache_latency(ds, vars)      { gridPos: pos._2 },


### PR DESCRIPTION
# Description

This PR adds response monitoring metrics and Grafana panels for the Tenderly simulation provider.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
