### PR TITLE
fix(CA): increasing cached gas slippage to 50 percent

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -22,7 +22,7 @@ pub mod route;
 pub mod status;
 
 /// How much to multiply the amount by when bridging to cover bridging differences
-pub const BRIDGING_AMOUNT_SLIPPAGE: i8 = 2; // 2%
+pub const BRIDGING_AMOUNT_SLIPPAGE: i8 = 50; // 50%
 
 /// Bridging timeout in seconds
 pub const BRIDGING_TIMEOUT: u64 = 1800; // 30 minutes


### PR DESCRIPTION
# Description

This PR increases the cached gas estimation slippage from 2% to 50% to cover possibly daily spikes.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
