### PR TITLE
fix: revert back new initial tx types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?rev=0684124#0684124cf58f3da85bcb89587e4c9a47c41b4d7b"
+source = "git+https://github.com/reown-com/yttrium.git?rev=befa0cb#befa0cb4769684ec48a16303c773c8477da926cd"
 dependencies = [
  "alloy 0.7.3",
  "alloy-provider 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
-yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "0684124" }
+yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "befa0cb" }
 
 # Async
 async-trait = "0.1.82"

--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -43,12 +43,7 @@ describe('Chain abstraction orchestrator', () => {
         from: from_address_with_funds,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        gas: "0x00",
-        gasPrice: "0x00",
-        data: data_encoded,
-        nonce: "0x00",
-        maxFeePerGas: "0x00",
-        maxPriorityFeePerGas: "0x00",
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -75,12 +70,7 @@ describe('Chain abstraction orchestrator', () => {
         from: empty_wallet_address,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        gas: "0x00",
-        gasPrice: "0x00",
-        data: data_encoded,
-        nonce: "0x00",
-        maxFeePerGas: "0x00",
-        maxPriorityFeePerGas: "0x00",
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -106,12 +96,7 @@ describe('Chain abstraction orchestrator', () => {
         from: from_address_with_funds,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        gas: "0x00",
-        gasPrice: "0x00",
-        data: data_encoded,
-        nonce: "0x00",
-        maxFeePerGas: "0x00",
-        maxPriorityFeePerGas: "0x00",
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -137,12 +122,7 @@ describe('Chain abstraction orchestrator', () => {
         from: from_address_with_funds,
         to: usdc_contract_optimism,
         value: "0x00", // Zero native tokens
-        gas: "0x00",
-        gasPrice: "0x00",
-        data: data_encoded,
-        nonce: "0x00",
-        maxFeePerGas: "0x00",
-        maxPriorityFeePerGas: "0x00",
+        input: data_encoded,
         chainId: chain_id_optimism,
       }
     }
@@ -162,8 +142,8 @@ describe('Chain abstraction orchestrator', () => {
     const approvalTransaction = data.transactions[0]
     expect(approvalTransaction.chainId).toBe(chain_id_base)
     expect(approvalTransaction.nonce).not.toBe("0x00")
-    expect(() => BigInt(approvalTransaction.gas)).not.toThrow();
-    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.data);
+    expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
+    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
     if (decodedData.amount < BigInt(amount_to_topup_with_fees)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }
@@ -172,14 +152,13 @@ describe('Chain abstraction orchestrator', () => {
     const bridgingTransaction = data.transactions[1]
     expect(bridgingTransaction.chainId).toBe(chain_id_base)
     expect(bridgingTransaction.nonce).not.toBe("0x00")
-    expect(() => BigInt(approvalTransaction.gas)).not.toThrow();
+    expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
 
     // Check for the initialTransaction
     const initialTransaction = data.initialTransaction;
     expect(initialTransaction.from).toBe(from_address_with_funds.toLowerCase());
     expect(initialTransaction.to).toBe(usdc_contract_optimism.toLowerCase());
-    expect(initialTransaction.gas).not.toBe("0x00");
-
+    expect(initialTransaction.gasLimit).not.toBe("0x00");
 
     // Check the metadata fundingFrom
     const fundingFrom = data.metadata.fundingFrom[0]

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -233,7 +233,7 @@ pub async fn get_assets_changes_from_simulation(
             transaction.chain_id.clone(),
             transaction.from,
             transaction.to,
-            transaction.data.clone(),
+            transaction.input.clone(),
             state_overrides,
             metrics,
         )

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -10,8 +10,7 @@ use {
         state::AppState,
         storage::irn::OperationType,
         utils::crypto::{
-            convert_alloy_address_to_h160, decode_erc20_transfer_data, get_erc20_balance,
-            get_gas_price, get_nonce,
+            convert_alloy_address_to_h160, decode_erc20_transfer_data, get_erc20_balance, get_nonce,
         },
     },
     alloy::primitives::{Address, U256, U64},
@@ -72,10 +71,29 @@ async fn handler_internal(
         .validate_project_access_and_quota(query_params.project_id.as_ref())
         .await?;
 
-    let mut initial_transaction = request_payload.transaction.clone();
+    let mut initial_transaction = Transaction {
+        from: request_payload.transaction.from,
+        to: request_payload.transaction.to,
+        value: request_payload.transaction.value,
+        gas_limit: U64::from(DEFAULT_GAS),
+        input: request_payload.transaction.input.clone(),
+        nonce: U64::ZERO,
+        chain_id: request_payload.transaction.chain_id.clone(),
+    };
+
     let from_address = initial_transaction.from;
     let to_address = initial_transaction.to;
     let transfer_value = initial_transaction.value;
+
+    // Calculate the initial transaction nonce
+    let intial_transaction_nonce = get_nonce(
+        &initial_transaction.chain_id.clone(),
+        from_address,
+        query_params.project_id.as_ref(),
+        MessageSource::ChainAgnosticCheck,
+    )
+    .await?;
+    initial_transaction.nonce = intial_transaction_nonce;
 
     let no_bridging_needed_response: Json<RouteResponse> = Json(RouteResponse::Success(
         RouteResponseSuccess::NotRequired(RouteResponseNotRequired {
@@ -92,7 +110,7 @@ async fn handler_internal(
         );
         return Ok(no_bridging_needed_response.into_response());
     }
-    let transaction_data = initial_transaction.data.clone();
+    let transaction_data = initial_transaction.input.clone();
 
     // Decode the ERC20 transfer function data or use the simulation
     // to get the transfer asset and amount
@@ -190,7 +208,8 @@ async fn handler_internal(
             }
         };
     // Estimated gas multiplied by the slippage
-    initial_transaction.gas = U64::from((gas_used * (100 + ESTIMATED_GAS_SLIPPAGE as u64)) / 100);
+    initial_transaction.gas_limit =
+        U64::from((gas_used * (100 + ESTIMATED_GAS_SLIPPAGE as u64)) / 100);
 
     // Check if the destination address is supported ERC20 asset contract
     // Attempt to destructure the result into symbol and decimals using a match expression
@@ -329,14 +348,6 @@ async fn handler_internal(
     )
     .await?;
 
-    // Getting the current gas price
-    let gas_price = get_gas_price(
-        &bridge_chain_id.clone(),
-        query_params.project_id.as_ref(),
-        MessageSource::ChainAgnosticCheck,
-    )
-    .await?;
-
     // TODO: Implement gas estimation using `eth_estimateGas` for each transaction
     let mut routes = Vec::new();
 
@@ -373,15 +384,12 @@ async fn handler_internal(
                 from: approval_tx.from,
                 to: approval_tx.to,
                 value: U256::ZERO,
-                gas_price: U256::from(gas_price),
-                gas: U64::from(DEFAULT_GAS),
-                data: approval_tx.data,
-                nonce: U64::from(current_nonce),
-                max_fee_per_gas: request_payload.transaction.max_fee_per_gas,
-                max_priority_fee_per_gas: request_payload.transaction.max_priority_fee_per_gas,
+                gas_limit: U64::from(DEFAULT_GAS),
+                input: approval_tx.data,
+                nonce: current_nonce,
                 chain_id: format!("eip155:{}", bridge_tx.chain_id),
             });
-            current_nonce += 1;
+            current_nonce += U64::from(1);
         }
     }
 
@@ -390,12 +398,9 @@ async fn handler_internal(
         from: from_address,
         to: bridge_tx.tx_target,
         value: bridge_tx.value,
-        gas_price: U256::from(gas_price),
-        gas: U64::from(DEFAULT_GAS),
-        data: bridge_tx.tx_data,
-        nonce: U64::from(current_nonce),
-        max_fee_per_gas: request_payload.transaction.max_fee_per_gas,
-        max_priority_fee_per_gas: request_payload.transaction.max_priority_fee_per_gas,
+        gas_limit: U64::from(DEFAULT_GAS),
+        input: bridge_tx.tx_data,
+        nonce: current_nonce,
         chain_id: format!("eip155:{}", bridge_tx.chain_id),
     });
 

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -2,7 +2,7 @@ use {
     crate::{analytics::MessageSource, error::RpcError},
     alloy::{
         network::Ethereum,
-        primitives::{Address, U256 as AlloyU256},
+        primitives::{Address, U256 as AlloyU256, U64 as AlloyU64},
         providers::{Provider as AlloyProvider, ReqwestProvider},
         rpc::json_rpc::Id,
         sol,
@@ -514,14 +514,14 @@ pub async fn get_nonce(
     wallet: Address,
     rpc_project_id: &str,
     source: MessageSource,
-) -> Result<u64, CryptoUitlsError> {
+) -> Result<AlloyU64, CryptoUitlsError> {
     let provider =
         ReqwestProvider::<Ethereum>::new_http(get_rpc_url(chain_id, rpc_project_id, source)?);
     let nonce = provider
         .get_transaction_count(wallet)
         .await
         .map_err(|e| CryptoUitlsError::ProviderError(format!("{}", e)))?;
-    Ok(nonce)
+    Ok(AlloyU64::from(nonce))
 }
 
 /// Call entry point v07 getUserOpHash contract and get the userOperation hash


### PR DESCRIPTION
# Description

This PR reverts back to the updated initial transaction types and API changes.

## How Has This Been Tested?

Integration tests were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
