### PR TITLE
feat: sessionId and hardcoded provider

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -317,6 +317,7 @@ async fn lookup_identity_rpc(
             // ENS registry contract is only deployed on mainnet
             chain_id: ETHEREUM_MAINNET.to_owned(),
             provider_id: None,
+            session_id: None,
             source: Some(crate::analytics::MessageSource::Identity),
             sdk_info,
         },

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -47,6 +47,7 @@ pub struct RpcQueryParams {
     pub project_id: String,
     /// Optional provider ID for the exact provider request
     pub provider_id: Option<String>,
+    pub session_id: Option<String>,
 
     // TODO remove this param, as it can be set by actual rpc users but it shouldn't be
     /// Optional "source" field to indicate an internal request

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -71,8 +71,8 @@ pub async fn rpc_call(
     if query_params.session_id.is_some() {
         let provider_id = match chain_id.as_str() {
             "eip155:10" => Some("quicknode"),    // Optimism
-            "eip155:8453" => Some("quicknode"),  // Base
-            "eip155:42161" => Some("quicknode"), // Arbitrum One
+            "eip155:8453" => Some("lava"),  // Base
+            "eip155:42161" => Some("lava"), // Arbitrum One
             _ => {
                 debug!(
                     "Requested sessionId for chain {chain_id} but no hardcoded provider was configured"

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -70,9 +70,9 @@ pub async fn rpc_call(
 
     if query_params.session_id.is_some() {
         let provider_id = match chain_id.as_str() {
-            "eip155:10" => Some("infura"),    // Optimism
-            "eip155:8453" => Some("infura"),  // Base
-            "eip155:42161" => Some("infura"), // Arbitrum One
+            "eip155:10" => Some("quicknode"),    // Optimism
+            "eip155:8453" => Some("quicknode"),  // Base
+            "eip155:42161" => Some("quicknode"), // Arbitrum One
             _ => {
                 debug!(
                     "Requested sessionId for chain {chain_id} but no hardcoded provider was configured"

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -67,6 +67,53 @@ pub async fn rpc_call(
     body: Bytes,
 ) -> Result<Response, RpcError> {
     let chain_id = query_params.chain_id.clone();
+
+    if query_params.session_id.is_some() {
+        let provider_id = match chain_id.as_str() {
+            "eip155:10" => Some("infura"),    // Optimism
+            "eip155:8453" => Some("infura"),  // Base
+            "eip155:42161" => Some("infura"), // Arbitrum One
+            _ => {
+                debug!(
+                    "Requested sessionId for chain {chain_id} but no hardcoded provider was configured"
+                );
+                None
+            }
+        };
+
+        if let Some(provider_id) = provider_id {
+            let provider = state
+                .providers
+                .get_rpc_provider_by_provider_id(provider_id)
+                .ok_or_else(|| RpcError::UnsupportedProvider(provider_id.to_owned()))?;
+            let response = rpc_provider_call(
+                state.clone(),
+                addr,
+                query_params.clone(),
+                headers.clone(),
+                body.clone(),
+                provider.clone(),
+            )
+            .await;
+
+            match response {
+                Ok(response) if !response.status().is_server_error() => {
+                    return Ok(response);
+                }
+                e => {
+                    // Not recording metric since this is a hardcoded provider
+                    // state
+                    //     .metrics
+                    //     .add_rpc_call_retries(0, chain_id.clone());
+                    debug!(
+                        "Provider (via sessionId) '{}' returned an error {e:?}, trying the next provider",
+                        provider.provider_kind()
+                    );
+                }
+            }
+        }
+    }
+
     // Exact provider proxy request for testing suite
     // This request is allowed only for the RPC_PROXY_TESTING_PROJECT_ID
     let providers = match query_params.provider_id.clone() {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -70,9 +70,9 @@ pub async fn rpc_call(
 
     if query_params.session_id.is_some() {
         let provider_id = match chain_id.as_str() {
-            "eip155:10" => Some("quicknode"),    // Optimism
-            "eip155:8453" => Some("lava"),  // Base
-            "eip155:42161" => Some("lava"), // Arbitrum One
+            "eip155:10" => Some("quicknode"), // Optimism
+            "eip155:8453" => Some("lava"),    // Base
+            "eip155:42161" => Some("lava"),   // Arbitrum One
             _ => {
                 debug!(
                     "Requested sessionId for chain {chain_id} but no hardcoded provider was configured"

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -133,6 +133,7 @@ async fn handler_internal(
                 chain_id: chain_id.into(),
                 project_id,
                 provider_id: None,
+                session_id: None,
                 source: Some(MessageSource::WalletGetCallsStatus),
                 sdk_info: query.sdk_info.clone(),
             },


### PR DESCRIPTION
# Description

Implements hardcoded providers when `sessionId` query param is provided.

If the provider fails, it will fallback to normal routing logic.

As per the [design doc](https://www.notion.so/walletconnect/1Pager-using-Blockchain-API-for-sending-chain-abstraction-txns-1503a661771e80f38612ea98a1079fc0?pvs=4#1933a661771e806abfa3fda685f6ba42).

Used by https://github.com/reown-com/yttrium/pull/128

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
