### PR TITLE
feat(CA): adding logging for the insufficient balance response

### DIFF
--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -293,6 +293,10 @@ async fn handler_internal(
         / U256::from(100))
         + required_topup_amount;
     if current_bridging_asset_balance < required_topup_amount {
+        error!(
+            "The current bridging asset balance on {} is {} less than the required topup amount:{}. The bridging fee is:{}",
+            from_address, current_bridging_asset_balance, required_topup_amount, bridging_fee
+        );
         return Ok(Json(RouteResponse::Error(RouteResponseError {
             error: BridgingError::InsufficientFunds,
         }))


### PR DESCRIPTION
# Description

This PR adds logging for the `Insufficient balance` chain abstraction route response.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
