### PR TITLE
feat(providers): enabling Allnodes provider and tuning Ethereum Mainnet RPC traffic

### DIFF
--- a/src/env/allnodes.rs
+++ b/src/env/allnodes.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct AllnodesConfig {
@@ -33,11 +37,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
     HashMap::from([
-        // Disabling Allnodes until the plan upgrade is complete
         // Ethereum Mainnet
-        // (
-        //     "eip155:1".into(),
-        //     ("eth30082".into(), Weight::new(Priority::Max).unwrap()),
-        // ),
+        (
+            "eip155:1".into(),
+            ("eth57873".into(), Weight::new(Priority::Max).unwrap()),
+        ),
     ])
 }

--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -40,7 +40,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:1".into(),
             (
                 "https://eth.drpc.org/".into(),
-                Weight::new(Priority::Low).unwrap(),
+                Weight::new(Priority::Minimal).unwrap(),
             ),
         ),
         // Ethereum Sepolia

--- a/src/env/getblock.rs
+++ b/src/env/getblock.rs
@@ -46,8 +46,8 @@ fn extract_supported_chains(access_tokens_json: String) -> HashMap<String, (Stri
 
     // Keep in-sync with SUPPORTED_CHAINS.md
     let supported_chain_ids = HashMap::from([
-        ("eip155:1", Priority::Low),
-        ("eip155:56", Priority::Low),
+        ("eip155:1", Priority::Minimal),
+        ("eip155:56", Priority::Minimal),
         ("eip155:137", Priority::Normal),
         ("eip155:324", Priority::Normal),
         ("eip155:17000", Priority::Normal),

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -44,11 +44,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum
         (
             "eip155:1".into(),
-            ("mainnet".into(), Weight::new(Priority::Custom(1)).unwrap()),
+            ("mainnet".into(), Weight::new(Priority::Minimal).unwrap()),
         ),
         (
             "eip155:11155111".into(),
-            ("sepolia".into(), Weight::new(Priority::Custom(1)).unwrap()),
+            ("sepolia".into(), Weight::new(Priority::Minimal).unwrap()),
         ),
         // Optimism
         (

--- a/src/env/lava.rs
+++ b/src/env/lava.rs
@@ -40,7 +40,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum Mainnet
         (
             "eip155:1".into(),
-            ("eth".into(), Weight::new(Priority::Low).unwrap()),
+            ("eth".into(), Weight::new(Priority::Minimal).unwrap()),
         ),
         // Ethereum Sepolia
         (

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -79,7 +79,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum mainnet
         (
             "eip155:1".into(),
-            ("eth".into(), Weight::new(Priority::Normal).unwrap()),
+            ("eth".into(), Weight::new(Priority::Minimal).unwrap()),
         ),
         // Ethereum holesky
         (

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -38,7 +38,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum mainnet
         (
             "eip155:1".into(),
-            ("ethereum-rpc".into(), Weight::new(Priority::Low).unwrap()),
+            (
+                "ethereum-rpc".into(),
+                Weight::new(Priority::Minimal).unwrap(),
+            ),
         ),
         // Ethereum Sepolia
         (

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -756,6 +756,7 @@ pub enum Priority {
     High,
     Normal,
     Low,
+    Minimal,
     Disabled,
     Custom(u64),
 }
@@ -769,6 +770,7 @@ impl TryInto<PriorityValue> for Priority {
             Self::High => PriorityValue::new(MAX_PRIORITY / 4 + MAX_PRIORITY / 2),
             Self::Normal => PriorityValue::new(MAX_PRIORITY / 2),
             Self::Low => PriorityValue::new(MAX_PRIORITY / 4),
+            Self::Minimal => PriorityValue::new(1),
             Self::Disabled => PriorityValue::new(0),
             Self::Custom(value) => PriorityValue::new(value),
         }


### PR DESCRIPTION
# Description

This PR enables the Allnodes provider for the `eip155:1`, adding a new `Minimal` priority weight with a `1` value and changes all `eip155:1` priorities to `Minimal` except the Allnodes to route most of the traffic to it.

## How Has This Been Tested?

Tested by provider integration test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
