### PR TITLE
fix(CA): increasing the default gas limit

### DIFF
--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -39,8 +39,8 @@ use {
 };
 
 // Default gas estimate
-// Using default with 6x increase
-const DEFAULT_GAS: i64 = 0x029a6b * 0x6;
+// Using default with 9x increase
+const DEFAULT_GAS: i64 = 0x029a6b * 0x9;
 
 // Slippage for the gas estimation
 const ESTIMATED_GAS_SLIPPAGE: i8 = 3;


### PR DESCRIPTION
# Description

This PR increases the default gas limit for the CA bridging transaction from x6 to x9.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
