### PR TITLE
fix(CA): comparing simulated transaction by the input

### DIFF
--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -363,7 +363,7 @@ async fn handler_internal(
         );
         return Err(RpcError::BridgingFinalAmountLess);
     }
-    let final_bridging_fee = bridging_amount - required_topup_amount;
+    let final_bridging_fee = required_topup_amount - bridging_amount;
 
     // Build bridging transaction
     let bridge_tx = state

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -447,10 +447,13 @@ async fn handler_internal(
         .simulate_bundled_transactions(routes.clone(), HashMap::new(), state.metrics.clone())
         .await?;
     for (index, simulation_result) in simulation_results.simulation_results.iter().enumerate() {
-        // Making sure the nonce matches the transaction nonce
-        if U64::from(simulation_result.transaction.nonce) != routes[index].nonce {
+        // Making sure the simulation input matches the transaction input
+        let curr_route = routes.get(index).ok_or_else(|| {
+            RpcError::SimulationFailed("The route index is out of bounds".to_string())
+        })?;
+        if simulation_result.transaction.input != curr_route.input {
             return Err(RpcError::SimulationFailed(
-                "The nonce for the simulation result does not match the nonce for the transaction"
+                "The input for the simulation result does not match the input for the transaction"
                     .into(),
             ));
         }

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -56,7 +56,7 @@ pub struct ResponseTransaction {
     pub gas: u64,
     pub transaction_info: ResponseTransactionInfo,
     pub status: bool, // Was simulating transaction successful
-    pub nonce: u64,
+    pub input: Bytes,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -93,6 +93,7 @@ pub struct TokenInfo {
 pub enum TokenStandard {
     Erc20,
     Erc721,
+    NativeCurrency,
 }
 
 pub struct TenderlyProvider {


### PR DESCRIPTION
# Description

This PR changes the simulated bridging transactions comparison by the data input instead of by the nonce, since this causes an error on the correct transaction because of the different nonce getting parameters are used in our implementation and in the Tenderly. It's much safer to check transactions using input data.

## How Has This Been Tested?

Manually tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
