### PR TITLE
feat(CA): prioritizing the same asset for bridging routes

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -127,8 +127,8 @@ describe('Chain abstraction orchestrator', () => {
 
   })
 
-  it('bridging routes (routes available, USDC Optimism ⇄ USDT Arbitrum)', async () => {
-    // Sending USDC to Optimism, but having the maximum balance of USDT on Arbitrum chain
+  it('bridging routes (routes available, USDC Optimism ⇄ USDC Base)', async () => {
+    // Sending USDC to Optimism, but having the balance of USDC on Base chain
     // which expected to be used for bridging
 
     // How much needs to be topped up
@@ -163,7 +163,7 @@ describe('Chain abstraction orchestrator', () => {
 
     // First transaction expected to be the approval transaction
     const approvalTransaction = data.transactions[0]
-    expect(approvalTransaction.chainId).toBe(chain_id_arbitrum)
+    expect(approvalTransaction.chainId).toBe(chain_id_base)
     expect(approvalTransaction.nonce).not.toBe("0x00")
     expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
     const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
@@ -171,9 +171,9 @@ describe('Chain abstraction orchestrator', () => {
       throw new Error(`Expected amount is lower then the minimal required`);
     }
 
-    // Second transaction expected to be the bridging to the Arbitrum
+    // Second transaction expected to be the bridging to the Base
     const bridgingTransaction = data.transactions[1]
-    expect(bridgingTransaction.chainId).toBe(chain_id_arbitrum)
+    expect(bridgingTransaction.chainId).toBe(chain_id_base)
     expect(bridgingTransaction.nonce).not.toBe("0x00")
     expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
 
@@ -185,9 +185,9 @@ describe('Chain abstraction orchestrator', () => {
 
     // Check the metadata fundingFrom
     const fundingFrom = data.metadata.fundingFrom[0]
-    expect(fundingFrom.chainId).toBe(chain_id_arbitrum)
-    expect(fundingFrom.symbol).toBe(usdt_token_symbol)
-    expect(fundingFrom.tokenContract).toBe(usdt_contracts[chain_id_arbitrum].toLowerCase())
+    expect(fundingFrom.chainId).toBe(chain_id_base)
+    expect(fundingFrom.symbol).toBe(usdc_token_symbol)
+    expect(fundingFrom.tokenContract).toBe(usdc_contracts[chain_id_base].toLowerCase())
     if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup_with_fees)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -246,6 +246,7 @@ async fn handler_internal(
         from_address,
         initial_transaction.chain_id.clone(),
         asset_transfer_contract,
+        initial_tx_token_symbol.clone(),
     )
     .await?
     else {


### PR DESCRIPTION
# Description

This PR updates the CA assets discovery algorithm to prioritize the same asset (same token symbol) when found first and use the rest of the available assets with the highest amount as a lower priority. This will solve the unnecessary swapping if there is the same asset (but on different chains) available for bridging.

## How Has This Been Tested?

* Integration test was updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
