### PR TITLE
feat(o11y): implementing metrics and Grafana panels for chain abstraction

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -192,6 +192,12 @@ dashboard.new(
   row.new('Account names (ENS gateway) Metrics'),
     panels.names.registered(ds, vars)                { gridPos: pos_short._3 },
 
+  row.new('Chain Abstraction'),
+    panels.chain_abstraction.gas_estimation(ds, vars)     { gridPos: pos_short._4 },
+    panels.chain_abstraction.insufficient_funds(ds, vars) { gridPos: pos_short._4 },
+    panels.chain_abstraction.no_bridging(ds, vars)        { gridPos: pos_short._4 },
+    panels.chain_abstraction.no_routes(ds, vars)          { gridPos: pos_short._4 },
+
   row.new('Redis'),
     panels.redis.cpu(ds, vars)                    { gridPos: pos._2 },
     panels.redis.memory(ds, vars)                 { gridPos: pos._2 },

--- a/terraform/monitoring/panels/chain_abstraction/gas_estimation.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/gas_estimation.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Gas estimations',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(chain_id) (rate(gas_estimation_sum[$__rate_interval])) / sum by(chain_id) (rate(gas_estimation_count[$__rate_interval]))',
+      legendFormat  = 'Gas estimation',
+    ))
+}

--- a/terraform/monitoring/panels/chain_abstraction/insufficient_funds.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/insufficient_funds.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Insufficient funds responses',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(increase(ca_insufficient_funds_total{}[$__rate_interval]))',
+      legendFormat  = 'Insufficient funds responses counter',
+    ))
+}

--- a/terraform/monitoring/panels/chain_abstraction/no_bridging.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/no_bridging.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'No bridging needed responses',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(type) (increase(ca_no_bridging_needed_total{}[$__rate_interval]))',
+      legendFormat  = 'No bridging needed responses counter',
+    ))
+}

--- a/terraform/monitoring/panels/chain_abstraction/no_routes.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/no_routes.libsonnet
@@ -1,0 +1,19 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'No bridging routes found',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(route) (increase(ca_no_routes_found_total{}[$__rate_interval]))',
+      legendFormat  = 'No routes responses counter',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -90,4 +90,11 @@ local redis  = panels.aws.redis;
     endpoints_latency: (import 'non_rpc/endpoints_latency.libsonnet').new,
     cache_latency: (import 'non_rpc/cache_latency.libsonnet').new,
   },
+
+  chain_abstraction: {
+    gas_estimation: (import 'chain_abstraction/gas_estimation.libsonnet').new,
+    insufficient_funds: (import 'chain_abstraction/insufficient_funds.libsonnet').new,
+    no_bridging: (import 'chain_abstraction/no_bridging.libsonnet').new,
+    no_routes: (import 'chain_abstraction/no_routes.libsonnet').new,
+  },
 }


### PR DESCRIPTION
# Description

This PR implements metrics and Grafana o11y panels for the Chain Abstraction.

The following metrics and panels were created:
* Gas estimation histogram with by chain observability panel,
* `Insufficient funds` responses counter and observability panel,
* `No bridging needed` responses counter with by type observability panel,
* `No routes found` responses counter with by route observability panel.

When we get some data to make alert threshold adjustments, appropriate alerts will be added.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
