### PR TITLE
feat(IRN): updating irn client to `wcn_replication` and switching to the mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@ export RPC_PROXY_POSTGRES_URI="postgres://postgres@localhost/postgres"
 # export RPC_PROXY_RATE_LIMITING_REFILL_RATE=2
 
 # Uncomment for using the IRN client
-# export RPC_PROXY_IRN_NODE=127.0.0.1:3011
+# export RPC_PROXY_IRN_NODES=/ip4/127.0.0.1/udp/3011/quic-v1
 # export RPC_PROXY_IRN_KEY=base64_key
 # export RPC_PROXY_IRN_NAMESPACE=namespace
 # export RPC_PROXY_IRN_NAMESPACE_SECRET=namespace_secret

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -67,15 +67,6 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
       - run: rustup update stable && rustup default stable
       - run: docker compose -p mock-bundler -f docker-compose.mock-bundler.yaml up -d # run this first since container startup takes foooorrrrrreeeeeeever
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: WalletConnectBot
-          password: ${{ secrets.PRIVATE_GHCR_TOKEN_WCF }}
-      - run: docker pull ghcr.io/walletconnectfoundation/irn-node:sha-baef4e8
-      - run: docker tag ghcr.io/walletconnectfoundation/irn-node:sha-baef4e8 irn:master
-      - run: cd irn && docker compose up -d
       - run: docker compose up -d redis postgres
       - run: cargo build --tests --features=test-mock-bundler # pre-build to parallelize container startup
       - run: while ! curl localhost:8545/health; do sleep 1; done # Anvil
@@ -105,12 +96,6 @@ jobs:
       - run: docker logs blockchain-api-postgres-1
         if: failure()
       - run: docker logs blockchain-api-redis-1
-        if: failure()
-      - run: docker logs irn-node-1
-        if: failure()
-      - run: docker logs irn-node-2
-        if: failure()
-      - run: docker logs irn-node-3
         if: failure()
 
   merge_check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -497,7 +497,7 @@ dependencies = [
  "alloy-genesis 0.9.2",
  "alloy-primitives",
  "k256",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "tempfile",
  "thiserror 2.0.3",
@@ -525,9 +525,9 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -899,7 +899,7 @@ dependencies = [
  "coins-bip32 0.12.0",
  "coins-bip39 0.12.0",
  "k256",
- "rand",
+ "rand 0.8.5",
  "thiserror 2.0.3",
 ]
 
@@ -1218,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1228,7 +1228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1257,46 +1257,18 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
-dependencies = [
- "asn1-rs-derive 0.4.0",
- "asn1-rs-impl 0.1.0",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl 0.2.0",
+ "asn1-rs-derive",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
-dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -1308,18 +1280,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 2.0.87",
- "synstructure 0.13.1",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
-dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
- "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -1345,25 +1306,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1464,17 +1406,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "attohttpc"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
-dependencies = [
- "http 0.2.12",
- "log",
- "url",
-]
 
 [[package]]
 name = "auto_impl"
@@ -2025,10 +1956,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -2343,6 +2274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,7 +2365,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror 1.0.69",
 ]
@@ -2444,7 +2381,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror 1.0.69",
 ]
@@ -2498,11 +2435,11 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "const-hex",
- "getrandom",
+ "getrandom 0.2.15",
  "hidapi-rusb",
  "js-sys",
  "log",
- "nix 0.26.4",
+ "nix",
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
@@ -2573,7 +2510,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2707,7 +2644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -2719,7 +2656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -2877,25 +2814,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
-dependencies = [
- "asn1-rs 0.5.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -3097,11 +3020,23 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3127,7 +3062,7 @@ dependencies = [
  "generic-array",
  "group 0.12.1",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.3.0",
  "subtle",
  "zeroize",
@@ -3147,7 +3082,7 @@ dependencies = [
  "group 0.13.0",
  "pem-rfc7468",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.7.3",
  "subtle",
  "zeroize",
@@ -3194,23 +3129,11 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "sha3",
  "zeroize",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2 1.0.89",
- "quote 1.0.37",
- "syn 2.0.87",
 ]
 
 [[package]]
@@ -3309,7 +3232,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -3466,7 +3389,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
@@ -3567,7 +3490,7 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "eth-keystore",
  "ethers-core",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror 1.0.69",
  "tracing",
@@ -3670,7 +3593,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3680,7 +3603,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3697,7 +3620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3885,16 +3808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-locks"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,16 +3826,6 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "futures-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
-dependencies = [
- "futures-io",
- "rustls 0.21.12",
 ]
 
 [[package]]
@@ -4062,6 +3965,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -4069,7 +3983,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -4129,7 +4043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4140,7 +4054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4257,12 +4171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,52 +4190,6 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
-
-[[package]]
-name = "hickory-proto"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "socket2",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "hidapi-rusb"
@@ -4366,17 +4228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
 ]
 
 [[package]]
@@ -4615,7 +4466,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -4777,58 +4628,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-addrs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "if-watch"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
-dependencies = [
- "async-io",
- "core-foundation",
- "fnv",
- "futures",
- "if-addrs",
- "ipnet",
- "log",
- "rtnetlink",
- "system-configuration 0.5.1",
- "tokio",
- "windows 0.51.1",
-]
-
-[[package]]
 name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
-
-[[package]]
-name = "igd-next"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
-dependencies = [
- "async-trait",
- "attohttpc",
- "bytes",
- "futures",
- "http 0.2.12",
- "hyper 0.14.31",
- "log",
- "rand",
- "tokio",
- "url",
- "xmltree",
-]
 
 [[package]]
 name = "impl-codec"
