### PR TITLE
fix(providers): fixing a bug in weights distribution and tune weights for Dune

### DIFF
--- a/src/env/dune.rs
+++ b/src/env/dune.rs
@@ -34,13 +34,7 @@ impl BalanceProviderConfig for DuneConfig {
 
 fn default_supported_namespaces() -> HashMap<CaipNamespaces, Weight> {
     HashMap::from([
-        (
-            CaipNamespaces::Eip155,
-            Weight::new(Priority::Normal).unwrap(),
-        ),
-        (
-            CaipNamespaces::Solana,
-            Weight::new(Priority::Normal).unwrap(),
-        ),
+        (CaipNamespaces::Eip155, Weight::new(Priority::High).unwrap()),
+        (CaipNamespaces::Solana, Weight::new(Priority::High).unwrap()),
     ])
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -350,7 +350,7 @@ impl ProviderRepository {
         let weights: Vec<_> = providers
             .iter()
             .map(|(_, weight)| weight.value())
-            .map(|w| w.min(1))
+            .map(|w| w.max(1))
             .collect();
         let non_zero_weight_providers = weights.iter().filter(|&x| *x > 0).count();
         let keys = providers.keys().cloned().collect::<Vec<_>>();
@@ -416,7 +416,7 @@ impl ProviderRepository {
         let weights: Vec<_> = providers
             .iter()
             .map(|(_, weight)| weight.value())
-            .map(|w| w.min(1))
+            .map(|w| w.max(1))
             .collect();
         let non_zero_weight_providers = weights.iter().filter(|&x| *x > 0).count();
         let keys = providers.keys().cloned().collect::<Vec<_>>();


### PR DESCRIPTION
# Description

This PR fixed a bug in a weighted distribution algorithm where the weight was always `1` due to using of `min()` instead of `max()`.
Also, increasing the weights to `High` for the Dune provider.

## How Has This Been Tested?

Tested manually by echoing the weights and checking providers' distribution.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
