### PR TITLE
fix(providers): removing Solana from DRPC

### DIFF
--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -34,14 +34,6 @@ impl ProviderConfig for DrpcConfig {
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
-    HashMap::from([
-        // Solana Mainnet
-        (
-            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into(),
-            (
-                "https://solana.drpc.org/".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
-    ])
+    // TODO: Add EVM only chains
+    HashMap::new()
 }

--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -34,6 +34,70 @@ impl ProviderConfig for DrpcConfig {
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
-    // TODO: Add EVM only chains
-    HashMap::new()
+    HashMap::from([
+        // Ethereum Mainnet
+        (
+            "eip155:1".into(),
+            (
+                "https://eth.drpc.org/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Ethereum Sepolia
+        (
+            "eip155:11155111".into(),
+            (
+                "https://sepolia.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Ethereum Holesky
+        (
+            "eip155:17000".into(),
+            (
+                "https://holesky.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Arbitrum One
+        (
+            "eip155:42161".into(),
+            (
+                "https://arbitrum.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Base
+        (
+            "eip155:8453".into(),
+            (
+                "https://base.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // BSC
+        (
+            "eip155:56".into(),
+            (
+                "https://bsc.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Polygon
+        (
+            "eip155:137".into(),
+            (
+                "https://polygon.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Optimism
+        (
+            "eip155:10".into(),
+            (
+                "https://optimism.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
 }

--- a/tests/functional/http/drpc.rs
+++ b/tests/functional/http/drpc.rs
@@ -1,19 +1,63 @@
 use {
-    super::check_if_rpc_is_responding_correctly_for_solana, crate::context::ServerContext,
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
     rpc_proxy::providers::ProviderKind, test_context::test_context,
 };
 
 #[test_context(ServerContext)]
 #[tokio::test]
 #[ignore]
-async fn drpc_provider_solana(ctx: &mut ServerContext) {
+async fn drpc_provider_evm(ctx: &mut ServerContext) {
     let provider = ProviderKind::Drpc;
 
-    // Solana mainnet
-    check_if_rpc_is_responding_correctly_for_solana(
+    // Ethereum Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:1", "0x1")
+        .await;
+
+    // Ethereum Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
-        "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
         &provider,
+        "eip155:11155111",
+        "0xaa36a7",
     )
     .await;
+
+    // Ethereum Holesky
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:17000",
+        "0x4268",
+    )
+    .await;
+
+    // Arbitrum One
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:42161",
+        "0xa4b1",
+    )
+    .await;
+
+    // Base
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:8453",
+        "0x2105",
+    )
+    .await;
+
+    // BSC
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:56", "0x38")
+        .await;
+
+    // Polygon Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
+        .await;
+
+    // Optimism Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
+        .await;
 }


### PR DESCRIPTION
# Description

This PR removes Solana support from the DRPC provider, because of the `solana is not supported on freetier` message response.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
