### PR TITLE
feat(analytics): adding identity `sender` field instead of the `same_sender`

### DIFF
--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -28,8 +28,7 @@ pub struct IdentityLookupInfo {
     pub continent: Option<Arc<str>>,
 
     pub client_id: Option<String>,
-    /// Whether the sender of the request is the same as the address being looked up
-    pub same_sender: Option<bool>,
+    pub sender: Option<String>,
 }
 
 impl IdentityLookupInfo {
@@ -46,7 +45,7 @@ impl IdentityLookupInfo {
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
         client_id: Option<String>,
-        same_sender: Option<bool>,
+        sender: Option<String>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -68,7 +67,7 @@ impl IdentityLookupInfo {
             continent,
 
             client_id,
-            same_sender,
+            sender,
         }
     }
 }

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -124,11 +124,6 @@ async fn handler_internal(
             .map(|geo| (geo.country, geo.continent, geo.region))
             .unwrap_or((None, None, None));
 
-        let same_sender = query
-            .sender
-            .as_ref()
-            .map(|sender| sender == &address.to_string());
-
         state.analytics.identity_lookup(IdentityLookupInfo::new(
             &query.0,
             address,
@@ -141,7 +136,7 @@ async fn handler_internal(
             country,
             continent,
             query.client_id.clone(),
-            same_sender,
+            query.sender.clone(),
         ));
     }
 


### PR DESCRIPTION
# Description

This PR removes the identity analytics `same_sender` field and adds the `sender` address optional field.

The [full context](https://reown-inc.slack.com/archives/C03RVH94K5K/p1734965652290149?thread_ts=1723117961.333029&cid=C03RVH94K5K) of this change.


## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
