### PR TITLE
fix(providers): reverting Bungee multiple bridge usage

### DIFF
--- a/src/providers/bungee.rs
+++ b/src/providers/bungee.rs
@@ -153,7 +153,7 @@ impl ChainOrchestrationProvider for BungeeProvider {
         );
         // Use only Across bridge for latency reason
         url.query_pairs_mut()
-            .append_pair("includeBridges", "across,hop,stargate");
+            .append_pair("includeBridges", "across");
 
         let latency_start = SystemTime::now();
         let response = self.send_get_request(url).await?;


### PR DESCRIPTION
# Description

This PR reverts multiple bridge usage in Bungee quotes requests using `includeBridges` parameter because it's not working as expected and leads to unexpected errors.

## How Has This Been Tested?

* Current integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
