### PR TITLE
fix(Bungee): making bridging route errors optional

### DIFF
--- a/src/providers/bungee.rs
+++ b/src/providers/bungee.rs
@@ -25,7 +25,7 @@ pub struct BungeeResponse<T> {
 #[serde(rename_all = "camelCase")]
 pub struct BungeeQuotes {
     pub routes: Vec<Value>,
-    pub bridge_route_errors: Value,
+    pub bridge_route_errors: Option<Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
# Description

This PR makes the `bridge_route_errors` response field optional, since it's absent in some responses that cause the deserialization errors.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
