### PR TITLE
feat(supported-chains): adding cache-control header

### DIFF
--- a/src/handlers/supported_chains.rs
+++ b/src/handlers/supported_chains.rs
@@ -1,20 +1,33 @@
 use {
     super::HANDLER_TASK_METRICS,
-    crate::{error::RpcError, providers::SupportedChains, state::AppState},
-    axum::{extract::State, Json},
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::State,
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::header::CACHE_CONTROL,
     std::sync::Arc,
     wc::future::FutureExt,
 };
 
-pub async fn handler(state: State<Arc<AppState>>) -> Result<Json<SupportedChains>, RpcError> {
+pub async fn handler(state: State<Arc<AppState>>) -> Result<Response, RpcError> {
     handler_internal(state)
         .with_metrics(HANDLER_TASK_METRICS.with_name("supported_chains"))
         .await
 }
 
 #[tracing::instrument(skip_all, level = "debug")]
-async fn handler_internal(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<SupportedChains>, RpcError> {
-    Ok(Json(state.providers.rpc_supported_chains.clone()))
+async fn handler_internal(State(state): State<Arc<AppState>>) -> Result<Response, RpcError> {
+    // Set cache control headers to 24 hours
+    let ttl_secs = 24 * 60 * 60;
+
+    Ok((
+        [(
+            CACHE_CONTROL,
+            format!("public, max-age={ttl_secs}, s-maxage={ttl_secs}"),
+        )],
+        Json(state.providers.rpc_supported_chains.clone()),
+    )
+        .into_response())
 }


### PR DESCRIPTION
# Description

This PR adds the cache-control header for the supported-chains endpoint for the 24-hour max-age.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
