### PR TITLE
feat(providers): adding Wemix RPC support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -17,6 +17,8 @@ Chain name with associated `chainId` query param to use.
 | zkSync Era Sepolia Testnet <sup>[1](#footnote1)</sup>    | eip155:300           |
 | zkSync Era                                               | eip155:324           |
 | Polygon Zkevm                                            | eip155:1101          |
+| Wemix Mainnet <sup>[1](#footnote1)</sup>                 | eip155:1111          |
+| Wemix Testnet <sup>[1](#footnote1)</sup>                 | eip155:1112          |
 | Unichain Sepolia <sup>[1](#footnote1)</sup>              | eip155:1301          |
 | Sei Network <sup>[1](#footnote1)</sup>                   | eip155:1329          |
 | Morph Holesky <sup>[1](#footnote1)</sup>                 | eip155:2810          |

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -16,7 +16,7 @@ use {
 pub use {
     arbitrum::*, aurora::*, base::*, berachain::*, binance::*, dune::*, getblock::*, infura::*,
     lava::*, mantle::*, morph::*, near::*, pokt::*, publicnode::*, quicknode::*, server::*,
-    solscan::*, unichain::*, zerion::*, zksync::*, zora::*,
+    solscan::*, unichain::*, wemix::*, zerion::*, zksync::*, zora::*,
 };
 mod arbitrum;
 mod aurora;
@@ -36,6 +36,7 @@ mod quicknode;
 mod server;
 pub mod solscan;
 mod unichain;
+mod wemix;
 pub mod zerion;
 mod zksync;
 mod zora;

--- a/src/env/wemix.rs
+++ b/src/env/wemix.rs
@@ -1,0 +1,55 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct WemixConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for WemixConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for WemixConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Wemix
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Wemix Mainnet
+        (
+            "eip155:1111".into(),
+            (
+                "https://api.wemix.com/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Wemix Testnet
+        (
+            "eip155:1112".into(),
+            (
+                "https://api.test.wemix.com".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ use {
     env::{
         ArbitrumConfig, AuroraConfig, BaseConfig, BerachainConfig, BinanceConfig, DuneConfig,
         GetBlockConfig, InfuraConfig, LavaConfig, MantleConfig, MorphConfig, NearConfig,
-        PoktConfig, PublicnodeConfig, QuicknodeConfig, SolScanConfig, UnichainConfig, ZKSyncConfig,
-        ZerionConfig, ZoraConfig,
+        PoktConfig, PublicnodeConfig, QuicknodeConfig, SolScanConfig, UnichainConfig, WemixConfig,
+        ZKSyncConfig, ZerionConfig, ZoraConfig,
     },
     error::RpcResult,
     http::Request,
@@ -30,8 +30,8 @@ use {
         ArbitrumProvider, AuroraProvider, BaseProvider, BerachainProvider, BinanceProvider,
         DuneProvider, GetBlockProvider, InfuraProvider, InfuraWsProvider, LavaProvider,
         MantleProvider, MorphProvider, NearProvider, PoktProvider, ProviderRepository,
-        PublicnodeProvider, QuicknodeProvider, SolScanProvider, UnichainProvider, ZKSyncProvider,
-        ZerionProvider, ZoraProvider, ZoraWsProvider,
+        PublicnodeProvider, QuicknodeProvider, SolScanProvider, UnichainProvider, WemixProvider,
+        ZKSyncProvider, ZerionProvider, ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -511,6 +511,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     providers
         .add_rpc_provider::<LavaProvider, LavaConfig>(LavaConfig::new(config.lava_api_key.clone()));
     providers.add_rpc_provider::<MorphProvider, MorphConfig>(MorphConfig::default());
+    providers.add_rpc_provider::<WemixProvider, WemixConfig>(WemixConfig::default());
 
     if let Some(getblock_access_tokens) = &config.getblock_access_tokens {
         providers.add_rpc_provider::<GetBlockProvider, GetBlockConfig>(GetBlockConfig::new(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -72,6 +72,7 @@ mod solscan;
 pub mod tenderly;
 mod unichain;
 mod weights;
+mod wemix;
 pub mod zerion;
 mod zksync;
 mod zora;
@@ -98,6 +99,7 @@ pub use {
     solscan::SolScanProvider,
     tenderly::TenderlyProvider,
     unichain::UnichainProvider,
+    wemix::WemixProvider,
     zerion::ZerionProvider,
     zksync::ZKSyncProvider,
     zora::{ZoraProvider, ZoraWsProvider},
@@ -627,6 +629,7 @@ pub enum ProviderKind {
     Morph,
     Tenderly,
     Dune,
+    Wemix,
 }
 
 impl Display for ProviderKind {
@@ -641,6 +644,7 @@ impl Display for ProviderKind {
                 ProviderKind::Pokt => "Pokt",
                 ProviderKind::Binance => "Binance",
                 ProviderKind::Berachain => "Berachain",
+                ProviderKind::Wemix => "Wemix",
                 ProviderKind::Bungee => "Bungee",
                 ProviderKind::ZKSync => "zkSync",
                 ProviderKind::Publicnode => "Publicnode",
@@ -692,6 +696,7 @@ impl ProviderKind {
             "Morph" => Some(Self::Morph),
             "Tenderly" => Some(Self::Tenderly),
             "Dune" => Some(Self::Dune),
+            "Wemix" => Some(Self::Wemix),
             _ => None,
         }
     }

--- a/src/providers/wemix.rs
+++ b/src/providers/wemix.rs
@@ -1,0 +1,96 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::WemixConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct WemixProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for WemixProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Wemix
+    }
+}
+
+#[async_trait]
+impl RateLimited for WemixProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for WemixProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Wemix: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<WemixConfig> for WemixProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &WemixConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        WemixProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -86,6 +86,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Unichain')      { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Lava')          { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Morph')         { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Wemix')         { gridPos: pos._4 },
 
   row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
@@ -105,6 +106,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'Unichain')    { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Lava')        { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Morph')       { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Wemix')       { gridPos: pos._4 },
 
   row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
@@ -124,6 +126,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Unichain')     { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Lava')         { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Morph')        { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Wemix')        { gridPos: pos._4 },
 
   row.new('RPC Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._3 },

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod pokt;
 pub(crate) mod publicnode;
 pub(crate) mod quicknode;
 pub(crate) mod unichain;
+pub(crate) mod wemix;
 pub(crate) mod zksync;
 pub(crate) mod zora;
 

--- a/tests/functional/http/wemix.rs
+++ b/tests/functional/http/wemix.rs
@@ -1,0 +1,27 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn wemix_provider(ctx: &mut ServerContext) {
+    // Wemix Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Wemix,
+        "eip155:1111",
+        "0x457",
+    )
+    .await;
+
+    // Wemix Testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Wemix,
+        "eip155:1112",
+        "0x458",
+    )
+    .await;
+}


### PR DESCRIPTION
# Description

This PR adds Wemix RPC support for the `eip155:1111` Mainnet and `eip155:1112` Testnet support.

## How Has This Been Tested?

* A new integration provider test was created and passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [x] Update `SUPPORTED_CHAINS.md`
* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update

