### PR TITLE
fix(CA): temporary disabling the cached gas estimation

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -301,7 +301,9 @@ impl ProviderRepository {
             config.tenderly_api_key.clone(),
             config.tenderly_account_id.clone(),
             config.tenderly_project_id.clone(),
-            redis_pool.clone(),
+            // Todo: Temporary disabling the gas estimation caching
+            // redis_pool.clone(),
+            None,
         ));
 
         Self {


### PR DESCRIPTION
# Description

This PR disables the cache for the gas estimation until we have a data for the appropriate TTL and slippage tuning.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
