### PR TITLE
fix(CA): using the bundled simulation for allowance and bridging transactions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -247,6 +247,12 @@ pub enum RpcError {
 
     #[error("Bridging final amount is less then expected")]
     BridgingFinalAmountLess,
+
+    #[error("Simulation provider unavailable")]
+    SimulationProviderUnavailable,
+
+    #[error("Simulation failed: {0}")]
+    SimulationFailed(String),
 }
 
 impl IntoResponse for RpcError {
@@ -620,6 +626,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response(
                     "".to_string(),
                     "Convertion provider is temporarily unavailable".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::SimulationProviderUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Simulation provider is temporarily unavailable".to_string(),
                 )),
             )
                 .into_response(),

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -287,12 +287,13 @@ pub async fn get_assets_changes_from_simulation(
     {
         if asset_changed.asset_type.clone() == AssetChangeType::Transfer
             && asset_changed.token_info.standard.clone() == TokenStandard::Erc20
+            && asset_changed.to.is_some()
         {
             asset_changes.push(Erc20AssetChange {
                 chain_id: transaction.chain_id.clone(),
                 asset_contract: asset_changed.token_info.contract_address,
                 amount: asset_changed.raw_amount,
-                receiver: asset_changed.to,
+                receiver: asset_changed.to.unwrap_or_default(),
             })
         }
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -47,6 +47,7 @@ use {
     },
     tracing::{debug, error, log::warn},
     wc::metrics::TaskMetrics,
+    yttrium::chain_abstraction::api::Transaction,
 };
 
 mod arbitrum;
@@ -1027,6 +1028,13 @@ pub trait SimulationProvider: Send + Sync {
         state_overrides: HashMap<Address, HashMap<B256, B256>>,
         metrics: Arc<Metrics>,
     ) -> Result<tenderly::SimulationResponse, RpcError>;
+
+    async fn simulate_bundled_transactions(
+        &self,
+        transactions: Vec<Transaction>,
+        state_overrides: HashMap<Address, HashMap<B256, B256>>,
+        metrics: Arc<Metrics>,
+    ) -> Result<tenderly::BundledSimulationResponse, RpcError>;
 
     /// Get the cached gas estimation
     /// for the token contract and chain_id


### PR DESCRIPTION
# Description

This PR changes the approach of the gas estimation from using the `eth_estimateGas` for the approval transaction and simulation for the bridging transaction to the bundled simulation for the approval and bridging transaction together.

The following changes were made:
* The bundled simulation provider trait was added and the implementation for the Tenderly provider;
* Flow of the estimation changed to simulate both transactions in a bundle;
* The proper check for the transaction simulation failure was added;
* The proper error handling for the simulation provider error and the simulation failure added;
* The estimated gas slippage decreased to 20% to cover the volatility between the estimation and the transaction execution.

## How Has This Been Tested?

The current integration test for the gas estimation shouldn't be zero which is the default if the simulation was not fulfilled.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
