### PR TITLE
fix(CA): removing USDT asset Base chain support

### DIFF
--- a/src/handlers/chain_agnostic/assets.rs
+++ b/src/handlers/chain_agnostic/assets.rs
@@ -34,8 +34,6 @@ static USDC_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
 static USDT_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
     // Optimism
     "eip155:10" => address!("94b008aA00579c1307B0EF2c499aD98a8ce58e58"),
-    // Base
-    "eip155:8453" => address!("fde4C96c8593536E31F229EA8f37b2ADa2699bb2"),
     // Arbitrum
     "eip155:42161" => address!("Fd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"),
 };


### PR DESCRIPTION
# Description

This PR removes the USDT Base contract from the available chain abstraction assets since there is no liquidity in any of the used bridges for it.
The full context in [Slack](https://reown-inc.slack.com/archives/C04DB2EAHE3/p1736944678522549?thread_ts=1736809028.859309&cid=C04DB2EAHE3).

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
