### PR TITLE
fix(o11y): fixing lables for chain abstraction Grafana panels

### DIFF
--- a/terraform/monitoring/panels/chain_abstraction/gas_estimation.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/gas_estimation.libsonnet
@@ -10,10 +10,14 @@ local targets   = grafana.targets;
       title       = 'Gas estimations',
       datasource  = ds.prometheus,
     )
-    .configure(defaults.configuration.timeseries)
+    .configure(
+      defaults.configuration.timeseries
+      .withSpanNulls(true)
+    )
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'sum by(chain_id) (rate(gas_estimation_sum[$__rate_interval])) / sum by(chain_id) (rate(gas_estimation_count[$__rate_interval]))',
-      legendFormat  = 'Gas estimation',
+      exemplar      = false,
+      legendFormat  = '__auto',
     ))
 }

--- a/terraform/monitoring/panels/chain_abstraction/insufficient_funds.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/insufficient_funds.libsonnet
@@ -14,6 +14,7 @@ local targets   = grafana.targets;
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'sum(increase(ca_insufficient_funds_total{}[$__rate_interval]))',
+      exemplar      = false,
       legendFormat  = 'Insufficient funds responses counter',
     ))
 }

--- a/terraform/monitoring/panels/chain_abstraction/no_bridging.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/no_bridging.libsonnet
@@ -14,6 +14,7 @@ local targets   = grafana.targets;
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'sum by(type) (increase(ca_no_bridging_needed_total{}[$__rate_interval]))',
-      legendFormat  = 'No bridging needed responses counter',
+      exemplar      = false,
+      legendFormat  = '__auto',
     ))
 }

--- a/terraform/monitoring/panels/chain_abstraction/no_routes.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/no_routes.libsonnet
@@ -14,6 +14,7 @@ local targets   = grafana.targets;
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'sum by(route) (increase(ca_no_routes_found_total{}[$__rate_interval]))',
-      legendFormat  = 'No routes responses counter',
+      exemplar      = false,
+      legendFormat  = '__auto',
     ))
 }


### PR DESCRIPTION
# Description

This PR fixes labels for Chain Abstraction Grafana panels where `sum by` is used. We should display the group name instead of the hardcoded label for better observability.
Also, `exemplar` is set to `false` because we don't need context-rich samples in the output.

## How Has This Been Tested?

Tested by manually putting these parameters into the Grafana.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
