### PR TITLE
feat(providers): decrease Infura weight to minimal

### DIFF
--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -44,7 +44,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum
         (
             "eip155:1".into(),
-            ("mainnet".into(), Weight::new(Priority::Low).unwrap()),
+            ("mainnet".into(), Weight::new(Priority::Custom(1)).unwrap()),
         ),
         (
             "eip155:11155111".into(),


### PR DESCRIPTION
# Description

This PR temporarily decreased the Infura provider weight to a minimal `1` for the `eip155:1`

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
