### PR TITLE
fix: capitalizing the metadata token name, multiply gas estimation from 1Inch

### DIFF
--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -12,7 +12,7 @@ use {
             ProviderKind,
         },
         storage::KeyValueStorage,
-        utils::crypto,
+        utils::{capitalize_first_letter, crypto},
         Metrics,
     },
     async_trait::async_trait,
@@ -233,7 +233,7 @@ impl BalanceProvider for DuneProvider {
 
                         // Determine name
                         let name = if f.address == "native" {
-                            f.chain.clone()
+                            capitalize_first_letter(&f.chain)
                         } else {
                             symbol.clone()
                         };

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -31,6 +31,7 @@ use {
 };
 
 const ONEINCH_FEE: f64 = 0.85;
+const GAS_ESTIMATION_SLIPPAGE: f64 = 1.1; // Increase the estimated gas by 10%
 
 #[derive(Debug)]
 pub struct OneInchProvider {
@@ -626,7 +627,7 @@ impl ConversionProvider for OneInchProvider {
                 data: body.tx.data,
                 amount: body.dst_amount,
                 eip155: Some(ConvertTxEip155 {
-                    gas: body.tx.gas.to_string(),
+                    gas: (body.tx.gas as f64 * GAS_ESTIMATION_SLIPPAGE).to_string(),
                     gas_price: body.tx.gas_price,
                 }),
             },

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -21,3 +21,34 @@ pub fn generate_random_string(len: usize) -> String {
         .take(len)
         .collect()
 }
+
+pub fn capitalize_first_letter(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(first) => {
+            // to_uppercase() returns an iterator because some characters can map to multiple chars
+            first.to_uppercase().collect::<String>() + c.as_str()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capitalize_first_letter() {
+        let input = "";
+        let expected = "";
+        assert_eq!(capitalize_first_letter(input), expected);
+
+        let input = "rust";
+        let expected = "Rust";
+        assert_eq!(capitalize_first_letter(input), expected);
+
+        let input = "rust world";
+        let expected = "Rust world";
+        assert_eq!(capitalize_first_letter(input), expected);
+    }
+}


### PR DESCRIPTION
# Description

This PR makes a few small fixes:
* Making the token name based on the chain name (native token) capitalized;
* Applying the slippage (+10%) to the 1Inch gas estimation to cover differences for SA.

## How Has This Been Tested?

Current integration tests and manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
