### PR TITLE
feat(CA): increasing gas estimation slippage and decreasing the cache TTL

### DIFF
--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -52,7 +52,7 @@ use {
 const DEFAULT_GAS: i64 = 0x029a6b * 0x9;
 
 // Slippage for the gas estimation
-const ESTIMATED_GAS_SLIPPAGE: i8 = 50;
+const ESTIMATED_GAS_SLIPPAGE: i8 = 100; // 100%, x2 slippage to cover the volatility
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -16,7 +16,7 @@ use {
 };
 
 /// Gas estimation caching TTL paramters
-const GAS_ESTIMATE_CACHE_TTL: u64 = 60 * 60 * 4; // 4 hours
+const GAS_ESTIMATE_CACHE_TTL: u64 = 60 * 60 * 2; // 2 hours
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SimulationRequest {


### PR DESCRIPTION
# Description

This PR increasing the gas estimation slippage from 50% to 100% (x2) and decreasing the cache TTL from 4 hours to 2 hours to cover the high volatility.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
