### PR TITLE
feat: adding tracking of the `request_id` in analytics for balance and history

### DIFF
--- a/src/analytics/balance_lookup_info.rs
+++ b/src/analytics/balance_lookup_info.rs
@@ -28,6 +28,8 @@ pub struct BalanceLookupInfo {
     // Sdk info
     pub sv: Option<String>,
     pub st: Option<String>,
+
+    pub request_id: String,
 }
 
 impl BalanceLookupInfo {
@@ -48,6 +50,7 @@ impl BalanceLookupInfo {
         continent: Option<Arc<str>>,
         sv: Option<String>,
         st: Option<String>,
+        request_id: String,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -66,6 +69,7 @@ impl BalanceLookupInfo {
             continent,
             sv,
             st,
+            request_id,
         }
     }
 }

--- a/src/analytics/history_lookup_info.rs
+++ b/src/analytics/history_lookup_info.rs
@@ -30,6 +30,8 @@ pub struct HistoryLookupInfo {
     // Sdk info
     pub sv: Option<String>,
     pub st: Option<String>,
+
+    pub request_id: String,
 }
 
 impl HistoryLookupInfo {
@@ -49,6 +51,7 @@ impl HistoryLookupInfo {
         continent: Option<Arc<str>>,
         sv: Option<String>,
         st: Option<String>,
+        request_id: String,
     ) -> Self {
         HistoryLookupInfo {
             timestamp: wc::analytics::time::now(),
@@ -66,6 +69,7 @@ impl HistoryLookupInfo {
             continent,
             sv,
             st,
+            request_id,
         }
     }
 }

--- a/src/analytics/onramp_history_lookup_info.rs
+++ b/src/analytics/onramp_history_lookup_info.rs
@@ -26,6 +26,8 @@ pub struct OnrampHistoryLookupInfo {
     // Sdk info
     pub sv: Option<String>,
     pub st: Option<String>,
+
+    pub request_id: String,
 }
 
 impl OnrampHistoryLookupInfo {
@@ -47,6 +49,8 @@ impl OnrampHistoryLookupInfo {
 
         sv: Option<String>,
         st: Option<String>,
+
+        request_id: String,
     ) -> Self {
         OnrampHistoryLookupInfo {
             transaction_id,
@@ -66,6 +70,8 @@ impl OnrampHistoryLookupInfo {
 
             sv,
             st,
+
+            request_id,
         }
     }
 }

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -241,6 +241,11 @@ async fn handler_internal(
     )?;
 
     {
+        // Filling the request_id from the `propagate_x_request_id` middleware
+        let request_id = headers
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("unknown");
         let origin = headers
             .get("origin")
             .map(|v| v.to_str().unwrap_or("invalid_header").to_string());
@@ -269,6 +274,7 @@ async fn handler_internal(
                 continent.clone(),
                 query.sdk_info.sv.clone(),
                 query.sdk_info.st.clone(),
+                request_id.to_string(),
             ));
         }
     }

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -207,6 +207,12 @@ async fn handler_internal(
         .map(|geo| (geo.country, geo.continent, geo.region))
         .unwrap_or((None, None, None));
 
+    // Filling the request_id from the `propagate_x_request_id` middleware
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("unknown");
+
     // Analytics schema exception for Coinbase Onramp
     match history_provider_kind {
         ProviderKind::Coinbase => {
@@ -243,6 +249,7 @@ async fn handler_internal(
                             .unwrap_or_default(),
                         query.sdk_info.sv.clone(),
                         query.sdk_info.st.clone(),
+                        request_id.to_string(),
                     ));
             }
         }
@@ -294,6 +301,7 @@ async fn handler_internal(
                 continent,
                 query.sdk_info.sv.clone(),
                 query.sdk_info.st.clone(),
+                request_id.to_string(),
             ));
         }
     }


### PR DESCRIPTION
# Description

This PR adds tracking of the `request_id` in analytics for the balance and history endpoints.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
