### PR TITLE
feat: adding SDK info `sv` and `st` query parameters for analytics

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -14,12 +14,7 @@ describe('Account balance', () => {
 
   it('fulfilled balance Ethereum address', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}`,
-      {
-        headers: {
-            'x-sdk-version': sdk_version,
-        }
-      }
+      `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}&sv=${sdk_version}`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
@@ -40,15 +35,24 @@ describe('Account balance', () => {
     }
   })
 
-  it('fulfilled balance Solana address', async () => {
-    let chainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+  it('fulfilled balance Ethereum address (deprecated \'x-sdk-version\')', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/${fulfilled_solana_address}/balance?projectId=${projectId}&currency=${currency}&chainId=${chainId}`,
+      `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}`,
       {
         headers: {
             'x-sdk-version': sdk_version,
         }
       }
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.balances).toBe('object')
+    expect(resp.data.balances.length).toBeGreaterThan(1)
+  })
+
+  it('fulfilled balance Solana address', async () => {
+    let chainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/account/${fulfilled_solana_address}/balance?projectId=${projectId}&currency=${currency}&chainId=${chainId}&sv=${sdk_version}`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
@@ -76,12 +80,7 @@ describe('Account balance', () => {
 
   it('empty balance Ethereum address', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/${empty_eth_address}/balance?projectId=${projectId}&currency=${currency}`,
-      {
-        headers: {
-            'x-sdk-version': sdk_version,
-        }
-      }
+      `${baseUrl}/v1/account/${empty_eth_address}/balance?projectId=${projectId}&currency=${currency}&sv=${sdk_version}`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
@@ -91,12 +90,7 @@ describe('Account balance', () => {
   it('empty balance Solana address', async () => {
     let chainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/${empty_solana_address}/balance?projectId=${projectId}&currency=${currency}&chainId=${chainId}`,
-      {
-        headers: {
-            'x-sdk-version': sdk_version,
-        }
-      }
+      `${baseUrl}/v1/account/${empty_solana_address}/balance?projectId=${projectId}&currency=${currency}&chainId=${chainId}&sv=${sdk_version}`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
@@ -107,12 +101,9 @@ describe('Account balance', () => {
     // USDC token contract address on Base
     const token_contract_address = 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
     const endpoint = `/v1/account/${fulfilled_eth_address}/balance`;
-    const queryParams = `?projectId=${projectId}&currency=${currency}&forceUpdate=${token_contract_address}`;
+    const queryParams = `?projectId=${projectId}&currency=${currency}&sv=${sdk_version}&forceUpdate=${token_contract_address}`;
     const url = `${baseUrl}${endpoint}${queryParams}`;
-    const headers = {
-        'x-sdk-version': sdk_version,
-    };
-    let resp = await httpClient.get(url, { headers });
+    let resp = await httpClient.get(url);
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
     expect(resp.data.balances.length).toBeGreaterThan(1)
@@ -140,12 +131,9 @@ describe('Account balance', () => {
     const zero_balance_address = '0x5b6262592954B925B510651462b63ddEbcc22eaD'
     const token_contract_address = 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
     const endpoint = `/v1/account/${zero_balance_address}/balance`;
-    let queryParams = `?projectId=${projectId}&currency=${currency}`;
+    let queryParams = `?projectId=${projectId}&currency=${currency}&sv=${sdk_version}`;
     let url = `${baseUrl}${endpoint}${queryParams}`;
-    const headers = {
-        'x-sdk-version': sdk_version,
-    };
-    let resp = await httpClient.get(url, { headers });
+    let resp = await httpClient.get(url);
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
     expect(resp.data.balances.length).toBe(0)
@@ -153,7 +141,7 @@ describe('Account balance', () => {
     // Forcing update and checking injected balance in response
     queryParams = `${queryParams}&forceUpdate=${token_contract_address}`;
     url = `${baseUrl}${endpoint}${queryParams}`;
-    resp = await httpClient.get(url, { headers });
+    resp = await httpClient.get(url);
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
     expect(resp.data.balances.length).toBe(1)
@@ -167,12 +155,9 @@ describe('Account balance', () => {
     // We are using `0xe...` as a contract address for native tokens
     const token_contract_address = 'eip155:1:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
     const endpoint = `/v1/account/${fulfilled_eth_address}/balance`;
-    const queryParams = `?projectId=${projectId}&currency=${currency}&forceUpdate=${token_contract_address}`;
+    const queryParams = `?projectId=${projectId}&currency=${currency}&sv=${sdk_version}&forceUpdate=${token_contract_address}`;
     const url = `${baseUrl}${endpoint}${queryParams}`;
-    const headers = {
-        'x-sdk-version': sdk_version,
-    };
-    let resp = await httpClient.get(url, { headers });
+    let resp = await httpClient.get(url);
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
     expect(resp.data.balances.length).toBeGreaterThan(1)

--- a/src/analytics/account_names_info.rs
+++ b/src/analytics/account_names_info.rs
@@ -13,6 +13,10 @@ pub struct AccountNameRegistration {
     pub region: Option<String>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,
+
+    // Sdk info
+    pub sv: Option<String>,
+    pub st: Option<String>,
 }
 
 impl AccountNameRegistration {
@@ -25,6 +29,8 @@ impl AccountNameRegistration {
         region: Option<Vec<String>>,
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
+        sv: Option<String>,
+        st: Option<String>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -35,6 +41,8 @@ impl AccountNameRegistration {
             region: region.map(|r| r.join(", ")),
             country,
             continent,
+            sv,
+            st,
         }
     }
 }

--- a/src/analytics/balance_lookup_info.rs
+++ b/src/analytics/balance_lookup_info.rs
@@ -19,6 +19,10 @@ pub struct BalanceLookupInfo {
     pub region: Option<String>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,
+
+    // Sdk info
+    pub sv: Option<String>,
+    pub st: Option<String>,
 }
 
 impl BalanceLookupInfo {
@@ -36,6 +40,8 @@ impl BalanceLookupInfo {
         region: Option<Vec<String>>,
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
+        sv: Option<String>,
+        st: Option<String>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -51,6 +57,8 @@ impl BalanceLookupInfo {
             region: region.map(|r| r.join(", ")),
             country,
             continent,
+            sv,
+            st,
         }
     }
 }

--- a/src/analytics/history_lookup_info.rs
+++ b/src/analytics/history_lookup_info.rs
@@ -23,6 +23,10 @@ pub struct HistoryLookupInfo {
     pub region: Option<String>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,
+
+    // Sdk info
+    pub sv: Option<String>,
+    pub st: Option<String>,
 }
 
 impl HistoryLookupInfo {
@@ -39,6 +43,8 @@ impl HistoryLookupInfo {
         region: Option<Vec<String>>,
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
+        sv: Option<String>,
+        st: Option<String>,
     ) -> Self {
         HistoryLookupInfo {
             timestamp: wc::analytics::time::now(),
@@ -53,6 +59,8 @@ impl HistoryLookupInfo {
             region: region.map(|r| r.join(", ")),
             country,
             continent,
+            sv,
+            st,
         }
     }
 }

--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -29,6 +29,10 @@ pub struct IdentityLookupInfo {
 
     pub client_id: Option<String>,
     pub sender: Option<String>,
+
+    // Sdk info
+    pub sv: Option<String>,
+    pub st: Option<String>,
 }
 
 impl IdentityLookupInfo {
@@ -46,6 +50,8 @@ impl IdentityLookupInfo {
         continent: Option<Arc<str>>,
         client_id: Option<String>,
         sender: Option<String>,
+        sv: Option<String>,
+        st: Option<String>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -68,6 +74,9 @@ impl IdentityLookupInfo {
 
             client_id,
             sender,
+
+            sv,
+            st,
         }
     }
 }

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -22,9 +22,14 @@ pub struct MessageInfo {
     pub region: Option<String>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,
+
+    // Sdk info
+    pub sv: Option<String>,
+    pub st: Option<String>,
 }
 
 impl MessageInfo {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         query_params: &RpcQueryParams,
         request: &JsonRpcRequest,
@@ -33,6 +38,8 @@ impl MessageInfo {
         continent: Option<Arc<str>>,
         provider: &ProviderKind,
         origin: Option<String>,
+        sv: Option<String>,
+        st: Option<String>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -52,6 +59,8 @@ impl MessageInfo {
             region: region.map(|r| r.join(", ")),
             country,
             continent,
+            sv,
+            st,
         }
     }
 }

--- a/src/analytics/onramp_history_lookup_info.rs
+++ b/src/analytics/onramp_history_lookup_info.rs
@@ -22,6 +22,10 @@ pub struct OnrampHistoryLookupInfo {
     pub purchase_currency: String,
     pub purchase_network: String,
     pub purchase_amount: String,
+
+    // Sdk info
+    pub sv: Option<String>,
+    pub st: Option<String>,
 }
 
 impl OnrampHistoryLookupInfo {
@@ -40,6 +44,9 @@ impl OnrampHistoryLookupInfo {
         purchase_currency: String,
         purchase_network: String,
         purchase_amount: String,
+
+        sv: Option<String>,
+        st: Option<String>,
     ) -> Self {
         OnrampHistoryLookupInfo {
             transaction_id,
@@ -56,6 +63,9 @@ impl OnrampHistoryLookupInfo {
             purchase_currency,
             purchase_network,
             purchase_amount,
+
+            sv,
+            st,
         }
     }
 }

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -1,5 +1,5 @@
 use {
-    super::HANDLER_TASK_METRICS,
+    super::{SdkInfoParams, HANDLER_TASK_METRICS},
     crate::{
         analytics::{HistoryLookupInfo, OnrampHistoryLookupInfo},
         error::RpcError,
@@ -28,6 +28,8 @@ pub struct HistoryQueryParams {
     pub chain_id: Option<String>,
     pub cursor: Option<String>,
     pub onramp: Option<String>,
+    #[serde(flatten)]
+    pub sdk_info: SdkInfoParams,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -252,6 +254,8 @@ async fn handler_internal(
                 region,
                 country,
                 continent,
+                query.sdk_info.sv.clone(),
+                query.sdk_info.st.clone(),
             ));
         }
         ProviderKind::Coinbase => {
@@ -286,6 +290,8 @@ async fn handler_internal(
                             .as_ref()
                             .map(|v| v[0].quantity.numeric.clone())
                             .unwrap_or_default(),
+                        query.sdk_info.sv.clone(),
+                        query.sdk_info.st.clone(),
                     ));
             }
         }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -33,6 +33,13 @@ pub mod ws_proxy;
 
 static HANDLER_TASK_METRICS: TaskMetrics = TaskMetrics::new("handler_task");
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkInfoParams {
+    pub st: Option<String>,
+    pub sv: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcQueryParams {
@@ -44,6 +51,8 @@ pub struct RpcQueryParams {
     // TODO remove this param, as it can be set by actual rpc users but it shouldn't be
     /// Optional "source" field to indicate an internal request
     pub source: Option<MessageSource>,
+    #[serde(flatten)]
+    pub sdk_info: SdkInfoParams,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -160,6 +160,8 @@ pub async fn rpc_provider_call(
             continent,
             &provider.provider_kind(),
             origin,
+            query_params.sdk_info.sv.clone(),
+            query_params.sdk_info.st.clone(),
         ));
     }
 

--- a/src/handlers/wallet/handler.rs
+++ b/src/handlers/wallet/handler.rs
@@ -5,7 +5,13 @@ use crate::error::RpcError;
 use crate::json_rpc::{
     ErrorResponse, JsonRpcError, JsonRpcRequest, JsonRpcResponse, JsonRpcResult,
 };
-use crate::{handlers::HANDLER_TASK_METRICS, state::AppState};
+use crate::{
+    handlers::{
+        wallet::get_calls_status::QueryParams as CallStatusQueryParams, SdkInfoParams,
+        HANDLER_TASK_METRICS,
+    },
+    state::AppState,
+};
 use axum::extract::{ConnectInfo, Query};
 use axum::response::{IntoResponse, Response};
 use axum::{extract::State, Json};
@@ -21,6 +27,8 @@ use wc::future::FutureExt;
 #[serde(rename_all = "camelCase")]
 pub struct WalletQueryParams {
     pub project_id: String,
+    #[serde(flatten)]
+    pub sdk_info: SdkInfoParams,
 }
 
 pub async fn handler(
@@ -189,6 +197,9 @@ async fn handle_rpc(
                 serde_json::from_value(params).map_err(Error::InvalidParams)?,
                 connect_info,
                 headers,
+                Query(CallStatusQueryParams {
+                    sdk_info: query.sdk_info,
+                }),
             )
             .await
             .map_err(Error::GetCallsStatus)?,


### PR DESCRIPTION
# Description

This PR adds the following SDK info query parameters: 
* `sv` - version,
* `st` - type.

These parameters append to the analytics where the analytics are already applied.

Also, adding the `sv` query parameter to the balances endpoint as a workaround for the deprecated `x-sdk-version` header parameter, keeping it backward compatible.

## How Has This Been Tested?

The integration test for the balance endpoint was updated to check the `sv` query parameter and backward compatibility with the `x-sdk-version` header.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
