### PR TITLE
feat(CA): using the gas estimation from the `gas` field

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -265,7 +265,7 @@ pub async fn get_assets_changes_from_simulation(
             metrics,
         )
         .await?;
-    let gas_used = simulation_result.transaction.gas_used;
+    let gas_used = simulation_result.transaction.gas;
 
     if simulation_result
         .transaction

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -49,7 +49,7 @@ use {
 };
 
 // Slippage for the gas estimation
-const ESTIMATED_GAS_SLIPPAGE: i16 = 500; // x5 slippage to cover the volatility
+const ESTIMATED_GAS_SLIPPAGE: i16 = 500; // Temporarily x5 slippage to cover the volatility
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -456,7 +456,7 @@ async fn handler_internal(
         }
 
         routes[index].gas_limit = U64::from(
-            (simulation_result.transaction.gas_used * (100 + ESTIMATED_GAS_SLIPPAGE as u64)) / 100,
+            (simulation_result.transaction.gas * (100 + ESTIMATED_GAS_SLIPPAGE as u64)) / 100,
         );
     }
 

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -53,7 +53,7 @@ pub struct BundledSimulationResponse {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ResponseTransaction {
     pub hash: String,
-    pub gas_used: u64,
+    pub gas: u64,
     pub transaction_info: ResponseTransactionInfo,
     pub status: bool, // Was simulating transaction successful
     pub nonce: u64,


### PR DESCRIPTION
# Description

This PR changes to use the `gas` field for the simulation gas estimation.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
