### PR TITLE
feat(providers): reverting back `eip155:1` weights

### DIFF
--- a/src/env/allnodes.rs
+++ b/src/env/allnodes.rs
@@ -1,8 +1,4 @@
-use {
-    super::ProviderConfig,
-    crate::providers::{Priority, Weight},
-    std::collections::HashMap,
-};
+use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
 
 #[derive(Debug)]
 pub struct AllnodesConfig {
@@ -37,10 +33,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
     HashMap::from([
+        // Disabling Allnodes until the plan upgrade is complete
         // Ethereum Mainnet
-        (
-            "eip155:1".into(),
-            ("eth30082".into(), Weight::new(Priority::Max).unwrap()),
-        ),
+        // (
+        //     "eip155:1".into(),
+        //     ("eth30082".into(), Weight::new(Priority::Max).unwrap()),
+        // ),
     ])
 }

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -44,7 +44,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum
         (
             "eip155:1".into(),
-            ("mainnet".into(), Weight::new(Priority::Custom(1)).unwrap()),
+            ("mainnet".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         (
             "eip155:11155111".into(),


### PR DESCRIPTION
# Description

This is a planned reverting `eip155:1` weights after Allnodes testing and disabling the Allnodes RPC endpoint.

## How Has This Been Tested?

Manual testing.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
