### PR TITLE
feat(CA): adding cached bridging transaction gas estimation

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1019,17 +1019,17 @@ pub trait SimulationProvider: Send + Sync {
         metrics: Arc<Metrics>,
     ) -> Result<tenderly::SimulationResponse, RpcError>;
 
-    /// Get the cached gas estimation for ERC20 transfer
+    /// Get the cached gas estimation
     /// for the token contract and chain_id
-    async fn get_cached_erc20_gas_estimation(
+    async fn get_cached_gas_estimation(
         &self,
         chain_id: &str,
         contract_address: Address,
     ) -> Result<Option<u64>, RpcError>;
 
     /// Save to the cahce the gas estimation
-    /// for ERC20 transfer for the token contract and chain_id
-    async fn set_cached_erc20_gas_estimation(
+    /// for the token contract and chain_id
+    async fn set_cached_gas_estimation(
         &self,
         chain_id: &str,
         contract_address: Address,


### PR DESCRIPTION
# Description

This PR adds the gas estimation for the bridging transaction by using the transaction simulation provider instead of the hardcoded value.

* The gas estimation is cached using the chainId and destination address composite key.
* The slippage for the estimated gas (to cover gas spikes between cache invalidation) is raised from 3% to 10%.
* The caching TTL is decreased from 24 hours to 4 hours for all gas caching (including ERC20 transfers) to cover gas spikes.

## How Has This Been Tested?

* Manually tested and partly covered by the current CA integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
