### PR TITLE
feat(providers): fune-tunning Zerion priority

### DIFF
--- a/src/env/zerion.rs
+++ b/src/env/zerion.rs
@@ -33,5 +33,8 @@ impl BalanceProviderConfig for ZerionConfig {
 }
 
 fn default_supported_namespaces() -> HashMap<CaipNamespaces, Weight> {
-    HashMap::from([(CaipNamespaces::Eip155, Weight::new(Priority::Low).unwrap())])
+    HashMap::from([(
+        CaipNamespaces::Eip155,
+        Weight::new(Priority::Custom(10)).unwrap(),
+    )])
 }


### PR DESCRIPTION
# Description

This PR fune-tunning Zerion provider priority to route 10% of the traffic.


## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
