### PR TITLE
fix(test): fixing the CA integration tests on the initial tx schema change

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -43,7 +43,7 @@ describe('Chain abstraction orchestrator', () => {
         from: from_address_with_funds,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        data: data_encoded,
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -70,7 +70,7 @@ describe('Chain abstraction orchestrator', () => {
         from: empty_wallet_address,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        data: data_encoded,
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -96,7 +96,7 @@ describe('Chain abstraction orchestrator', () => {
         from: from_address_with_funds,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        data: data_encoded,
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -122,7 +122,7 @@ describe('Chain abstraction orchestrator', () => {
         from: from_address_with_funds,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        data: data_encoded,
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -143,7 +143,7 @@ describe('Chain abstraction orchestrator', () => {
     expect(approvalTransaction.chainId).toBe(chain_id_base)
     expect(approvalTransaction.nonce).not.toBe("0x00")
     expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
-    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data);
+    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
     if (decodedData.amount < BigInt(amount_to_topup_with_fees)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }


### PR DESCRIPTION
# Description

This PR fixes the integration test on the recent initial tx schema change in https://github.com/reown-com/blockchain-api/pull/872. This will fix the CI/CD integration tests for the CA.

## How Has This Been Tested?

Tested by running the updated tests on the production URL.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
