### PR TITLE
fix(providers): changing Klaytn to Kaia endpoint

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -23,7 +23,7 @@ Chain name with associated `chainId` query param to use.
 | Morph Mainnet <sup>[1](#footnote1)</sup>                 | eip155:2818          |
 | Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |
 | Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5003          |
-| Klaytn Mainnet                                           | eip155:8217          |
+| Kaia Mainnet                                             | eip155:8217          |
 | Base                                                     | eip155:8453          |
 | Ethereum Holesky                                         | eip155:17000         |
 | Arbitrum                                                 | eip155:42161         |

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -166,11 +166,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Klaytn
+        // Kaia Mainnet
         (
             "eip155:8217".into(),
             (
-                "klaytn-mainnet".into(),
+                "kaia-mainnet".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
@@ -199,7 +199,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:534351".into(),
             (
-                "scroll-sepolia-testnet".into(),
+                "scroll-testnet".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),


### PR DESCRIPTION
# Description

This PR changed the `Klaytn` chain `eip155:8217` endpoint and name to `Kaia` since the chain name was renamed according to the [official website](https://www.kaia.io/).

## How Has This Been Tested?

* Current integration tests for providers.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
