### PR TITLE
fix: make Grafana key sensitive

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,6 +5,7 @@ variable "grafana_auth" {
   description = "The API Token for the Grafana instance"
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This PR makes grafana key terraform variable sensitive.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
