### PR TITLE
feat(bundler): extending supported bundler operations

### DIFF
--- a/src/providers/mock_alto.rs
+++ b/src/providers/mock_alto.rs
@@ -56,7 +56,9 @@ impl BundlerOpsProvider for MockAltoProvider {
             | SupportedBundlerOps::EthGetUserOperationReceipt
             | SupportedBundlerOps::EthEstimateUserOperationGas
             | SupportedBundlerOps::PimlicoGetUserOperationGasPrice => self.bundler_url.clone(),
-            SupportedBundlerOps::PmSponsorUserOperation => self.paymaster_url.clone(),
+            SupportedBundlerOps::PmSponsorUserOperation
+            | SupportedBundlerOps::PmGetPaymasterData
+            | SupportedBundlerOps::PmGetPaymasterStubData => self.paymaster_url.clone(),
         };
         let response = self
             .http_client
@@ -84,6 +86,8 @@ impl BundlerOpsProvider for MockAltoProvider {
                 "eth_estimateUserOperationGas".into()
             }
             SupportedBundlerOps::PmSponsorUserOperation => "pm_sponsorUserOperation".into(),
+            SupportedBundlerOps::PmGetPaymasterData => "pm_getPaymasterData".into(),
+            SupportedBundlerOps::PmGetPaymasterStubData => "pm_getPaymasterStubData".into(),
             SupportedBundlerOps::PimlicoGetUserOperationGasPrice => {
                 "pimlico_getUserOperationGasPrice".into()
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -806,6 +806,10 @@ pub enum SupportedBundlerOps {
     /// Paymaster sponsor UserOp
     #[serde(rename = "pm_sponsorUserOperation")]
     PmSponsorUserOperation,
+    #[serde(rename = "pm_getPaymasterData")]
+    PmGetPaymasterData,
+    #[serde(rename = "pm_getPaymasterStubData")]
+    PmGetPaymasterStubData,
     #[serde(rename = "pimlico_getUserOperationGasPrice")]
     PimlicoGetUserOperationGasPrice,
 }

--- a/src/providers/pimlico.rs
+++ b/src/providers/pimlico.rs
@@ -74,6 +74,8 @@ impl BundlerOpsProvider for PimlicoProvider {
                 "eth_estimateUserOperationGas".into()
             }
             SupportedBundlerOps::PmSponsorUserOperation => "pm_sponsorUserOperation".into(),
+            SupportedBundlerOps::PmGetPaymasterData => "pm_getPaymasterData".into(),
+            SupportedBundlerOps::PmGetPaymasterStubData => "pm_getPaymasterStubData".into(),
             SupportedBundlerOps::PimlicoGetUserOperationGasPrice => {
                 "pimlico_getUserOperationGasPrice".into()
             }


### PR DESCRIPTION
# Description

This PR extends the bundler operations endpoint with the new methods:
* `pm_getPaymasterData`,
* `pm_getPaymasterStubData`.

As Pimlico is compliant with ERC7677 they support and recommend the above paymaster-related bundler methods.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
