### PR TITLE
fix(CA): increasing the bridging fee slippage

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -23,7 +23,7 @@ pub mod route;
 pub mod status;
 
 /// How much to multiply the bridging fee amount to cover bridging fee volatility
-pub const BRIDGING_FEE_SLIPPAGE: i8 = 50; // 50%
+pub const BRIDGING_FEE_SLIPPAGE: i8 = 75; // 75%
 
 /// Bridging timeout in seconds
 pub const BRIDGING_TIMEOUT: u64 = 1800; // 30 minutes


### PR DESCRIPTION
# Description

This PR increases the bridging fee slippage `50%` -> `75%`, to cover the bridging fee fluctuation between the route requested and executed to guarantee get the minimal requested amount at the end. That should fix the reported issue when the final amount was half-cent less.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
