### PR TITLE
feat(CA): using the `pending` block for the nonce

### DIFF
--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -519,6 +519,7 @@ pub async fn get_nonce(
         ReqwestProvider::<Ethereum>::new_http(get_rpc_url(chain_id, rpc_project_id, source)?);
     let nonce = provider
         .get_transaction_count(wallet)
+        .pending()
         .await
         .map_err(|e| CryptoUitlsError::ProviderError(format!("{}", e)))?;
     Ok(AlloyU64::from(nonce))


### PR DESCRIPTION
# Description

This PR changes the block to `pending` instead of the `latest` for the nonce calculation.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
