### PR TITLE
fix(SolScan): adding new `close account` activity type

### DIFF
--- a/src/providers/solscan.rs
+++ b/src/providers/solscan.rs
@@ -391,6 +391,8 @@ enum HistoryActivityType {
     Mint,
     #[serde(rename = "ACTIVITY_SPL_CREATE_ACCOUNT")]
     CreateAccount,
+    #[serde(rename = "ACTIVITY_SPL_CLOSE_ACCOUNT")]
+    CloseAccount,
 }
 
 #[async_trait]
@@ -553,6 +555,7 @@ impl HistoryProvider for SolScanProvider {
                         HistoryActivityType::Burn => "burn".to_string(),
                         HistoryActivityType::Mint => "mint".to_string(),
                         HistoryActivityType::CreateAccount => "execute".to_string(),
+                        HistoryActivityType::CloseAccount => "close".to_string(),
                     },
                     hash: item.trans_id.clone(),
                     mined_at: item.time.clone(),


### PR DESCRIPTION
# Description

This PR adds a new SolScan activity type `ACTIVITY_SPL_CLOSE_ACCOUNT`. This will fix the deserialization error when this type occurs in the history response.

## How Has This Been Tested?

* Current integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
