### PR TITLE
feat(IRN): removing Irn VPC peering

### DIFF
--- a/terraform/res_network.tf
+++ b/terraform/res_network.tf
@@ -38,20 +38,6 @@ module "vpc" {
   vpc_flow_log_tags         = module.this.tags
 }
 
-resource "aws_vpc_peering_connection" "irn" {
-  vpc_id        = module.vpc.vpc_id
-  peer_vpc_id   = var.irn_vpc_id
-  peer_owner_id = var.irn_aws_account_id
-}
-
-resource "aws_route" "irn" {
-  count = length(module.vpc.private_route_table_ids)
-
-  route_table_id            = module.vpc.private_route_table_ids[count.index]
-  vpc_peering_connection_id = aws_vpc_peering_connection.irn.id
-  destination_cidr_block    = var.irn_vpc_cidr
-}
-
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "5.1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -243,24 +243,6 @@ variable "rate_limiting_ip_whitelist" {
 }
 
 #-------------------------------------------------------------------------------
-# IRN VPC peering
-
-variable "irn_vpc_id" {
-  description = "ID of the IRN VPC"
-  type        = string
-}
-
-variable "irn_vpc_cidr" {
-  description = "CIDR block of the IRN VPC"
-  type        = string
-}
-
-variable "irn_aws_account_id" {
-  description = "ID of the AWS account in IRN is being deployed"
-  type        = string
-}
-
-#-------------------------------------------------------------------------------
 # IRN client configuration
 
 variable "irn_nodes" {


### PR DESCRIPTION
# Description

This PR removes IRN VPC peering, since the IRN/WCN nodes are currently in a public network.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
