### PR TITLE
fix(CA): proper bridging fee calculation

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -33,8 +33,6 @@ describe('Chain abstraction orchestrator', () => {
 
   // Amount to send to Optimism
   const amount_to_send = 3_000_000
-  // Amount bridging slippage
-  const amount_slippage = 2; // +2% topup
   
   let usdc_contracts = {};
   usdc_contracts[chain_id_optimism] = "0x0b2c639c533813f4aa9d7837caf62653d097ff85";
@@ -133,7 +131,6 @@ describe('Chain abstraction orchestrator', () => {
 
     // How much needs to be topped up
     const amount_to_topup = Math.round(amount_to_send - usdc_funds[chain_id_optimism]);
-    const amount_to_topup_with_fees = Math.round(((amount_to_topup * amount_slippage) / 100) + amount_to_topup);
 
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
@@ -167,7 +164,7 @@ describe('Chain abstraction orchestrator', () => {
     expect(approvalTransaction.nonce).not.toBe("0x00")
     expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
     const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
-    if (decodedData.amount < BigInt(amount_to_topup_with_fees)) {
+    if (decodedData.amount <= BigInt(amount_to_topup)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }
 
@@ -188,10 +185,10 @@ describe('Chain abstraction orchestrator', () => {
     expect(fundingFrom.chainId).toBe(chain_id_base)
     expect(fundingFrom.symbol).toBe(usdc_token_symbol)
     expect(fundingFrom.tokenContract).toBe(usdc_contracts[chain_id_base].toLowerCase())
-    if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup_with_fees)) {
+    if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }
-    if (BigInt(fundingFrom.bridgingFee) != BigInt(fundingFrom.amount - amount_to_topup)){
+    if (BigInt(fundingFrom.bridgingFee) < BigInt(fundingFrom.amount - amount_to_topup)){
       throw new Error(`Expected bridging fee is incorrect. `);
     }
     // Check the initialTransaction metadata
@@ -212,7 +209,6 @@ describe('Chain abstraction orchestrator', () => {
 
     // How much needs to be topped up
     const amount_to_topup = Math.round(amount_to_send - usdt_funds[chain_id_optimism]);
-    const amount_to_topup_with_fees = Math.round(((amount_to_topup * amount_slippage) / 100) + amount_to_topup);
 
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
@@ -246,7 +242,7 @@ describe('Chain abstraction orchestrator', () => {
     expect(approvalTransaction.nonce).not.toBe("0x00")
     expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
     const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
-    if (decodedData.amount < BigInt(amount_to_topup_with_fees)) {
+    if (decodedData.amount <= BigInt(amount_to_topup)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }
 
@@ -267,10 +263,10 @@ describe('Chain abstraction orchestrator', () => {
     expect(fundingFrom.chainId).toBe(chain_id_arbitrum)
     expect(fundingFrom.symbol).toBe(usdt_token_symbol)
     expect(fundingFrom.tokenContract).toBe(usdt_contracts[chain_id_arbitrum].toLowerCase())
-    if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup_with_fees)) {
+    if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup)) {
       throw new Error(`Expected amount is lower then the minimal required`);
     }
-    if (BigInt(fundingFrom.bridgingFee) != BigInt(fundingFrom.amount - amount_to_topup)){
+    if (BigInt(fundingFrom.bridgingFee) < BigInt(fundingFrom.amount - amount_to_topup)){
       throw new Error(`Expected bridging fee is incorrect. `);
     }
     // Check the initialTransaction metadata

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -22,8 +22,8 @@ pub mod assets;
 pub mod route;
 pub mod status;
 
-/// How much to multiply the amount by when bridging to cover bridging differences
-pub const BRIDGING_AMOUNT_SLIPPAGE: i8 = 50; // 50%
+/// How much to multiply the bridging fee amount to cover bridging fee volatility
+pub const BRIDGING_FEE_SLIPPAGE: i8 = 50; // 50%
 
 /// Bridging timeout in seconds
 pub const BRIDGING_TIMEOUT: u64 = 1800; // 30 minutes


### PR DESCRIPTION
# Description

This PR fixes the following bugs when calculating the bridging fee:
* The 50% slippage was applied to the top-up amount itself instead of the bridging fee only. We are applying the slippage to the bridging fee to cover the volatility between getting the route and the execution.
* The metadata bridging fee was calculated using the top-up amount from the first routes request instead of the final top-up amount (required top-up amount + bridging fee * slippage), which resulted in the higher fee in the UI than was exactly used.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
