### PR TITLE
feat(providers): extending Dune provider to serve Solana balances

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -55,6 +55,7 @@ describe('Account balance', () => {
     expect(resp.data.balances.length).toBeGreaterThan(1)
 
     for (const item of resp.data.balances) {
+      expect(item.chainId).toEqual(chainId)
       expect(typeof item.name).toBe('string')
       expect(typeof item.symbol).toBe('string')
       expect(typeof item.quantity).toBe('object')

--- a/src/env/dune.rs
+++ b/src/env/dune.rs
@@ -33,8 +33,14 @@ impl BalanceProviderConfig for DuneConfig {
 }
 
 fn default_supported_namespaces() -> HashMap<CaipNamespaces, Weight> {
-    HashMap::from([(
-        CaipNamespaces::Eip155,
-        Weight::new(Priority::Normal).unwrap(),
-    )])
+    HashMap::from([
+        (
+            CaipNamespaces::Eip155,
+            Weight::new(Priority::Normal).unwrap(),
+        ),
+        (
+            CaipNamespaces::Solana,
+            Weight::new(Priority::Normal).unwrap(),
+        ),
+    ])
 }

--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -21,28 +21,32 @@ use {
     url::Url,
 };
 
+const DUNE_API_BASE_URL: &str = "https://api.dune.com/api";
+
 /// Native token icons, since Dune doesn't provide them yet
 /// TODO: Hardcoding icon urls temporarily until Dune provides them
 pub static NATIVE_TOKEN_ICONS: phf::Map<&'static str, &'static str> = phf_map! {
       // Ethereum
-      "ETH" => "https://assets.coingecko.com/coins/images/279/small/ethereum.png",
+      "ETH" => "https://cdn.jsdelivr.net/gh/trustwallet/assets@master/blockchains/ethereum/info/logo.png",
       // Polygon
-      "POL" => "https://assets.coingecko.com/coins/images/32440/standard/polygon.png",
+      "POL" => "https://cdn.jsdelivr.net/gh/trustwallet/assets@master/blockchains/polygon/info/logo.png",
       // xDAI
-      "XDAI" => "https://assets.coingecko.com/coins/images/662/standard/logo_square_simple_300px.png",
+      "XDAI" => "https://cdn.jsdelivr.net/gh/trustwallet/assets@master/blockchains/xdai/info/logo.png",
       // BNB
-      "BNB" => "https://assets.coingecko.com/coins/images/825/small/binance-coin-logo.png",
+      "BNB" => "https://cdn.jsdelivr.net/gh/trustwallet/assets@master/blockchains/binance/info/logo.png",
+      // Solana
+      "SOL" => "https://cdn.jsdelivr.net/gh/trustwallet/assets@master/blockchains/solana/info/logo.png",
 };
 
 #[derive(Debug, Serialize, Deserialize)]
-struct DuneResponseBody {
+struct DuneBalanceResponseBody {
     balances: Vec<Balance>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Balance {
     chain: String,
-    chain_id: u64,
+    chain_id: Option<u64>,
     address: String,
     amount: String,
     decimals: Option<u8>,
@@ -72,18 +76,14 @@ impl DuneProvider {
             .send()
             .await
     }
-}
 
-#[async_trait]
-impl BalanceProvider for DuneProvider {
-    #[tracing::instrument(skip(self, params), fields(provider = "Dune"), level = "debug")]
-    async fn get_balance(
+    async fn get_evm_balance(
         &self,
         address: String,
         params: BalanceQueryParams,
         metrics: Arc<Metrics>,
-    ) -> RpcResult<BalanceResponseBody> {
-        let base = format!("https://api.dune.com/api/echo/v1/balances/evm/{}", &address);
+    ) -> RpcResult<DuneBalanceResponseBody> {
+        let base = format!("{}/echo/v1/balances/evm/{}", DUNE_API_BASE_URL, &address);
         let mut url = Url::parse(&base).map_err(|_| RpcError::BalanceParseURLError)?;
         url.query_pairs_mut()
             .append_pair("exclude_spam_tokens", "true");
@@ -101,19 +101,81 @@ impl BalanceProvider for DuneProvider {
             response.status().into(),
             latency_start,
             None,
-            Some("balances".to_string()),
+            Some("evm_balances".to_string()),
         );
 
         if !response.status().is_success() {
             error!(
-                "Error on Dune balance response. Status is not OK: {:?}",
+                "Error on Dune EVM balance response. Status is not OK: {:?}",
                 response.status(),
             );
             return Err(RpcError::BalanceProviderError);
         }
-        let body = response.json::<DuneResponseBody>().await?;
+        Ok(response.json::<DuneBalanceResponseBody>().await?)
+    }
 
-        let balances_vec = body
+    async fn get_solana_balance(
+        &self,
+        address: String,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<DuneBalanceResponseBody> {
+        let base = format!("{}/echo/beta/balances/svm/{}", DUNE_API_BASE_URL, &address);
+        let mut url = Url::parse(&base).map_err(|_| RpcError::BalanceParseURLError)?;
+        url.query_pairs_mut()
+            .append_pair("exclude_spam_tokens", "true");
+        url.query_pairs_mut().append_pair("metadata", "logo");
+
+        let latency_start = SystemTime::now();
+        let response = self.send_request(url.clone()).await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("solana_balances".to_string()),
+        );
+
+        if !response.status().is_success() {
+            error!(
+                "Error on Dune Solana balance response. Status is not OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::BalanceProviderError);
+        }
+        Ok(response.json::<DuneBalanceResponseBody>().await?)
+    }
+}
+
+#[async_trait]
+impl BalanceProvider for DuneProvider {
+    #[tracing::instrument(skip(self, params), fields(provider = "Dune"), level = "debug")]
+    async fn get_balance(
+        &self,
+        address: String,
+        params: BalanceQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<BalanceResponseBody> {
+        let namespace = params
+            .chain_id
+            .as_ref()
+            .map(|chain_id| {
+                crypto::disassemble_caip2(chain_id)
+                    .map(|(namespace, _)| namespace)
+                    .unwrap_or(crypto::CaipNamespaces::Eip155)
+            })
+            .unwrap_or(crypto::CaipNamespaces::Eip155);
+
+        let balance_response = match namespace {
+            crypto::CaipNamespaces::Eip155 => {
+                self.get_evm_balance(address, params, metrics.clone())
+                    .await?
+            }
+            crypto::CaipNamespaces::Solana => {
+                self.get_solana_balance(address, metrics.clone()).await?
+            }
+        };
+
+        let balances_vec = balance_response
             .balances
             .into_iter()
             .filter_map(|mut f| {
@@ -122,7 +184,17 @@ impl BalanceProvider for DuneProvider {
                 let symbol = f.symbol.take()?;
                 let price_usd = f.price_usd.take()?;
                 let decimals = f.decimals.take()?;
-                let caip2_chain_id = format!("eip155:{}", f.chain_id.clone());
+                let caip2_chain_id = match f.chain_id {
+                    Some(cid) => format!("{}:{}", namespace, cid),
+                    None => match namespace {
+                        // Using defaul Mainnet chain ids if not provided since
+                        // Dune doesn't provide balances for testnets
+                        crypto::CaipNamespaces::Eip155 => format!("{}:{}", namespace, "1"),
+                        crypto::CaipNamespaces::Solana => {
+                            format!("{}:{}", namespace, "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
+                        }
+                    },
+                };
                 Some(BalanceItem {
                     name: {
                         if f.address == "native" {
@@ -132,13 +204,20 @@ impl BalanceProvider for DuneProvider {
                         }
                     },
                     symbol: symbol.clone(),
-                    chain_id: Some(caip2_chain_id),
+                    chain_id: Some(caip2_chain_id.clone()),
                     address: {
                         // Return None if the address is native for the native token
                         if f.address == "native" {
-                            None
+                            // UI expecting `None`` for the Eip155 and Solana's native
+                            // token address for Solana
+                            match namespace {
+                                crypto::CaipNamespaces::Eip155 => None,
+                                crypto::CaipNamespaces::Solana => {
+                                    Some(crypto::SOLANA_NATIVE_TOKEN_ADDRESS.to_string())
+                                }
+                            }
                         } else {
-                            Some(format!("eip155:{}:{}", f.chain_id, f.address.clone()))
+                            Some(format!("{}:{}", caip2_chain_id, f.address.clone()))
                         }
                     },
                     value: f.value_usd,


### PR DESCRIPTION
# Description

This PR extends the Dune provider to serve Solana balance requests along with the Eip155.

## How Has This Been Tested?

Current Solana balance integration tests were passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
