### PR TITLE
feat(balance): implementing tokens metadata caching between Zerion and Dune providers

### DIFF
--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -25,7 +25,7 @@ use {
 pub const H160_EMPTY_ADDRESS: H160 = H160::repeat_byte(0xee);
 
 const PROVIDER_MAX_CALLS: usize = 2;
-const METADATA_CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 7); // 1 week
+const METADATA_CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24); // 1 day
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -243,12 +243,20 @@ impl BalanceProvider for DuneProvider {
                             symbol: symbol.clone(),
                             icon_url: icon_url.clone(),
                         };
-                        set_cached_metadata(
-                            metadata_cache,
-                            &caip10_token_address_strict,
-                            &new_item,
-                        )
-                        .await;
+                        // Spawn a background task to set the cache without blocking
+                        {
+                            let metadata_cache = metadata_cache.clone();
+                            let address_key = caip10_token_address_strict.clone();
+                            let new_item_to_store = new_item.clone();
+                            tokio::spawn(async move {
+                                set_cached_metadata(
+                                    &metadata_cache,
+                                    &address_key,
+                                    &new_item_to_store,
+                                )
+                                .await;
+                            });
+                        }
                         new_item
                     }
                 };

--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -3,11 +3,15 @@ use {
     crate::{
         env::DuneConfig,
         error::{RpcError, RpcResult},
-        handlers::balance::{BalanceQueryParams, BalanceResponseBody},
+        handlers::balance::{
+            get_cached_metadata, set_cached_metadata, BalanceQueryParams, BalanceResponseBody,
+            TokenMetadataCacheItem, H160_EMPTY_ADDRESS,
+        },
         providers::{
             balance::{BalanceItem, BalanceQuantity},
             ProviderKind,
         },
+        storage::KeyValueStorage,
         utils::crypto,
         Metrics,
     },
@@ -153,6 +157,7 @@ impl BalanceProvider for DuneProvider {
         &self,
         address: String,
         params: BalanceQueryParams,
+        metadata_cache: &Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
         metrics: Arc<Metrics>,
     ) -> RpcResult<BalanceResponseBody> {
         let namespace = params
@@ -175,76 +180,116 @@ impl BalanceProvider for DuneProvider {
             }
         };
 
-        let balances_vec = balance_response
-            .balances
-            .into_iter()
-            .filter_map(|mut f| {
-                // Skip the asset if there are no symbol, decimals, since this
-                // is likely a spam token
-                let symbol = f.symbol.take()?;
-                let price_usd = f.price_usd.take()?;
-                let decimals = f.decimals.take()?;
-                let caip2_chain_id = match f.chain_id {
-                    Some(cid) => format!("{}:{}", namespace, cid),
-                    None => match namespace {
-                        // Using defaul Mainnet chain ids if not provided since
-                        // Dune doesn't provide balances for testnets
-                        crypto::CaipNamespaces::Eip155 => format!("{}:{}", namespace, "1"),
-                        crypto::CaipNamespaces::Solana => {
-                            format!("{}:{}", namespace, "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
-                        }
-                    },
+        let mut balances_vec = Vec::new();
+        for f in balance_response.balances {
+            // Skip if missing required fields as a possible spam token
+            let (Some(symbol), Some(price_usd), Some(decimals)) =
+                (f.symbol, f.price_usd, f.decimals)
+            else {
+                continue;
+            };
+
+            // Build a CAIP-2 chain ID
+            let caip2_chain_id = match f.chain_id {
+                Some(cid) => format!("{}:{}", namespace, cid),
+                None => match namespace {
+                    // Use default Mainnet chain IDs if not provided
+                    crypto::CaipNamespaces::Eip155 => format!("{}:1", namespace),
+                    crypto::CaipNamespaces::Solana => {
+                        format!("{}:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", namespace)
+                    }
+                },
+            };
+
+            // Determine name
+            let name = if f.address == "native" {
+                f.chain.clone()
+            } else {
+                symbol.clone()
+            };
+
+            // Determine icon URL
+            let icon_url = if f.address == "native" {
+                NATIVE_TOKEN_ICONS.get(&symbol).unwrap_or(&"").to_string()
+            } else {
+                // If there's no token_metadata or no logo, skip
+                match &f.token_metadata {
+                    Some(m) => m.logo.clone(),
+                    None => continue,
+                }
+            };
+
+            // Build the CAIP-10 address
+            let caip10_token_address_strict = if f.address == "native" {
+                match namespace {
+                    crypto::CaipNamespaces::Eip155 => {
+                        format!("{}:{}", caip2_chain_id, H160_EMPTY_ADDRESS)
+                    }
+                    crypto::CaipNamespaces::Solana => {
+                        format!("{}:{}", caip2_chain_id, crypto::SOLANA_NATIVE_TOKEN_ADDRESS)
+                    }
+                }
+            } else {
+                format!("{}:{}", caip2_chain_id, f.address)
+            };
+
+            // Get token metadata from the cache or update it
+            let token_metadata =
+                match get_cached_metadata(metadata_cache, &caip10_token_address_strict).await {
+                    Some(cached) => cached,
+                    None => {
+                        let new_item = TokenMetadataCacheItem {
+                            name: name.clone(),
+                            symbol: symbol.clone(),
+                            icon_url: icon_url.clone(),
+                        };
+                        set_cached_metadata(
+                            metadata_cache,
+                            &caip10_token_address_strict,
+                            &new_item,
+                        )
+                        .await;
+                        new_item
+                    }
                 };
-                Some(BalanceItem {
-                    name: {
-                        if f.address == "native" {
-                            f.chain
-                        } else {
-                            symbol.clone()
-                        }
-                    },
-                    symbol: symbol.clone(),
-                    chain_id: Some(caip2_chain_id.clone()),
-                    address: {
-                        // Return None if the address is native for the native token
-                        if f.address == "native" {
-                            // UI expecting `None`` for the Eip155 and Solana's native
-                            // token address for Solana
-                            match namespace {
-                                crypto::CaipNamespaces::Eip155 => None,
-                                crypto::CaipNamespaces::Solana => {
-                                    Some(crypto::SOLANA_NATIVE_TOKEN_ADDRESS.to_string())
-                                }
+
+            // Construct the final BalanceItem
+            let balance_item = BalanceItem {
+                name: token_metadata.name,
+                symbol: token_metadata.symbol,
+                chain_id: Some(caip2_chain_id.clone()),
+                address: {
+                    // Return None if the address is native (for EIP-155).
+                    // For Solana’s “native” token, we return the Solana native token address.
+                    if f.address == "native" {
+                        match namespace {
+                            crypto::CaipNamespaces::Eip155 => None,
+                            crypto::CaipNamespaces::Solana => {
+                                Some(crypto::SOLANA_NATIVE_TOKEN_ADDRESS.to_string())
                             }
-                        } else {
-                            Some(format!("{}:{}", caip2_chain_id, f.address.clone()))
                         }
-                    },
-                    value: f.value_usd,
-                    price: price_usd,
-                    quantity: BalanceQuantity {
-                        decimals: decimals.to_string(),
-                        numeric: crypto::format_token_amount(
-                            U256::from_dec_str(&f.amount).unwrap_or_default(),
-                            decimals,
-                        ),
-                    },
-                    icon_url: {
-                        if f.address == "native" {
-                            NATIVE_TOKEN_ICONS.get(&symbol).unwrap_or(&"").to_string()
-                        } else {
-                            f.token_metadata?.logo
-                        }
-                    },
-                })
-            })
-            .collect::<Vec<_>>();
+                    } else {
+                        Some(format!("{}:{}", caip2_chain_id, f.address))
+                    }
+                },
+                value: f.value_usd,
+                price: price_usd,
+                quantity: BalanceQuantity {
+                    decimals: decimals.to_string(),
+                    numeric: crypto::format_token_amount(
+                        U256::from_dec_str(&f.amount).unwrap_or_default(),
+                        decimals,
+                    ),
+                },
+                icon_url: token_metadata.icon_url,
+            };
 
-        let response = BalanceResponseBody {
+            balances_vec.push(balance_item);
+        }
+
+        Ok(BalanceResponseBody {
             balances: balances_vec,
-        };
-
-        Ok(response)
+        })
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -4,7 +4,7 @@ use {
         env::{BalanceProviderConfig, ProviderConfig},
         error::{RpcError, RpcResult},
         handlers::{
-            balance::{self, BalanceQueryParams, BalanceResponseBody},
+            balance::{self, BalanceQueryParams, BalanceResponseBody, TokenMetadataCacheItem},
             convert::{
                 allowance::{AllowanceQueryParams, AllowanceResponseBody},
                 approve::{ConvertApproveQueryParams, ConvertApproveResponseBody},
@@ -22,6 +22,7 @@ use {
             portfolio::{PortfolioQueryParams, PortfolioResponseBody},
             RpcQueryParams, SupportedCurrencies,
         },
+        storage::KeyValueStorage,
         utils::crypto::CaipNamespaces,
         Metrics,
     },
@@ -863,6 +864,7 @@ pub trait BalanceProvider: Send + Sync {
         &self,
         address: String,
         params: BalanceQueryParams,
+        metadata_cache: &Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
         metrics: Arc<Metrics>,
     ) -> RpcResult<BalanceResponseBody>;
 }

--- a/src/providers/solscan.rs
+++ b/src/providers/solscan.rs
@@ -7,7 +7,10 @@ use {
         env::SolScanConfig,
         error::{RpcError, RpcResult},
         handlers::{
-            balance::{BalanceItem, BalanceQuantity, BalanceQueryParams, BalanceResponseBody},
+            balance::{
+                BalanceItem, BalanceQuantity, BalanceQueryParams, BalanceResponseBody,
+                TokenMetadataCacheItem,
+            },
             fungible_price::FungiblePriceItem,
             history::{
                 HistoryQueryParams, HistoryResponseBody, HistoryTransaction,
@@ -17,7 +20,7 @@ use {
             },
         },
         providers::{BalanceProviderFactory, ProviderKind},
-        storage::error::StorageError,
+        storage::{error::StorageError, KeyValueStorage},
         utils::crypto::{CaipNamespaces, SOLANA_NATIVE_TOKEN_ADDRESS},
         Metrics,
     },
@@ -397,6 +400,7 @@ impl BalanceProvider for SolScanProvider {
         &self,
         address: String,
         _params: BalanceQueryParams,
+        _metadata_cache: &Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
         metrics: Arc<Metrics>,
     ) -> RpcResult<BalanceResponseBody> {
         let mut url = Url::parse(ACCOUNT_TOKENS_URL).map_err(|_| RpcError::BalanceParseURLError)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use {
         analytics::RPCAnalytics,
         env::Config,
         error::RpcError,
-        handlers::identity::IdentityResponse,
+        handlers::{balance::TokenMetadataCacheItem, identity::IdentityResponse},
         metrics::Metrics,
         project::Registry,
         providers::ProviderRepository,
@@ -24,7 +24,6 @@ pub struct AppState {
     pub providers: ProviderRepository,
     pub metrics: Arc<Metrics>,
     pub registry: Registry,
-    pub identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     pub analytics: RPCAnalytics,
     pub compile_info: CompileInfo,
     /// Service instance uptime measurement
@@ -35,6 +34,9 @@ pub struct AppState {
     pub rate_limit: Option<RateLimit>,
     // IRN client
     pub irn: Option<Irn>,
+    // Redis caching
+    pub identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
+    pub token_metadata_cache: Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -44,11 +46,12 @@ pub fn new_state(
     providers: ProviderRepository,
     metrics: Arc<Metrics>,
     registry: Registry,
-    identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     analytics: RPCAnalytics,
     http_client: reqwest::Client,
     rate_limit: Option<RateLimit>,
     irn: Option<Irn>,
+    identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
+    token_metadata_cache: Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
 ) -> AppState {
     AppState {
         config,
@@ -56,13 +59,14 @@ pub fn new_state(
         providers,
         metrics,
         registry,
-        identity_cache,
         analytics,
         compile_info: CompileInfo {},
         uptime: std::time::Instant::now(),
         http_client,
         rate_limit,
         irn,
+        identity_cache,
+        token_metadata_cache,
     }
 }
 


### PR DESCRIPTION
# Description

This PR implements tokens metadata shared cache between Zerion and Dune providers for the address balances endpoint. The reason to use a shared cache is that when using multiple providers there can be a difference in the token metadata (like different names or icons). 
By using a long-living (1 day) cache with the "first hit, first saved" rule we will use the same metadata for every provider and fix icons flipping on every request and keeping the metadata updated in case some of the providers will be added or removed.
Since the tokens metadata doesn't update often, keeping the 1 day caching seems reasonable.

## How Has This Been Tested?

* Current balance integration tests are passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
