### PR TITLE
fix(CA): adding different storage slots per contracts and enabling USDT on Arbitrum

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -125,7 +125,7 @@ describe('Chain abstraction orchestrator', () => {
 
   })
 
-  it('bridging routes (routes available, USDC Optimism ⇄ USDC Base)', async () => {
+  it('bridging routes (routes available, USDC Base → USDC Optimism)', async () => {
     // Sending USDC to Optimism, but having the balance of USDC on Base chain
     // which expected to be used for bridging
 
@@ -204,8 +204,7 @@ describe('Chain abstraction orchestrator', () => {
     orchestration_id = data.orchestrationId;
   })
 
-   // Temporary disabled due to the issue with the Arbitrum USDT contract simulation
-  it.skip('bridging routes (routes available, USDT Optimism ⇄ USDT Arbitrum)', async () => {
+  it('bridging routes (routes available, USDT Arbitrum → USDT Optimism)', async () => {
     // Sending USDT to Optimism, but having the USDT balance on Arbitrum.
 
     // How much needs to be topped up
@@ -281,6 +280,37 @@ describe('Chain abstraction orchestrator', () => {
 
     // Set the Orchestration ID for the next test
     orchestration_id = data.orchestrationId;
+  })
+
+  it('bridging routes (routes available, USDT Optimism → USDT Arbitrum)', async () => {
+    // Sending USDT to Arbitrum, but having the USDT balance on Optimism.
+    let amount_to_send = usdt_funds[chain_id_arbitrum] + 500_000;
+
+    const data_encoded = erc20Interface.encodeFunctionData('transfer', [
+      receiver_address,
+      amount_to_send,
+    ]);
+
+    let transactionObj = {
+      transaction: {
+        from: from_address_with_funds,
+        to: usdt_contracts[chain_id_arbitrum],
+        value: "0x00", // Zero native tokens
+        input: data_encoded,
+        chainId: chain_id_arbitrum,
+      }
+    }
+
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/ca/orchestrator/route?projectId=${projectId}`,
+      transactionObj
+    )
+    expect(resp.status).toBe(200)
+
+    const data = resp.data
+    expect(typeof data.orchestrationId).toBe('string')
+    // Expecting 2 transactions in the route
+    expect(data.transactions.length).toBe(2)
   })
 
   it('bridging status', async () => {

--- a/src/handlers/chain_agnostic/assets.rs
+++ b/src/handlers/chain_agnostic/assets.rs
@@ -9,8 +9,8 @@ pub struct AssetMetadata {
 
 /// Asset simulation parameters to override the asset's balance state
 pub struct SimulationParams {
-    /// Asset contract balance storage slot number
-    pub balance_storage_slot: u64,
+    /// Asset contract balance storage slot number per chain
+    pub balance_storage_slots: &'static phf::Map<&'static str, u64>,
     /// Balance override for the asset
     pub balance: u128,
 }
@@ -35,8 +35,7 @@ static USDT_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
     // Optimism
     "eip155:10" => address!("94b008aA00579c1307B0EF2c499aD98a8ce58e58"),
     // Arbitrum
-    // Temporarily disabling Arbitrum USDT until the simulation fix
-    // "eip155:42161" => address!("Fd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"),
+    "eip155:42161" => address!("Fd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"),
 };
 
 pub static BRIDGING_ASSETS: phf::Map<&'static str, AssetEntry> = phf_map! {
@@ -45,7 +44,12 @@ pub static BRIDGING_ASSETS: phf::Map<&'static str, AssetEntry> = phf_map! {
             decimals: 6,
         },
         simulation: SimulationParams {
-            balance_storage_slot: 9,
+            // Must be in sync with the `USDC_CONTRACTS` from above
+            balance_storage_slots: &phf_map! {
+                "eip155:10" => 9u64,
+                "eip155:8453" => 9u64,
+                "eip155:42161" => 9u64,
+            },
             balance: 99000000000,
         },
         contracts: &USDC_CONTRACTS,
@@ -55,7 +59,11 @@ pub static BRIDGING_ASSETS: phf::Map<&'static str, AssetEntry> = phf_map! {
             decimals: 6,
         },
         simulation: SimulationParams {
-            balance_storage_slot: 0,
+            // Must be in sync with the `USDT_CONTRACTS` from above
+            balance_storage_slots: &phf_map! {
+                "eip155:10" => 0u64,
+                "eip155:42161" => 51u64,
+            },
             balance: 99000000000,
         },
         contracts: &USDT_CONTRACTS,

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -247,11 +247,17 @@ pub async fn get_assets_changes_from_simulation(
             let Some(simulation_params) = get_simulation_params_for_asset(&asset_name) else {
                 continue;
             };
+            let balance_storage_slot = *simulation_params
+                .balance_storage_slots
+                .get(&transaction.chain_id)
+                .ok_or_else(|| {
+                    RpcError::InvalidConfiguration(format!(
+                        "Contract balance storage slot for simulation is not present for {} on {}",
+                        asset_name, transaction.chain_id
+                    ))
+                })?;
             account_state.insert(
-                compute_simulation_storage_slot(
-                    transaction.from,
-                    simulation_params.balance_storage_slot,
-                ),
+                compute_simulation_storage_slot(transaction.from, balance_storage_slot),
                 compute_simulation_balance(simulation_params.balance),
             );
             state_overrides.insert(asset_contract, account_state.clone());


### PR DESCRIPTION
# Description

This PR adds different contract storage slots support, adding a correct `balanceOf` storage slot for the USDT Arbitrum contract to fix the simulation error and enable the USDT Arbitrum chain abstraction support.

## How Has This Been Tested?

* A new integration test was created to cover such cases.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
