### PR TITLE
feat(CA): adding cached gas estimation for the approval transaction

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -23,7 +23,7 @@ use {
             RpcQueryParams, SupportedCurrencies,
         },
         storage::KeyValueStorage,
-        utils::crypto::CaipNamespaces,
+        utils::crypto::{CaipNamespaces, Erc20FunctionType},
         Metrics,
     },
     alloy::{
@@ -1032,6 +1032,7 @@ pub trait SimulationProvider: Send + Sync {
         &self,
         chain_id: &str,
         contract_address: Address,
+        function_type: Option<Erc20FunctionType>,
     ) -> Result<Option<u64>, RpcError>;
 
     /// Save to the cahce the gas estimation
@@ -1040,6 +1041,7 @@ pub trait SimulationProvider: Send + Sync {
         &self,
         chain_id: &str,
         contract_address: Address,
+        function_type: Option<Erc20FunctionType>,
         gas: u64,
     ) -> Result<(), RpcError>;
 }


### PR DESCRIPTION
# Description

This PR adds gas estimation for the approval transaction using the `eth_estimateGas` RPC call and caches the result to reuse it. The gas set/get cache method was extended to use the ERC20 function as an additional optional key parameter since the ERC20 `transfer` gas estimate and ERC20 `approval` functions will have different gas estimations but the same contract address.

## How Has This Been Tested?

* Current integration test: schema check only.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
