### PR TITLE
feat(providers): decrease SolScan and Zerion priority for the balance request

### DIFF
--- a/src/env/solscan.rs
+++ b/src/env/solscan.rs
@@ -32,8 +32,5 @@ impl BalanceProviderConfig for SolScanConfig {
 }
 
 fn default_supported_namespaces() -> HashMap<CaipNamespaces, Weight> {
-    HashMap::from([(
-        CaipNamespaces::Solana,
-        Weight::new(Priority::Normal).unwrap(),
-    )])
+    HashMap::from([(CaipNamespaces::Solana, Weight::new(Priority::Low).unwrap())])
 }

--- a/src/env/zerion.rs
+++ b/src/env/zerion.rs
@@ -33,8 +33,5 @@ impl BalanceProviderConfig for ZerionConfig {
 }
 
 fn default_supported_namespaces() -> HashMap<CaipNamespaces, Weight> {
-    HashMap::from([(
-        CaipNamespaces::Eip155,
-        Weight::new(Priority::Normal).unwrap(),
-    )])
+    HashMap::from([(CaipNamespaces::Eip155, Weight::new(Priority::Low).unwrap())])
 }


### PR DESCRIPTION
# Description

This PR decreases SolScan and Zerion's priority for the balance requests to route more traffic to other providers.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