@@ -4920,18 +4723,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
-name = "ipconfig"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
-dependencies = [
- "socket2",
- "widestring",
- "windows-sys 0.48.0",
- "winreg",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,62 +4747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "irn_api"
-version = "0.1.0"
-dependencies = [
- "async-stream",
- "data-encoding",
- "derive_more 1.0.0",
- "ed25519-dalek",
- "futures",
- "futures-util",
- "irn_rpc",
- "metrics 0.23.0",
- "postcard",
- "rand",
- "ring 0.17.8",
- "serde",
- "serde-big-array",
- "tap",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tryhard",
- "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
- "xxhash-rust",
-]
-
-[[package]]
-name = "irn_rpc"
-version = "0.1.0"
-dependencies = [
- "backoff",
- "derivative",
- "derive_more 1.0.0",
- "futures",
- "indexmap 2.6.0",
- "libp2p",
- "libp2p-tls 0.3.0",
- "metrics 0.23.0",
- "pin-project 1.1.7",
- "quinn 0.10.2",
- "quinn-proto 0.10.6",
- "rand",
- "rustls 0.21.12",
- "serde",
- "socket2",
- "tap",
- "thiserror 1.0.69",
- "tokio",
- "tokio-serde",
- "tokio-serde-postcard",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,6 +4766,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -5043,6 +4787,26 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -5200,28 +4964,22 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p"
-version = "0.53.2"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681fb3f183edfbedd7a57d32ebe5dcdc0b9f94061185acf3c30249349cc6fc99"
+checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
 dependencies = [
  "bytes",
  "either",
  "futures",
  "futures-timer",
- "getrandom",
- "instant",
+ "getrandom 0.2.15",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
- "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identity",
  "libp2p-kad",
- "libp2p-mdns",
- "libp2p-quic",
  "libp2p-swarm",
- "libp2p-tcp",
- "libp2p-upnp",
  "multiaddr",
  "pin-project 1.1.7",
  "rw-stream-sink",
@@ -5230,9 +4988,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
+checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5242,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cd50a78ccfada14de94cbacd3ce4b0138157f376870f13d3a8422cd075b4fd"
+checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5254,9 +5012,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.41.3"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a8920cbd8540059a01950c1e5c96ea8d89eb50c51cd366fc18bdf540a6e48f"
+checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
 dependencies = [
  "either",
  "fnv",
@@ -5270,7 +5028,7 @@ dependencies = [
  "parking_lot",
  "pin-project 1.1.7",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "serde",
  "smallvec",
@@ -5282,51 +5040,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-dns"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17cbcf7160ff35c3e8e560de4a068fe9d6cb777ea72840e48eb76ff9576c4b6"
-dependencies = [
- "async-trait",
- "futures",
- "hickory-resolver",
- "libp2p-core",
- "libp2p-identity",
- "parking_lot",
- "smallvec",
- "tracing",
-]
-
-[[package]]
 name = "libp2p-gossipsub"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d665144a616dadebdc5fff186b1233488cdcd8bfb1223218ff084b6d052c94f7"
+checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
 dependencies = [
  "asynchronous-codec",
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "either",
  "fnv",
  "futures",
  "futures-ticker",
- "getrandom",
+ "getrandom 0.2.15",
  "hex_fmt",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "sha2",
  "smallvec",
  "tracing",
  "void",
+ "web-time",
 ]
 
 [[package]]
@@ -5340,7 +5082,7 @@ dependencies = [
  "hkdf",
  "multihash",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "thiserror 1.0.69",
@@ -5350,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.45.3"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc5767727d062c4eac74dd812c998f0e488008e82cce9c33b463d38423f9ad2"
+checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -5362,13 +5104,12 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "smallvec",
@@ -5376,120 +5117,39 @@ dependencies = [
  "tracing",
  "uint",
  "void",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49007d9a339b3e1d7eeebc4d67c05dbf23d300b7d091193ec2d3f26802d7faf2"
-dependencies = [
- "data-encoding",
- "futures",
- "hickory-proto",
- "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "rand",
- "smallvec",
- "socket2",
- "tokio",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67296ad4e092e23f92aea3d2bdb6f24eab79c0929ed816dfb460ea2f4567d2b"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-tls 0.4.1",
- "parking_lot",
- "quinn 0.11.6",
- "rand",
- "ring 0.17.8",
- "rustls 0.23.16",
- "socket2",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.44.2"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
+checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "lru",
  "multistream-select",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
- "tokio",
  "tracing",
  "void",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2460fc2748919adff99ecbc1aab296e4579e41f374fb164149bd2c9e529d4c"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core",
- "libp2p-identity",
- "socket2",
- "tokio",
- "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ce7e3c2e7569d685d08ec795157981722ff96e9e9f9eae75df3c29d02b07a5"
+checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
 dependencies = [
  "futures",
- "futures-rustls 0.24.0",
- "libp2p-core",
- "libp2p-identity",
- "rcgen",
- "ring 0.16.20",
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
- "x509-parser 0.15.1",
- "yasna",
-]
-
-[[package]]
-name = "libp2p-tls"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b7b831e55ce2aa6c354e6861a85fdd4dd0a2b97d5e276fabac0e4810a71776"
-dependencies = [
- "futures",
- "futures-rustls 0.26.0",
+ "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
  "rcgen",
@@ -5497,24 +5157,8 @@ dependencies = [
  "rustls 0.23.16",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
- "x509-parser 0.16.0",
+ "x509-parser",
  "yasna",
-]
-
-[[package]]
-name = "libp2p-upnp"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccf04b0e3ff3de52d07d5fd6c3b061d0e7f908ffc683c32d9638caedce86fc8"
-dependencies = [
- "futures",
- "futures-timer",
- "igd-next",
- "libp2p-core",
- "libp2p-swarm",
- "tokio",
- "tracing",
- "void",
 ]
 
 [[package]]
@@ -5563,12 +5207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,21 +5242,6 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.1",
 ]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -5732,9 +5355,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -5835,87 +5458,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-packet-core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
-dependencies = [
- "anyhow",
- "byteorder",
- "libc",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "netlink-proto"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-sys",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
-dependencies = [
- "bytes",
- "futures",
- "libc",
- "log",
- "tokio",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "nix"
@@ -6006,7 +5552,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -6072,7 +5618,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -6121,20 +5667,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
-dependencies = [
- "asn1-rs 0.5.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -6265,7 +5802,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -6400,7 +5937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -6520,7 +6057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6673,21 +6210,6 @@ checksum = "328e231f0add6d247d82421bf3790b4b33b39c8930637f428eef24c4c6a90805"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6889,8 +6411,8 @@ dependencies = [
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -6946,7 +6468,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -6981,55 +6503,19 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto 0.10.6",
- "quinn-udp 0.4.1",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
- "futures-io",
  "pin-project-lite",
- "quinn-proto 0.11.9",
- "quinn-udp 0.5.7",
- "rustc-hash 2.0.0",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
  "rustls 0.23.16",
  "socket2",
  "thiserror 2.0.3",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
-dependencies = [
- "bytes",
- "rand",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "slab",
- "thiserror 1.0.69",
- "tinyvec",
  "tracing",
 ]
 
@@ -7040,30 +6526,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.16",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.3",
  "tinyvec",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
-dependencies = [
- "bytes",
- "libc",
- "socket2",
- "tracing",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7106,14 +6580,37 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7123,7 +6620,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -7132,7 +6638,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7141,7 +6656,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7235,7 +6750,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -7305,7 +6820,7 @@ dependencies = [
  "jsonwebtoken 8.3.0",
  "k256",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde-aux 4.5.0",
@@ -7330,7 +6845,7 @@ dependencies = [
  "hex",
  "jsonwebtoken 8.3.0",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde-aux 4.5.0",
@@ -7414,7 +6929,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn 0.11.6",
+ "quinn",
  "rustls 0.23.16",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
@@ -7435,16 +6950,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "windows-registry",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
 ]
 
 [[package]]
@@ -7491,7 +6996,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -7581,8 +7086,6 @@ dependencies = [
  "hyper 0.14.31",
  "hyper-tls 0.5.0",
  "ipnet",
- "irn_api",
- "irn_rpc",
  "jsonrpc",
  "moka",
  "num_enum",
@@ -7592,8 +7095,8 @@ dependencies = [
  "phf",
  "pnet_datalink",
  "prometheus-http-query",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "relay_rpc 0.1.0 (git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.32.0)",
  "reqwest 0.12.9",
@@ -7621,6 +7124,7 @@ dependencies = [
  "validator",
  "vergen",
  "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
+ "wcn_replication",
  "yttrium",
 ]
 
@@ -7637,26 +7141,11 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-route",
- "netlink-proto",
- "nix 0.24.3",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
@@ -7675,7 +7164,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -7704,12 +7193,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7804,6 +7287,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
@@ -7841,6 +7337,33 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 dependencies = [
  "web-time",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.16",
+ "rustls-native-certs 0.7.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.102.8",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -8039,6 +7562,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
@@ -8294,6 +7818,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharding"
+version = "0.1.0"
+dependencies = [
+ "indexmap 2.6.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8315,7 +7847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -8325,7 +7857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -8556,7 +8088,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -8596,7 +8128,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -8778,18 +8310,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
- "syn 1.0.109",
- "unicode-xid 0.2.6",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
@@ -8811,7 +8331,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -9141,21 +8661,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+version = "0.9.0"
+source = "git+https://github.com/xDarksome/tokio-serde.git?rev=6df9ff9#6df9ff9ca8896dfa2b83347bbeb2bb00e9b294a0"
 dependencies = [
  "bytes",
+ "educe",
  "futures-core",
  "futures-sink",
  "pin-project 1.1.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "tokio-serde-postcard"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bc47334cd92ae09ac4ae741108a3a7437c3d2c75c38c957b93dbc066984329"
+source = "git+https://github.com/xDarksome/tokio-serde-postcard.git?rev=5e1b77a#5e1b77a687eb80e3c37b9038025e4897d71f720d"
 dependencies = [
  "bytes",
  "postcard",
@@ -9294,7 +8815,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project 1.1.7",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -9460,17 +8981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tryhard"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
-dependencies = [
- "futures",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9483,7 +8993,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -9502,7 +9012,7 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.69",
@@ -9673,7 +9183,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -9683,7 +9193,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -9802,6 +9312,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -9949,6 +9465,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "wcn_auth"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "data-encoding",
+ "derive_more 1.0.0",
+ "ed25519-dalek",
+ "rand 0.8.5",
+ "ring 0.17.8",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wcn_rpc",
+]
+
+[[package]]
+name = "wcn_client_api"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "futures-util",
+ "postcard",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
+ "wcn_auth",
+ "wcn_domain",
+ "wcn_rpc",
+]
+
+[[package]]
+name = "wcn_core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "backoff",
+ "bitflags 2.6.0",
+ "bytes",
+ "chrono",
+ "dashmap 5.5.3",
+ "derivative",
+ "derive_more 1.0.0",
+ "fnv",
+ "futures",
+ "futures-util",
+ "itertools 0.12.1",
+ "libp2p",
+ "metrics 0.23.0",
+ "num-traits",
+ "once_cell",
+ "pin-project 1.1.7",
+ "rand 0.7.3",
+ "serde",
+ "sharding",
+ "smallvec",
+ "tap",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "wcn_domain"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "sharding",
+ "thiserror 1.0.69",
+ "wcn_core",
+ "wcn_rpc",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "wcn_replication"
+version = "0.1.0"
+dependencies = [
+ "derive_more 1.0.0",
+ "futures",
+ "smallvec",
+ "tap",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
+ "wcn_client_api",
+ "wcn_core",
+ "wcn_domain",
+ "wcn_storage_api",
+]
+
+[[package]]
+name = "wcn_rpc"
+version = "0.1.0"
+dependencies = [
+ "backoff",
+ "derivative",
+ "derive_more 1.0.0",
+ "futures",
+ "indexmap 2.6.0",
+ "libp2p",
+ "libp2p-tls",
+ "metrics 0.23.0",
+ "pin-project 1.1.7",
+ "quinn",
+ "quinn-proto",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "socket2",
+ "tap",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-serde",
+ "tokio-serde-postcard",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
+]
+
+[[package]]
+name = "wcn_storage_api"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "futures",
+ "serde",
+ "thiserror 1.0.69",
+ "time",
+ "tracing",
+ "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
+ "wcn_auth",
+ "wcn_rpc",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9969,6 +9632,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd5da49bdf1f30054cfe0b8ce2958b8fbeb67c4d82c8967a598af481bef255c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9983,12 +9655,6 @@ dependencies = [
  "redox_syscall",
  "wasite",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -10023,31 +9689,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
-dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -10298,58 +9945,26 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
-dependencies = [
- "asn1-rs 0.5.2",
- "data-encoding",
- "der-parser 8.2.0",
- "lazy_static",
- "nom",
- "oid-registry 0.6.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 9.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.7.1",
+ "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "xmltree"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
-dependencies = [
- "xml-rs",
-]
 
 [[package]]
 name = "xxhash-rust"
@@ -10393,7 +10008,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 2.0.87",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]
@@ -10408,7 +10023,7 @@ dependencies = [
  "erc6492",
  "eyre",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "relay_rpc 0.1.0 (git+https://github.com/WalletConnect/WalletConnectRust.git?rev=51e984e)",
  "reqwest 0.12.9",
@@ -10458,7 +10073,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 2.0.87",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ moka = "0.12"
 sqlx = { version = "0.7.4", features = ["runtime-tokio-native-tls", "postgres", "chrono"] }
 
 # IRN
-irn_api = { package = "irn_api", path = "irn/crates/irn_api", features = ["client"] }
-irn_rpc = { package = "irn_rpc", path = "irn/crates/rpc"}
+wcn_replication = { package = "wcn_replication", path = "irn/crates/replication" }
 
 dotenv = "0.15.0"
 envy = "0.4"

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -220,7 +220,7 @@ mod test {
                 "127.0.0.1,127.0.0.2",
             ),
             // IRN config.
-            ("RPC_PROXY_IRN_NODE", "node"),
+            ("RPC_PROXY_IRN_NODES", "node1.id,node2.id"),
             ("RPC_PROXY_IRN_KEY", "key"),
             ("RPC_PROXY_IRN_NAMESPACE", "namespace"),
             ("RPC_PROXY_IRN_NAMESPACE_SECRET", "namespace"),
@@ -312,7 +312,7 @@ mod test {
                     ip_whitelist: Some(vec!["127.0.0.1".into(), "127.0.0.2".into()]),
                 },
                 irn: IrnConfig {
-                    node: Some("node".to_owned()),
+                    nodes: Some(vec!["node1.id".to_owned(), "node2.id".to_owned()]),
                     key: Some("key".to_owned()),
                     namespace: Some("namespace".to_owned()),
                     namespace_secret: Some("namespace".to_owned()),

--- a/src/handlers/chain_agnostic/status.rs
+++ b/src/handlers/chain_agnostic/status.rs
@@ -54,7 +54,7 @@ async fn handler_internal(
     state
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Get);
-    let mut bridging_status_item = serde_json::from_str::<StorageBridgingItem>(&irn_result)?;
+    let mut bridging_status_item = serde_json::from_slice::<StorageBridgingItem>(&irn_result)?;
 
     // Return without checking the balance if the status is completed or errored
     match bridging_status_item.status {
@@ -91,7 +91,7 @@ async fn handler_internal(
         irn_client
             .set(
                 query_params.orchestration_id,
-                serde_json::to_string(&bridging_status_item)?.into(),
+                serde_json::to_vec(&bridging_status_item)?,
             )
             .await?;
         state
@@ -129,7 +129,7 @@ async fn handler_internal(
         irn_client
             .set(
                 query_params.orchestration_id,
-                serde_json::to_string(&bridging_status_item)?.into(),
+                serde_json::to_vec(&bridging_status_item)?,
             )
             .await?;
         state

--- a/src/handlers/sessions/context.rs
+++ b/src/handlers/sessions/context.rs
@@ -53,7 +53,7 @@ async fn handler_internal(
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hget);
     let mut storage_permissions_item =
-        serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
+        serde_json::from_slice::<StoragePermissionsItem>(&storage_permissions_item)?;
 
     // Update the context
     storage_permissions_item.context = Some(request_payload.context);
@@ -64,7 +64,7 @@ async fn handler_internal(
         .hset(
             address,
             request_payload.pci,
-            serde_json::to_string(&storage_permissions_item)?.into(),
+            serde_json::to_vec(&storage_permissions_item)?,
         )
         .await?;
     state

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -146,7 +146,7 @@ async fn handler_internal(
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hget);
     let storage_permissions_item =
-        serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
+        serde_json::from_slice::<StoragePermissionsItem>(&storage_permissions_item)?;
 
     // Check if the permission is revoked
     if storage_permissions_item.revoked_at.is_some() {

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -78,6 +78,9 @@ async fn handler_internal(
 
     // Store the permission item in the IRN database
     let storage_permissions_item = StoragePermissionsItem {
+        // Storing the PCI inside of the item along with the item field
+        // as a temporary hotfix solution for the WCN/IRN field wrong naming
+        pci: pci.clone(),
         expiry: request_payload.expiry,
         created_at: SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -98,7 +98,7 @@ async fn handler_internal(
         .hset(
             address.clone(),
             pci.clone(),
-            serde_json::to_string(&storage_permissions_item)?.into(),
+            serde_json::to_vec(&storage_permissions_item)?,
         )
         .await?;
     state

--- a/src/handlers/sessions/get.rs
+++ b/src/handlers/sessions/get.rs
@@ -111,11 +111,13 @@ pub async fn get_session_context(
         .ok_or(GetSessionContextError::PermissionNotFound(address, pci))?;
     metrics.add_irn_latency(irn_call_start, OperationType::Hget);
 
-    let storage_permissions_item =
-        serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item).map_err(|e| {
-            GetSessionContextError::InternalGetSessionContextError(
-                InternalGetSessionContextError::Deserializing(e),
-            )
-        })?;
+    let storage_permissions_item = serde_json::from_slice::<StoragePermissionsItem>(
+        &storage_permissions_item,
+    )
+    .map_err(|e| {
+        GetSessionContextError::InternalGetSessionContextError(
+            InternalGetSessionContextError::Deserializing(e),
+        )
+    })?;
     Ok(storage_permissions_item.context)
 }

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -80,7 +80,7 @@ async fn handler_internal(
         .add_irn_latency(irn_call_start, OperationType::Hscan);
 
     let mut result_pcis: Vec<Pci> = Vec::new();
-    for (pci, entity) in pcis {
+    for (_, entity) in pcis {
         let storage_permissions_item = serde_json::from_slice::<StoragePermissionsItem>(&entity)?;
 
         // Get project data
@@ -96,7 +96,7 @@ async fn handler_internal(
                 url: None,
                 icon_url: None,
             },
-            pci,
+            pci: storage_permissions_item.pci,
             expiry: storage_permissions_item.expiry,
             created_at: storage_permissions_item.created_at,
             permissions: storage_permissions_item.permissions,

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -55,6 +55,7 @@ pub struct PermissionSubContextSignerData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StoragePermissionsItem {
+    pci: String,
     expiry: usize,
     created_at: usize,
     project_id: String,

--- a/src/handlers/sessions/revoke.rs
+++ b/src/handlers/sessions/revoke.rs
@@ -53,7 +53,7 @@ async fn handler_internal(
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hget);
     let mut storage_permissions_item =
-        serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
+        serde_json::from_slice::<StoragePermissionsItem>(&storage_permissions_item)?;
 
     if storage_permissions_item.revoked_at.is_some() {
         return Err(RpcError::RevokedPermission(request_payload.pci.clone()));
@@ -73,7 +73,7 @@ async fn handler_internal(
         .hset(
             address,
             request_payload.pci,
-            serde_json::to_string(&storage_permissions_item)?.into(),
+            serde_json::to_vec(&storage_permissions_item)?,
         )
         .await?;
     state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,20 +172,15 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
 
     let http_client = reqwest::Client::new();
     let irn_client =
-        if let (Some(node_addr), Some(key_base64), Some(namespace), Some(namespace_secret)) = (
-            config.irn.node.clone(),
+        if let (Some(nodes), Some(key_base64), Some(namespace), Some(namespace_secret)) = (
+            config.irn.nodes.clone(),
             config.irn.key.clone(),
             config.irn.namespace.clone(),
             config.irn.namespace_secret.clone(),
         ) {
-            Some(irn::Irn::new(
-                node_addr,
-                key_base64,
-                namespace,
-                namespace_secret,
-            )?)
+            Some(irn::Irn::new(key_base64, nodes, namespace, namespace_secret).await?)
         } else {
-            warn!("IRN client is disabled (missing env configuration variables)");
+            warn!("IRN client is disabled (missing required environment configuration variables)");
             None
         };
 

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -29,12 +29,13 @@ pub enum StorageError {
     /// Wrong UTF8 encoding
     #[error("wrong UTF8 encoding")]
     Utf8Error(#[from] std::string::FromUtf8Error),
-    /// IRN network errors
-    #[error("IRN network error: {0}")]
-    IrnNetworkError(#[from] irn_rpc::quic::Error),
-    /// IRN client errors
-    #[error("IRN client error: {0}")]
-    IrnClientError(#[from] irn_api::client::Error),
+    /// WCN replication client error
+    #[error("WCN client error: {0}")]
+    WcnClientError(#[from] wcn_replication::Error),
+    #[error("WCN auth error: {0}")]
+    WcnAuthError(#[from] wcn_replication::auth::Error),
+    #[error("WCN driver creation error: {0}")]
+    WcnDriverCreationError(#[from] wcn_replication::CreationError),
     /// An unexpected error occurred
     #[error("{0:?}")]
     Other(String),

--- a/src/storage/irn/mod.rs
+++ b/src/storage/irn/mod.rs
@@ -1,26 +1,25 @@
 use {
     super::StorageError,
-    irn_api::{
-        auth::{Auth, PublicKey},
-        Client, Key,
-    },
-    irn_rpc::identity::Keypair,
     serde::Deserialize,
-    std::{net::SocketAddr, time::Duration},
+    std::{collections::HashSet, str::FromStr, time::Duration},
+    wcn_replication::{
+        auth::{client_key_from_secret, peer_id, PublicKey},
+        identity::Keypair,
+        storage::{auth::Auth, Entry, Key, MapEntry, Multiaddr},
+        Config as WcnConfig, Driver,
+    },
 };
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
 const MAX_OPERATION_TIME: Duration = Duration::from_secs(3);
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(3);
 const RECORDS_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 30); // 30 days
-const UDP_SOCKET_COUNT: usize = 1;
 
 /// IRN storage operation type
 #[derive(Debug)]
 pub enum OperationType {
     Hset,
     Hget,
-    Hfields,
+    Hscan,
     Hdel,
     Set,
     Get,
@@ -31,7 +30,7 @@ impl OperationType {
         match self {
             OperationType::Hset => "hset",
             OperationType::Hget => "hget",
-            OperationType::Hfields => "hfields",
+            OperationType::Hscan => "hscan",
             OperationType::Hdel => "hdel",
             OperationType::Set => "set",
             OperationType::Get => "get",
@@ -47,7 +46,7 @@ impl From<OperationType> for String {
 
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 pub struct Config {
-    pub node: Option<String>,
+    pub nodes: Option<Vec<String>>,
     pub key: Option<String>,
     pub namespace: Option<String>,
     pub namespace_secret: Option<String>,
@@ -55,87 +54,84 @@ pub struct Config {
 
 #[derive(Clone)]
 pub struct Irn {
-    client: Client,
+    driver: Driver,
     namespace: PublicKey,
 }
 
 impl Irn {
-    pub fn new(
-        node_addr: String,
-        key_base64: String,
+    pub async fn new(
+        key: String,
+        nodes: Vec<String>,
         namespace: String,
         namespace_secret: String,
     ) -> Result<Self, StorageError> {
-        let keypair = Keypair::ed25519_from_bytes(
-            data_encoding::BASE64
-                .decode(key_base64.as_bytes())
-                .map_err(|_| StorageError::WrongKey(key_base64.clone()))?,
-        )
-        .map_err(|_| StorageError::WrongKey(key_base64))?;
-        // Generating peer_id. This should be replaced by the actual peer_id
-        // in a future
-        let peer_id = irn_rpc::identity::Keypair::generate_ed25519()
-            .public()
-            .to_peer_id();
-        let node_addr = node_addr
-            .parse::<SocketAddr>()
-            .map_err(|_| StorageError::WrongNodeAddress(node_addr))?;
-        let address = (peer_id, irn_rpc::quic::socketaddr_to_multiaddr(node_addr));
+        let client_key =
+            client_key_from_secret(key.as_bytes()).map_err(StorageError::WcnAuthError)?;
+
+        // Safe unwrap as the key is guaranteed to be valid since its created by the `client_key_from_secret``
+        let keypair = Keypair::ed25519_from_bytes(client_key.to_bytes())
+            .expect("Failed to create keypair from ed25519 client key");
+
+        // Verify and log client public key for debugging purposes.
+        let public_key = client_key.verifying_key();
+        let peer_id = peer_id(&public_key);
+        let public_key = data_encoding::BASE64.encode(public_key.as_bytes());
+
+        tracing::info!(%peer_id, %public_key, "IRN client key");
+
+        let nodes = Self::parse_node_addresses(nodes)?;
         let namespace = Auth::from_secret(namespace_secret.as_bytes(), namespace.as_bytes())
             .map_err(|_| StorageError::WrongNamespace(namespace))?;
-        let client = Client::new(irn_api::client::Config {
-            keypair,
-            nodes: [address].into(),
-            shadowing_nodes: Default::default(),
-            shadowing_factor: 0.0,
-            request_timeout: REQUEST_TIMEOUT,
-            max_operation_time: MAX_OPERATION_TIME,
-            connection_timeout: CONNECTION_TIMEOUT,
-            udp_socket_count: UDP_SOCKET_COUNT,
-            namespaces: vec![namespace.clone()],
-            shadowing_default_namespace: None,
-        })?;
+
+        let config = WcnConfig::new(nodes)
+            .with_keypair(keypair)
+            .with_namespaces(vec![namespace.clone()])
+            .with_connection_timeout(CONNECTION_TIMEOUT)
+            .with_operation_timeout(MAX_OPERATION_TIME);
+
+        let driver = Driver::new(config)
+            .await
+            .map_err(StorageError::WcnDriverCreationError)?;
 
         Ok(Self {
-            client,
+            driver,
             namespace: namespace.public_key(),
         })
     }
 
-    /// Calculate unixtimestamp based on the record TTL and the current time
-    pub fn calculate_ttl(&self) -> u64 {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("Failed to get time since epoch")
-            .as_secs();
-        now + RECORDS_TTL.as_secs()
+    fn parse_node_addresses(addresses: Vec<String>) -> Result<HashSet<Multiaddr>, StorageError> {
+        let mut nodes: HashSet<Multiaddr> = HashSet::new();
+        for address in addresses {
+            let addr = Multiaddr::from_str(&address)
+                .map_err(|_| StorageError::WrongNodeAddress(address))?;
+            nodes.insert(addr);
+        }
+        Ok(nodes)
     }
 
     /// Create a key from the namespace and the bytes
-    fn key(&self, bytes: Vec<u8>) -> Key {
-        Key {
-            namespace: Some(self.namespace),
-            bytes,
-        }
+    fn key(&self, key: Vec<u8>) -> Key {
+        Key::private(&self.namespace, key)
     }
 
     /// Set a value in the storage
     pub async fn set(&self, key: String, value: Vec<u8>) -> Result<(), StorageError> {
-        self.client
-            .set(self.key(key.as_bytes().into()), value, self.calculate_ttl())
+        self.driver
+            .set(Entry::new(
+                self.key(key.as_bytes().into()),
+                value,
+                RECORDS_TTL,
+            ))
             .await
-            .map_err(StorageError::IrnClientError)
+            .map_err(StorageError::WcnClientError)
     }
 
     /// Get a value from the storage
-    pub async fn get(&self, key: String) -> Result<Option<String>, StorageError> {
-        let result = self.client.get(self.key(key.as_bytes().into())).await;
+    pub async fn get(&self, key: String) -> Result<Option<Vec<u8>>, StorageError> {
+        let result = self.driver.get(self.key(key.as_bytes().into())).await;
 
         match result {
-            Ok(Some(data)) => match String::from_utf8(data) {
-                Ok(string) => Ok(Some(string)),
-                Err(e) => Err(StorageError::Utf8Error(e)),
-            },
+            Ok(Some(record)) => Ok(Some(record.value)),
             Ok(None) => Ok(None),
             Err(e) => Err(e.into()),
         }
@@ -143,10 +139,10 @@ impl Irn {
 
     /// Delete a value from the storage
     pub async fn delete(&self, key: String) -> Result<(), StorageError> {
-        self.client
+        self.driver
             .del(self.key(key.as_bytes().into()))
             .await
-            .map_err(StorageError::IrnClientError)
+            .map_err(StorageError::WcnClientError)
     }
 
     /// Set the hasmap value in the storage
@@ -156,29 +152,26 @@ impl Irn {
         field: String,
         value: Vec<u8>,
     ) -> Result<(), StorageError> {
-        self.client
-            .hset(
-                self.key(key.as_bytes().into()),
-                field.as_bytes().into(),
+        self.driver
+            .hset(MapEntry::new(
+                self.key(key.as_bytes().to_vec()),
+                field.as_bytes(),
                 value,
-                self.calculate_ttl(),
-            )
+                RECORDS_TTL,
+            ))
             .await
-            .map_err(StorageError::IrnClientError)
+            .map_err(StorageError::WcnClientError)
     }
 
     /// Get the hashmap value from the storage
-    pub async fn hget(&self, key: String, field: String) -> Result<Option<String>, StorageError> {
+    pub async fn hget(&self, key: String, field: String) -> Result<Option<Vec<u8>>, StorageError> {
         let result = self
-            .client
+            .driver
             .hget(self.key(key.as_bytes().into()), field.as_bytes().into())
             .await;
 
         match result {
-            Ok(Some(data)) => match String::from_utf8(data) {
-                Ok(string) => Ok(Some(string)),
-                Err(e) => Err(StorageError::Utf8Error(e)),
-            },
+            Ok(Some(record)) => Ok(Some(record.value)),
             Ok(None) => Ok(None),
             Err(e) => Err(e.into()),
         }
@@ -186,68 +179,59 @@ impl Irn {
 
     /// Delete the hashmap value from the storage
     pub async fn hdel(&self, key: String, field: String) -> Result<(), StorageError> {
-        self.client
+        self.driver
             .hdel(self.key(key.as_bytes().into()), field.as_bytes().into())
             .await
-            .map_err(StorageError::IrnClientError)
+            .map_err(StorageError::WcnClientError)
     }
 
-    /// Get all the hashmap fields from the storage
-    pub async fn hfields(&self, key: String) -> Result<Vec<String>, StorageError> {
-        let result = self.client.hfields(self.key(key.as_bytes().into())).await?;
-        let fields = result
-            .into_iter()
-            .map(String::from_utf8)
-            .collect::<Result<Vec<String>, _>>()?;
-        Ok(fields)
-    }
+    /// Get all the hashmap ((field, value) cursor) from the storage
+    pub async fn hscan(
+        &self,
+        key: String,
+        count: u32,
+        cursor: Option<Vec<u8>>,
+    ) -> Result<(Vec<(String, Vec<u8>)>, Option<Vec<u8>>), StorageError> {
+        let result = self
+            .driver
+            .hscan(self.key(key.as_bytes().into()), count, cursor)
+            .await
+            .map(|resp| {
+                let cursor = resp.next_page_cursor().cloned();
+                let records = resp.records.into_iter().map(|rec| (rec.field, rec.value));
 
-    /// Get all the hashmap values from the storage
-    pub async fn hvals(&self, key: String) -> Result<Vec<String>, StorageError> {
-        let result = self.client.hvals(self.key(key.as_bytes().into())).await?;
-        let fields = result
-            .into_iter()
-            .map(String::from_utf8)
-            .collect::<Result<Vec<String>, _>>()?;
-        Ok(fields)
+                (records, cursor)
+            })
+            .map_err(StorageError::WcnClientError)?;
+
+        let (records, next_cursor) = result;
+        let fields_values = records
+            .map(|(field_bytes, value_bytes)| {
+                let field_string =
+                    String::from_utf8(field_bytes).map_err(StorageError::Utf8Error)?;
+                Ok((field_string, value_bytes))
+            })
+            .collect::<Result<Vec<(String, Vec<u8>)>, StorageError>>()?;
+
+        Ok((fields_values, next_cursor))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    #[tokio::test]
-    async fn test_irn_client_calculate_ttl() {
-        let irn = Irn::new(
-            "127.0.0.1:1".into(),
-            "2SjlbfXx6md6337H63KjOEFlv4XP5g2dl7Qam6ot84o=".into(),
-            "test_namespace".into(),
-            "namespace_secret".into(),
-        )
-        .unwrap();
-
-        let ttl = irn.calculate_ttl();
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
-
-        assert!(ttl > now);
-        assert_eq!(ttl, now + RECORDS_TTL.as_secs());
-    }
 
     /// Ignoring this test by default to use it for local cluster testing only
     #[ignore]
     #[tokio::test]
     async fn test_irn_client_set_get_del() {
         let irn = Irn::new(
-            "127.0.0.1:3011".into(),
             "2SjlbfXx6md6337H63KjOEFlv4XP5g2dl7Qam6ot84o=".into(),
+            vec!["/ip4/127.0.0.1/udp/3011/quic-v1".into()],
             "test_namespace".into(),
             "namespace_secret".into(),
         )
+        .await
         .unwrap();
 
         let key = "test_key".to_string();
@@ -256,7 +240,7 @@ mod tests {
 
         // Get the value from the correct key
         let result = irn.get(key.clone()).await.unwrap().unwrap();
-        assert_eq!(value, result.into_bytes());
+        assert_eq!(value, result);
 
         // Get the value from the wrong key
         let result = irn.get("wrong_key".into()).await.unwrap();
@@ -275,11 +259,12 @@ mod tests {
     #[tokio::test]
     async fn test_irn_client_hashmap() {
         let irn = Irn::new(
-            "127.0.0.1:3011".into(),
             "2SjlbfXx6md6337H63KjOEFlv4XP5g2dl7Qam6ot84o=".into(),
+            vec!["/ip4/127.0.0.1/udp/3011/quic-v1".into()],
             "test_namespace".into(),
             "namespace_secret".into(),
         )
+        .await
         .unwrap();
 
         let key = "test_key".to_string();
@@ -291,27 +276,20 @@ mod tests {
             .await
             .unwrap();
         let result = irn.hget(key.clone(), field.clone()).await.unwrap().unwrap();
-        assert_eq!(value, result.into_bytes());
+        assert_eq!(value, result);
 
-        // Get hasmap fields list
-        let fields = irn.hfields(key.clone()).await.unwrap();
-        assert_eq!(vec![field.clone()], fields);
-
-        // Get hasmap values list
-        let values = irn.hvals(key.clone()).await.unwrap();
+        // Get hashmap scan list
+        let (fields_values, _) = irn.hscan(key.clone(), 5, None).await.unwrap();
         assert_eq!(
-            vec![value.clone()],
-            values
-                .iter()
-                .map(|v| v.clone().into_bytes())
-                .collect::<Vec<Vec<u8>>>()
+            (field.clone(), value),
+            fields_values.first().unwrap().clone()
         );
 
         // Delete the hashmap field
         irn.hdel(key.clone(), field.clone()).await.unwrap();
         let result = irn.hget(key.clone(), field.clone()).await.unwrap();
         assert_eq!(None, result);
-        let fields = irn.hfields(key.clone()).await.unwrap();
-        assert_eq!(Vec::<String>::new(), fields);
+        let (fields_values, _) = irn.hscan(key.clone(), 5, None).await.unwrap();
+        assert_eq!(Vec::<(String, Vec<u8>)>::new(), fields_values);
     }
 }

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -127,7 +127,7 @@ resource "aws_ecs_task_definition" "app_task" {
 
         { name = "RPC_PROXY_POSTGRES_URI", value = var.postgres_url },
 
-        { name = "RPC_PROXY_IRN_NODE", value = var.irn_node },
+        { name = "RPC_PROXY_IRN_NODES", value = var.irn_nodes },
         { name = "RPC_PROXY_IRN_KEY", value = var.irn_key },
         { name = "RPC_PROXY_IRN_NAMESPACE", value = var.irn_namespace },
         { name = "RPC_PROXY_IRN_NAMESPACE_SECRET", value = var.irn_namespace_secret },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -395,8 +395,8 @@ variable "rate_limiting_ip_whitelist" {
 #-------------------------------------------------------------------------------
 # IRN client configuration
 
-variable "irn_node" {
-  description = "IRN node address in Address:Socket format"
+variable "irn_nodes" {
+  description = "Comma-separated IRN nodes address in MultiAddr format"
   type        = string
 }
 

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -93,7 +93,7 @@ module "ecs" {
   rate_limiting_ip_whitelist    = var.rate_limiting_ip_whitelist
 
   # IRN Client
-  irn_node             = var.irn_node
+  irn_nodes            = var.irn_nodes
   irn_key              = var.irn_key
   irn_namespace        = var.irn_namespace
   irn_namespace_secret = var.irn_namespace_secret

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -263,8 +263,8 @@ variable "irn_aws_account_id" {
 #-------------------------------------------------------------------------------
 # IRN client configuration
 
-variable "irn_node" {
-  description = "IRN node address in Address:Socket format"
+variable "irn_nodes" {
+  description = "Comma-separated IRN nodes address in MultiAddr format"
   type        = string
 }
 


### PR DESCRIPTION
# Description

This PR updates the IRN client to the latest `wcn_replication`, switching to the mainnet. 
Internal methods were refactored to use `Strings` as keys and `Bytes (Vec<u8>)` as values to be in sync with the client. 
We are using the Serde serialization for the values data. Hence, it makes sense to serialize/deserialize directly to bytes instead of strings. `hfields` method was refactored to be `hscan` that returns a vector of tuples with `(field_name, value)` pairs.
The IRN node environment variable was updated to be `nodes` including a list of WCN nodes in a MultiAddr format.

## How Has This Been Tested?

* Tested on the local IRN cluster using `test_irn_client_set_get_del()` and `test_irn_client_hashmap()` cargo tests which are included in the implementation.

<!-- If valid for smoke test on feature add screenshots -->

## Merging policy 🚧

* [x] Update TFC `irn_nodes` with actual nodes list,
* [x] Add PeerID to allow-list to connect to nodes.
