### PR TITLE
fix: update WCN client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9507,6 +9507,7 @@ dependencies = [
  "postcard",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/src/storage/irn/mod.rs
+++ b/src/storage/irn/mod.rs
@@ -5,8 +5,8 @@ use {
     wcn_replication::{
         auth::{client_key_from_secret, peer_id, PublicKey},
         identity::Keypair,
-        storage::{auth::Auth, Entry, Key, MapEntry, Multiaddr},
-        Config as WcnConfig, Driver,
+        storage::{auth::Auth, Entry, Key, MapEntry},
+        Config as WcnConfig, Driver, PeerAddr,
     },
 };
 
@@ -68,7 +68,8 @@ impl Irn {
         let client_key =
             client_key_from_secret(key.as_bytes()).map_err(StorageError::WcnAuthError)?;
 
-        // Safe unwrap as the key is guaranteed to be valid since its created by the `client_key_from_secret``
+        // Safe unwrap as the key is guaranteed to be valid since its created by the
+        // `client_key_from_secret``
         let keypair = Keypair::ed25519_from_bytes(client_key.to_bytes())
             .expect("Failed to create keypair from ed25519 client key");
 
@@ -99,10 +100,10 @@ impl Irn {
         })
     }
 
-    fn parse_node_addresses(addresses: Vec<String>) -> Result<HashSet<Multiaddr>, StorageError> {
-        let mut nodes: HashSet<Multiaddr> = HashSet::new();
+    fn parse_node_addresses(addresses: Vec<String>) -> Result<HashSet<PeerAddr>, StorageError> {
+        let mut nodes = HashSet::new();
         for address in addresses {
-            let addr = Multiaddr::from_str(&address)
+            let addr = PeerAddr::from_str(&address)
                 .map_err(|_| StorageError::WrongNodeAddress(address))?;
             nodes.insert(addr);
         }
@@ -258,9 +259,12 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn test_irn_client_hashmap() {
+        let addr =
+            "12D3KooWDJrGKPuU1vJLBZv2UXfcZvdBprUgAkjvkUET7q2PzwPp-/ip4/127.0.0.1/udp/3011/quic-v1";
+
         let irn = Irn::new(
             "2SjlbfXx6md6337H63KjOEFlv4XP5g2dl7Qam6ot84o=".into(),
-            vec!["/ip4/127.0.0.1/udp/3011/quic-v1".into()],
+            vec![addr.into()],
             "test_namespace".into(),
             "namespace_secret".into(),
         )

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -258,7 +258,7 @@ variable "rate_limiting_ip_whitelist" {
 # IRN client configuration
 
 variable "irn_nodes" {
-  description = "Comma-separated IRN nodes address in MultiAddr format"
+  description = "Comma-separated IRN nodes address in PeerAddr format"
   type        = string
 }
 


### PR DESCRIPTION
# Description

This updates the WCN client to the following version: https://github.com/WalletConnectFoundation/wcn/pull/169.

The update requires changing the format of WCN node addresses from `Multiaddr` to [`PeerAddr`](https://github.com/WalletConnectFoundation/wcn/blob/main/crates/rpc/src/lib.rs#L246). Following is the list of EU WCN `mainnet` nodes in the `PeerAddr` format:
```
12D3KooWFJpHSpFCoHqFJsHyc9JA7C9XPTVhyXsiTRucU6TikGWe-/ip4/35.157.165.56/udp/3014/quic-v1,12D3KooWFvEEKjqhobbAfdLdj3BFnDkt1dXS2AZBJ1nYPJaSQ7Nj-/ip4/3.79.81.125/udp/3014/quic-v1,12D3KooWPFwn2kqsv8E773d1HFhUvmWEKBdubue6BE4pH2Hq6g63-/ip4/52.28.124.174/udp/3014/quic-v1
```

## How Has This Been Tested?

Not tested.

## Due Diligence

* [x] Update `IRN_NODES` TFC *before merging*.
