### PR TITLE
feat(CA): adding USDT asset to the chain abstraction

### DIFF
--- a/src/handlers/chain_agnostic/assets.rs
+++ b/src/handlers/chain_agnostic/assets.rs
@@ -1,0 +1,64 @@
+use {
+    alloy::primitives::{address, Address},
+    phf::phf_map,
+};
+
+pub struct AssetMetadata {
+    pub decimals: u8,
+}
+
+/// Asset simulation parameters to override the asset's balance state
+pub struct SimulationParams {
+    /// Asset contract balance storage slot number
+    pub balance_storage_slot: u64,
+    /// Balance override for the asset
+    pub balance: u128,
+}
+
+pub struct AssetEntry {
+    pub metadata: AssetMetadata,
+    pub simulation: SimulationParams,
+    /// Asset contracts per CAIP-2 chain ID
+    pub contracts: &'static phf::Map<&'static str, Address>,
+}
+
+static USDC_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
+    // Optimism
+    "eip155:10" => address!("0b2c639c533813f4aa9d7837caf62653d097ff85"),
+    // Base
+    "eip155:8453" => address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
+    // Arbitrum
+    "eip155:42161" => address!("af88d065e77c8cC2239327C5EDb3A432268e5831"),
+};
+
+static USDT_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
+    // Optimism
+    "eip155:10" => address!("94b008aA00579c1307B0EF2c499aD98a8ce58e58"),
+    // Base
+    "eip155:8453" => address!("fde4C96c8593536E31F229EA8f37b2ADa2699bb2"),
+    // Arbitrum
+    "eip155:42161" => address!("Fd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"),
+};
+
+pub static BRIDGING_ASSETS: phf::Map<&'static str, AssetEntry> = phf_map! {
+    "USDC" => AssetEntry {
+        metadata: AssetMetadata {
+            decimals: 6,
+        },
+        simulation: SimulationParams {
+            balance_storage_slot: 9,
+            balance: 99000000000,
+        },
+        contracts: &USDC_CONTRACTS,
+    },
+    "USDT" => AssetEntry {
+        metadata: AssetMetadata {
+            decimals: 6,
+        },
+        simulation: SimulationParams {
+            balance_storage_slot: 0,
+            balance: 99000000000,
+        },
+        contracts: &USDT_CONTRACTS,
+    },
+};

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -9,15 +9,16 @@ use {
         utils::crypto::get_erc20_contract_balance,
         Metrics,
     },
-    alloy::primitives::{address, Address, B256, U256},
+    alloy::primitives::{Address, B256, U256},
+    assets::{SimulationParams, BRIDGING_ASSETS},
     ethers::{types::H160 as EthersH160, utils::keccak256},
-    phf::phf_map,
     serde::{Deserialize, Serialize},
     std::{collections::HashMap, str::FromStr, sync::Arc},
     tracing::debug,
     yttrium::chain_abstraction::api::Transaction,
 };
 
+pub mod assets;
 pub mod route;
 pub mod status;
 
@@ -26,19 +27,6 @@ pub const BRIDGING_AMOUNT_SLIPPAGE: i8 = 50; // 50%
 
 /// Bridging timeout in seconds
 pub const BRIDGING_TIMEOUT: u64 = 1800; // 30 minutes
-
-/// Available assets for Bridging
-pub static BRIDGING_AVAILABLE_ASSETS: phf::Map<&'static str, phf::Map<&'static str, Address>> = phf_map! {
-  "USDC" => phf_map! {
-      // Optimism
-      "eip155:10" => address!("0b2c639c533813f4aa9d7837caf62653d097ff85"),
-      // Base
-      "eip155:8453" => address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
-      // Arbitrum
-      "eip155:42161" => address!("af88d065e77c8cC2239327C5EDb3A432268e5831"),
-  },
-};
-pub const USDC_DECIMALS: u8 = 6;
 
 /// The status polling interval in ms for the client
 pub const STATUS_POLLING_INTERVAL: u64 = 3000; // 3 seconds
@@ -66,25 +54,34 @@ pub enum BridgingStatus {
     Error,
 }
 
