### PR TITLE
feat(balances): adding project IDs denylist

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -3,6 +3,7 @@ use {
         analytics::Config as AnalyticsConfig,
         database::config::PostgresConfig,
         error,
+        handlers::balance::Config as BalanceConfig,
         names::Config as NamesConfig,
         profiler::ProfilerConfig,
         project::{storage::Config as StorageConfig, Config as RegistryConfig},
@@ -66,6 +67,7 @@ pub struct Config {
     pub rate_limiting: RateLimitingConfig,
     pub irn: IrnConfig,
     pub names: NamesConfig,
+    pub balances: BalanceConfig,
 }
 
 impl Config {
@@ -81,6 +83,7 @@ impl Config {
             rate_limiting: from_env("RPC_PROXY_RATE_LIMITING_")?,
             irn: from_env("RPC_PROXY_IRN_")?,
             names: from_env("RPC_PROXY_NAMES_")?,
+            balances: from_env("RPC_PROXY_BALANCES_")?,
         })
     }
 }
@@ -108,6 +111,7 @@ mod test {
             analytics,
             database::config::PostgresConfig,
             env::{Config, ServerConfig},
+            handlers::balance::Config as BalanceConfig,
             names::Config as NamesConfig,
             profiler::ProfilerConfig,
             project,
@@ -229,6 +233,8 @@ mod test {
             ("RPC_PROXY_IRN_NAMESPACE_SECRET", "namespace"),
             // Names configuration
             ("RPC_PROXY_NAMES_ALLOWED_ZONES", "test1.id,test2.id"),
+            // Account balances-related configuration
+            ("RPC_PROXY_BALANCES_DENYLIST_PROJECT_IDS", "test_project_id"),
         ];
 
         values.iter().for_each(set_env_var);
@@ -323,7 +329,10 @@ mod test {
                 },
                 names: NamesConfig {
                     allowed_zones: Some(vec!["test1.id".to_owned(), "test2.id".to_owned()]),
-                }
+                },
+                balances: BalanceConfig {
+                    denylist_project_ids: Some(vec!["test_project_id".to_owned()]),
+                },
             }
         );
 

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -134,6 +134,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_IRN_NAMESPACE_SECRET", value = var.irn_namespace_secret },
 
         { name = "RPC_PROXY_NAMES_ALLOWED_ZONES", value = var.names_allowed_zones },
+        { name = "RPC_PROXY_BALANCES_DENYLIST_PROJECT_IDS", value = var.balances_denylist_project_ids },
 
         { name = "RPC_PROXY_ANALYTICS_EXPORT_BUCKET", value = var.analytics_datalake_bucket_name },
       ],

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -428,3 +428,10 @@ variable "names_allowed_zones" {
   description = "Comma separated list of allowed zones for names"
   type        = string
 }
+
+#-------------------------------------------------------------------------------
+# Address balances projects denylist
+variable "balances_denylist_project_ids" {
+  description = "Comma separated list of project IDs to denylist"
+  type        = string
+}

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -102,6 +102,9 @@ module "ecs" {
   # ENS Names
   names_allowed_zones = var.names_allowed_zones
 
+  # Address balances related configuration
+  balances_denylist_project_ids = var.balances_denylist_project_ids
+
   # Analytics
   analytics_datalake_bucket_name = data.terraform_remote_state.datalake.outputs.datalake_bucket_id
   analytics_datalake_kms_key_arn = data.terraform_remote_state.datalake.outputs.datalake_kms_key_arn

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -278,3 +278,10 @@ variable "names_allowed_zones" {
   description = "Comma separated list of allowed zones for names"
   type        = string
 }
+
+#-------------------------------------------------------------------------------
+# Address balances projects denylist
+variable "balances_denylist_project_ids" {
+  description = "Comma separated list of project IDs to denylist"
+  type        = string
+}


### PR DESCRIPTION
# Description

This PR implements a denylist for the address balance endpoint. Project IDs in the list will get an empty balance response without calling the balance provider. This will mitigate extensive usage for the endpoint in certain cases.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
