### PR TITLE
feat(CA): temporarily increasing the gas slippage

### DIFF
--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -49,7 +49,7 @@ use {
 };
 
 // Slippage for the gas estimation
-const ESTIMATED_GAS_SLIPPAGE: i8 = 20; // 20% slippage to cover the volatility
+const ESTIMATED_GAS_SLIPPAGE: i16 = 500; // x5 slippage to cover the volatility
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
# Description

This PR temporarily increases the estimated gas slippage to x5 to pass ethe xecution of transactions.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