-/// Return available assets contracts addresses for the given chain_id
-pub fn get_bridging_assets_contracts_for_chain(chain_id: &str) -> Vec<String> {
-    BRIDGING_AVAILABLE_ASSETS
+/// Return available assets names and contract addresses for the given chain_id
+pub fn get_bridging_assets_contracts_for_chain(chain_id: &str) -> Vec<(String, Address)> {
+    BRIDGING_ASSETS
         .entries()
-        .filter_map(|(_token_symbol, chain_map)| {
-            chain_map
+        .filter_map(|(token_symbol, asset_entry)| {
+            asset_entry
+                .contracts
                 .entries()
                 .find(|(chain, _)| **chain == chain_id)
-                .map(|(_, contract_address)| contract_address.to_string())
+                .map(|(_, contract_address)| (token_symbol.to_string(), *contract_address))
         })
         .collect()
 }
 
+/// Returns simulation params for the bridging asset
+pub fn get_simulation_params_for_asset(asset_name: &str) -> Option<&SimulationParams> {
+    BRIDGING_ASSETS
+        .entries()
+        .find(|(name, _)| **name == asset_name)
+        .map(|(_, asset_entry)| &asset_entry.simulation)
+}
+
 /// Check is the address is supported bridging asset and return the token symbol and decimals
 pub fn find_supported_bridging_asset(chain_id: &str, contract: Address) -> Option<(String, u8)> {
-    for (symbol, chain_map) in BRIDGING_AVAILABLE_ASSETS.entries() {
-        for (chain, contract_address) in chain_map.entries() {
+    for (symbol, asset_entry) in BRIDGING_ASSETS.entries() {
+        for (chain, contract_address) in asset_entry.contracts.entries() {
             if *chain == chain_id && contract == *contract_address {
-                return Some((symbol.to_string(), USDC_DECIMALS));
+                return Some((symbol.to_string(), asset_entry.metadata.decimals));
             }
         }
     }
@@ -133,20 +130,24 @@ pub async fn check_bridging_for_erc20_transfer(
     exclude_contract_address: Address,
 ) -> Result<Option<BridgingAsset>, RpcError> {
     // Check ERC20 tokens balance for each of supported assets
-    let mut contracts_per_chain: HashMap<(String, String), Vec<String>> = HashMap::new();
-    for (token_symbol, chain_map) in BRIDGING_AVAILABLE_ASSETS.entries() {
-        for (chain_id, contract_address) in chain_map.entries() {
+    let mut contracts_per_chain: HashMap<(String, String, u8), Vec<String>> = HashMap::new();
+    for (token_symbol, asset_entry) in BRIDGING_ASSETS.entries() {
+        for (chain_id, contract_address) in asset_entry.contracts.entries() {
             if *chain_id == exclude_chain_id && *contract_address == exclude_contract_address {
                 continue;
             }
             contracts_per_chain
-                .entry((token_symbol.to_string(), (*chain_id).to_string()))
+                .entry((
+                    token_symbol.to_string(),
+                    (*chain_id).to_string(),
+                    asset_entry.metadata.decimals,
+                ))
                 .or_default()
                 .push((*contract_address).to_string());
         }
     }
     // Making the check for each chain_id
-    for ((token_symbol, chain_id), contracts) in contracts_per_chain {
+    for ((token_symbol, chain_id, decimals), contracts) in contracts_per_chain {
         let erc20_balances = check_erc20_balances(
             rpc_project_id.clone(),
             sender,
@@ -164,8 +165,7 @@ pub async fn check_bridging_for_erc20_transfer(
                     token_symbol,
                     contract_address,
                     current_balance,
-                    // We are supporting only USDC for now which have a fixed decimals
-                    decimals: USDC_DECIMALS,
+                    decimals,
                 }));
             }
         }
@@ -207,23 +207,24 @@ pub async fn get_assets_changes_from_simulation(
     metrics: Arc<Metrics>,
 ) -> Result<(Vec<Erc20AssetChange>, u64), RpcError> {
     // Fill the state overrides for the source address for each of the supported
-    // assets on the initial tx chain
+    // assets on the initial tx chain for the balance slot
     let state_overrides = {
         let mut state_overrides = HashMap::new();
         let assets_contracts =
             get_bridging_assets_contracts_for_chain(&transaction.chain_id.clone());
         let mut account_state = HashMap::new();
-        account_state.insert(
-            // Since we are using only USDC for the bridging,
-            // we can hardcode the storage slot for the contract which is 9
-            compute_simulation_storage_slot(transaction.from, 9),
-            compute_simulation_balance(99000000000),
-        );
-        for contract in assets_contracts {
-            state_overrides.insert(
-                Address::from_str(&contract).unwrap_or_default(),
-                account_state.clone(),
+        for (asset_name, asset_contract) in assets_contracts {
+            let Some(simulation_params) = get_simulation_params_for_asset(&asset_name) else {
+                continue;
+            };
+            account_state.insert(
+                compute_simulation_storage_slot(
+                    transaction.from,
+                    simulation_params.balance_storage_slot,
+                ),
+                compute_simulation_balance(simulation_params.balance),
             );
+            state_overrides.insert(asset_contract, account_state.clone());
         }
         state_overrides
     };


### PR DESCRIPTION
# Description

This PR adds USDT asset support for the chain abstraction. The asset is supported by the following chains: Optimism, Base, and Arbitrum. 
To support different assets the default assets list schema was changed to support different balance storage slots for different assets contracts.

## How Has This Been Tested?

A new integration test for the USDT CA was added along with the USDC CA asset.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
