### PR TITLE
feat(providers): routing more traffic to Allnodes

### DIFF
--- a/src/env/allnodes.rs
+++ b/src/env/allnodes.rs
@@ -40,7 +40,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum Mainnet
         (
             "eip155:1".into(),
-            ("eth30082".into(), Weight::new(Priority::High).unwrap()),
+            ("eth30082".into(), Weight::new(Priority::Max).unwrap()),
         ),
     ])
 }

--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -40,7 +40,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:1".into(),
             (
                 "https://eth.drpc.org/".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::Low).unwrap(),
             ),
         ),
         // Ethereum Sepolia

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -44,7 +44,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum
         (
             "eip155:1".into(),
-            ("mainnet".into(), Weight::new(Priority::Max).unwrap()),
+            ("mainnet".into(), Weight::new(Priority::Low).unwrap()),
         ),
         (
             "eip155:11155111".into(),

--- a/src/env/lava.rs
+++ b/src/env/lava.rs
@@ -40,7 +40,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum Mainnet
         (
             "eip155:1".into(),
-            ("eth".into(), Weight::new(Priority::Normal).unwrap()),
+            ("eth".into(), Weight::new(Priority::Low).unwrap()),
         ),
         // Ethereum Sepolia
         (

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -38,7 +38,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum mainnet
         (
             "eip155:1".into(),
-            ("ethereum-rpc".into(), Weight::new(Priority::High).unwrap()),
+            ("ethereum-rpc".into(), Weight::new(Priority::Low).unwrap()),
         ),
         // Ethereum Sepolia
         (

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -90,6 +90,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Drpc')          { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Odyssey')       { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Syndica')       { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Allnodes')      { gridPos: pos._4 },
 
   row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
@@ -113,6 +114,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'Drpc')        { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Odyssey')     { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Syndica')     { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Allnodes')    { gridPos: pos._4 },
 
   row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
@@ -136,6 +138,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Drpc')         { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Odyssey')      { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Syndica')      { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Allnodes')     { gridPos: pos._4 },
 
   row.new('RPC Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._3 },


### PR DESCRIPTION
# Description

This PR changes all `eip155:1` providers priority to `Low` and Allnodes to `Max` to route most RPC traffic to the Allnodes provider.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
