### PR TITLE
feat(CA): extending bridges list for bridging routes

### DIFF
--- a/src/providers/bungee.rs
+++ b/src/providers/bungee.rs
@@ -153,7 +153,7 @@ impl ChainOrchestrationProvider for BungeeProvider {
         );
         // Use only Across bridge for latency reason
         url.query_pairs_mut()
-            .append_pair("includeBridges", "across");
+            .append_pair("includeBridges", "across,hop,stargate");
 
         let latency_start = SystemTime::now();
         let response = self.send_get_request(url).await?;


### PR DESCRIPTION
# Description

This PR updates the bridges list for the CA to include `stargate` and `hop` to the list of bridges where to look for the routes.
Manual testing shows that Hop has liquidity for USDT bridging and Stargate for USDC.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
