### PR TITLE
feat(OnRamp): adding Meld API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ export RPC_PROXY_PROVIDER_TENDERLY_PROJECT_ID=""
 export RPC_PROXY_PROVIDER_DUNE_API_KEY=""
 export RPC_PROXY_PROVIDER_SYNDICA_API_KEY=""
 export RPC_PROXY_PROVIDER_ALLNODES_API_KEY=""
+export RPC_PROXY_PROVIDER_MELD_API_KEY=""
 
 # PostgreSQL URI connection string
 export RPC_PROXY_POSTGRES_URI="postgres://postgres@localhost/postgres"

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -89,6 +89,7 @@ jobs:
           RPC_PROXY_PROVIDER_DUNE_API_KEY: ""
           RPC_PROXY_PROVIDER_SYNDICA_API_KEY: ""
           RPC_PROXY_PROVIDER_ALLNODES_API_KEY: ""
+          RPC_PROXY_PROVIDER_MELD_API_KEY: ""
       - run: docker logs mock-bundler-anvil-1
         if: failure()
       - run: docker logs mock-bundler-alto-1

--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -6,7 +6,7 @@ describe('OnRamp', () => {
   const country = 'US';
   const subdivision = 'NY';
 
-  it('buy options', async () => {
+  it('get options', async () => {
     let resp: any = await httpClient.get(
       `${onRampPath}/buy/options?projectId=${projectId}&country=${country}&subdivision=${subdivision}`,
     )
@@ -30,7 +30,7 @@ describe('OnRamp', () => {
     expect(typeof firstPurchaseNetworks.chainId).toBe('string')
   })
 
-  it('buy quotes', async () => {
+  it('get quotes', async () => {
     let resp: any = await httpClient.get(
       `${onRampPath}/buy/quotes` +
       `?projectId=${projectId}` +
@@ -135,5 +135,24 @@ describe('OnRamp', () => {
     expect(typeof resp.data[0].defaultAmount).toBe('number')
     expect(typeof resp.data[0].minimumAmount).toBe('number')
     expect(typeof resp.data[0].maximumAmount).toBe('number')
+  })
+
+  it('get multi provider quotes', async () => {
+    const requestData = {
+      projectId: projectId,
+      destinationCurrencyCode: 'BTC',
+      sourceAmount: 100,
+      sourceCurrencyCode: 'USD',
+    };
+
+    let resp: any = await httpClient.post(
+      `${onRampPath}/multi/quotes`, requestData
+    );
+
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].destinationAmount).toBe('number')
+    expect(resp.data[0].destinationCurrencyCode).toBe('BTC')
+    expect(typeof resp.data[0].sourceAmount).toBe('number')
   })
 })

--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -55,4 +55,85 @@ describe('OnRamp', () => {
     checkValueAndCurrency(resp.data.coinbaseFee)
     checkValueAndCurrency(resp.data.networkFee)
   })
+
+  it('get providers', async () => {
+    let resp: any = await httpClient.get(
+      `${onRampPath}/providers` +
+      `?projectId=${projectId}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].name).toBe('string')
+    expect(typeof resp.data[0].serviceProvider).toBe('string')
+    expect(typeof resp.data[0].logos).toBe('object')
+  })
+
+  it('get providers properties', async () => {
+    // Check for `countries` type
+    let type = 'countries'
+    let resp: any = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].countryCode).toBe('string')
+    expect(typeof resp.data[0].name).toBe('string')
+    expect(typeof resp.data[0].flagImageUrl).toBe('string')
+
+    // Check for `crypto-currencies` type
+    type = 'crypto-currencies'
+    resp = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].currencyCode).toBe('string')
+    expect(typeof resp.data[0].name).toBe('string')
+    expect(typeof resp.data[0].chainCode).toBe('string')
+    expect(typeof resp.data[0].symbolImageUrl).toBe('string')
+
+    // Check for `fiat-currencies` type
+    type = 'fiat-currencies'
+    resp = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].currencyCode).toBe('string')
+    expect(typeof resp.data[0].name).toBe('string')
+    expect(typeof resp.data[0].symbolImageUrl).toBe('string')
+
+    // Check for `payment-methods` type
+    type = 'payment-methods'
+    resp = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].paymentMethod).toBe('string')
+    expect(typeof resp.data[0].name).toBe('string')
+    expect(typeof resp.data[0].paymentType).toBe('string')
+
+    // Check for `fiat-purchases-limits` type
+    type = 'fiat-purchases-limits'
+    resp = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].currencyCode).toBe('string')
+    expect(typeof resp.data[0].defaultAmount).toBe('number')
+    expect(typeof resp.data[0].minimumAmount).toBe('number')
+    expect(typeof resp.data[0].maximumAmount).toBe('number')
+  })
 })

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -206,6 +206,7 @@ mod test {
             ("RPC_PROXY_PROVIDER_DUNE_API_KEY", "DUNE_API_KEY"),
             ("RPC_PROXY_PROVIDER_SYNDICA_API_KEY", "SYNDICA_API_KEY"),
             ("RPC_PROXY_PROVIDER_ALLNODES_API_KEY", "ALLNODES_API_KEY"),
+            ("RPC_PROXY_PROVIDER_MELD_API_KEY", "MELD_API_KEY"),
             (
                 "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL",
                 "PROMETHEUS_QUERY_URL",
@@ -317,6 +318,7 @@ mod test {
                     syndica_api_key: "SYNDICA_API_KEY".to_string(),
                     override_bundler_urls: None,
                     allnodes_api_key: "ALLNODES_API_KEY".to_string(),
+                    meld_api_key: "MELD_API_KEY".to_string(),
                 },
                 rate_limiting: RateLimitingConfig {
                     max_tokens: Some(100),

--- a/src/handlers/onramp/mod.rs
+++ b/src/handlers/onramp/mod.rs
@@ -1,3 +1,4 @@
+pub mod multi_quotes;
 pub mod options;
 pub mod properties;
 pub mod providers;

--- a/src/handlers/onramp/mod.rs
+++ b/src/handlers/onramp/mod.rs
@@ -1,2 +1,3 @@
 pub mod options;
+pub mod providers;
 pub mod quotes;

--- a/src/handlers/onramp/mod.rs
+++ b/src/handlers/onramp/mod.rs
@@ -1,3 +1,5 @@
 pub mod options;
+pub mod properties;
 pub mod providers;
 pub mod quotes;
+pub mod widget;

--- a/src/handlers/onramp/providers.rs
+++ b/src/handlers/onramp/providers.rs
@@ -1,0 +1,71 @@
+use {
+    crate::{error::RpcError, handlers::HANDLER_TASK_METRICS, state::AppState},
+    axum::{
+        extract::{Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::{collections::HashMap, sync::Arc},
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryParams {
+    pub countries: Option<String>,
+    pub project_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvidersResponse {
+    pub categories: Vec<String>,
+    pub category_statuses: HashMap<String, String>,
+    pub logos: Logos,
+    pub name: String,
+    pub service_provider: String,
+    pub status: String,
+    pub website_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Logos {
+    pub dark: String,
+    pub dark_short: String,
+    pub light: String,
+    pub light_short: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query: Query<QueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("onramp_providers"))
+        .await
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    query: Query<QueryParams>,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query.project_id)
+        .await?;
+
+    let buy_options = state
+        .providers
+        .onramp_multi_provider
+        .get_providers(query.0, state.metrics.clone())
+        .await
+        .tap_err(|e| {
+            error!("Failed to call onramp providers with {}", e);
+        })?;
+
+    Ok(Json(buy_options).into_response())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             get(handlers::onramp::quotes::handler),
         )
         .route(
+            "/v1/onramp/multi/quotes",
+            post(handlers::onramp::multi_quotes::handler),
+        )
+        .route(
             "/v1/onramp/providers",
             get(handlers::onramp::providers::handler),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,18 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/onramp/buy/quotes",
             get(handlers::onramp::quotes::handler),
         )
+        .route(
+            "/v1/onramp/providers",
+            get(handlers::onramp::providers::handler),
+        )
+        .route(
+            "/v1/onramp/providers/properties",
+            get(handlers::onramp::properties::handler),
+        )
+        .route(
+            "/v1/onramp/widget",
+            post(handlers::onramp::widget::handler),
+        )
         // Conversion
         .route(
             "/v1/convert/tokens",

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -1,0 +1,81 @@
+use {
+    super::OnRampMultiProvider,
+    crate::{
+        error::{RpcError, RpcResult},
+        handlers::onramp::providers::{ProvidersResponse, QueryParams as ProvidersQueryParams},
+        providers::ProviderKind,
+        Metrics,
+    },
+    async_trait::async_trait,
+    std::{sync::Arc, time::SystemTime},
+    tracing::log::error,
+    url::Url,
+};
+
+const BASE_URL: &str = "https://api-sb.meld.io";
+const API_VERSION: &str = "2023-12-19";
+const DEFAULT_CATEGORY: &str = "CRYPTO_ONRAMP";
+
+#[derive(Debug)]
+pub struct MeldProvider {
+    pub provider_kind: ProviderKind,
+    pub api_key: String,
+    pub http_client: reqwest::Client,
+}
+
+impl MeldProvider {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            provider_kind: ProviderKind::Meld,
+            api_key,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    async fn send_get_request(&self, url: Url) -> Result<reqwest::Response, reqwest::Error> {
+        self.http_client
+            .get(url)
+            .header("Meld-Version", API_VERSION)
+            .header("Authorization", format!("BASIC {}", self.api_key))
+            .send()
+            .await
+    }
+}
+
+#[async_trait]
+impl OnRampMultiProvider for MeldProvider {
+    #[tracing::instrument(skip(self), fields(provider = "Meld"), level = "debug")]
+    async fn get_providers(
+        &self,
+        params: ProvidersQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<ProvidersResponse> {
+        let base = format!("{}/service-providers", BASE_URL);
+        let mut url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
+        if let Some(countries) = params.countries {
+            url.query_pairs_mut().append_pair("countries", &countries);
+        }
+        url.query_pairs_mut()
+            .append_pair("categories", DEFAULT_CATEGORY);
+
+        let latency_start = SystemTime::now();
+        let response = self.send_get_request(url).await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("onramp_providers".to_string()),
+        );
+
+        if !response.status().is_success() {
+            error!(
+                "Error on Meld providers response. Status is not OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::OnRampProviderError);
+        }
+
+        Ok(response.json::<ProvidersResponse>().await?)
+    }
+}

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -2,19 +2,25 @@ use {
     super::OnRampMultiProvider,
     crate::{
         error::{RpcError, RpcResult},
-        handlers::onramp::providers::{ProvidersResponse, QueryParams as ProvidersQueryParams},
+        handlers::onramp::{
+            properties::{PropertyType, QueryParams as ProvidersPropertiesQueryParams},
+            providers::{ProvidersResponse, QueryParams as ProvidersQueryParams},
+            widget::{QueryParams as WidgetQueryParams, SessionData, WidgetResponse},
+        },
         providers::ProviderKind,
         Metrics,
     },
     async_trait::async_trait,
+    serde::Serialize,
     std::{sync::Arc, time::SystemTime},
     tracing::log::error,
     url::Url,
 };
 
-const BASE_URL: &str = "https://api-sb.meld.io";
+const BASE_URL: &str = "https://api.meld.io";
 const API_VERSION: &str = "2023-12-19";
 const DEFAULT_CATEGORY: &str = "CRYPTO_ONRAMP";
+const DEFAULT_SESSION_TYPE: &str = "BUY";
 
 #[derive(Debug)]
 pub struct MeldProvider {
@@ -40,6 +46,30 @@ impl MeldProvider {
             .send()
             .await
     }
+
+    async fn send_post_request<T>(
+        &self,
+        url: Url,
+        params: &T,
+    ) -> Result<reqwest::Response, reqwest::Error>
+    where
+        T: Serialize,
+    {
+        self.http_client
+            .post(url)
+            .json(&params)
+            .header("Meld-Version", API_VERSION)
+            .header("Authorization", format!("BASIC {}", self.api_key))
+            .send()
+            .await
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WidgetRequestParams {
+    pub session_data: SessionData,
+    pub session_type: String,
 }
 
 #[async_trait]
@@ -49,7 +79,7 @@ impl OnRampMultiProvider for MeldProvider {
         &self,
         params: ProvidersQueryParams,
         metrics: Arc<Metrics>,
-    ) -> RpcResult<ProvidersResponse> {
+    ) -> RpcResult<Vec<ProvidersResponse>> {
         let base = format!("{}/service-providers", BASE_URL);
         let mut url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
         if let Some(countries) = params.countries {
@@ -76,6 +106,97 @@ impl OnRampMultiProvider for MeldProvider {
             return Err(RpcError::OnRampProviderError);
         }
 
-        Ok(response.json::<ProvidersResponse>().await?)
+        Ok(response.json::<Vec<ProvidersResponse>>().await?)
+    }
+
+    #[tracing::instrument(skip(self), fields(provider = "Meld"), level = "debug")]
+    async fn get_providers_properties(
+        &self,
+        params: ProvidersPropertiesQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<serde_json::Value> {
+        let base_url = match params.r#type {
+            PropertyType::Countries => {
+                format!("{}/service-providers/properties/countries", BASE_URL)
+            }
+            PropertyType::CryptoCurrencies => format!(
+                "{}/service-providers/properties/crypto-currencies",
+                BASE_URL
+            ),
+            PropertyType::FiatCurrencies => {
+                format!("{}/service-providers/properties/fiat-currencies", BASE_URL)
+            }
+            PropertyType::PaymentMethods => {
+                format!("{}/service-providers/properties/payment-methods", BASE_URL)
+            }
+            PropertyType::FiatPurchasesLimits => format!(
+                "{}/service-providers/limits/fiat-currency-purchases",
+                BASE_URL
+            ),
+        };
+        let mut url = Url::parse(&base_url).map_err(|_| RpcError::OnRampParseURLError)?;
+        if let Some(countries) = params.countries {
+            url.query_pairs_mut().append_pair("countries", &countries);
+        }
+        url.query_pairs_mut()
+            .append_pair("categories", DEFAULT_CATEGORY);
+
+        let latency_start = SystemTime::now();
+        let response = self.send_get_request(url).await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("onramp_providers_properties".to_string()),
+        );
+
+        if !response.status().is_success() {
+            error!(
+                "Error on Meld providers properties response. Status is not OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::OnRampProviderError);
+        }
+
+        Ok(response.json().await?)
+    }
+
+    #[tracing::instrument(skip(self), fields(provider = "Meld"), level = "debug")]
+    async fn get_widget(
+        &self,
+        params: WidgetQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<WidgetResponse> {
+        let base = format!("{}/crypto/session/widget", BASE_URL);
+        let url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
+
+        let latency_start = SystemTime::now();
+        let response = self
+            .send_post_request(
+                url,
+                &WidgetRequestParams {
+                    session_type: DEFAULT_SESSION_TYPE.to_string(),
+                    session_data: params.session_data,
+                },
+            )
+            .await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("onramp_widget".to_string()),
+        );
+
+        if !response.status().is_success() {
+            error!(
+                "Error on Meld get widget url response. Status is not OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::OnRampProviderError);
+        }
+
+        Ok(response.json::<WidgetResponse>().await?)
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -17,11 +17,15 @@ use {
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
                 options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
+                properties::QueryParams as OnRampProvidersPropertiesQueryParams,
                 providers::{
                     ProvidersResponse as OnRampProvidersResponse,
                     QueryParams as OnRampProvidersQueryParams,
                 },
                 quotes::{OnRampBuyQuotesParams, OnRampBuyQuotesResponse},
+                widget::{
+                    QueryParams as OnRampWidgetQueryParams, WidgetResponse as OnRampWidgetResponse,
+                },
             },
             portfolio::{PortfolioQueryParams, PortfolioResponseBody},
             RpcQueryParams, SupportedCurrencies,
@@ -913,7 +917,19 @@ pub trait OnRampMultiProvider: Send + Sync + Debug {
         &self,
         params: OnRampProvidersQueryParams,
         metrics: Arc<Metrics>,
-    ) -> RpcResult<OnRampProvidersResponse>;
+    ) -> RpcResult<Vec<OnRampProvidersResponse>>;
+
+    async fn get_providers_properties(
+        &self,
+        params: OnRampProvidersPropertiesQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<serde_json::Value>;
+
+    async fn get_widget(
+        &self,
+        params: OnRampWidgetQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<OnRampWidgetResponse>;
 }
 
 #[async_trait]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -16,6 +16,9 @@ use {
             fungible_price::PriceResponseBody,
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
+                multi_quotes::{
+                    QueryParams as MultiQuotesQueryParams, QuotesResponse as MultiQuotesResponse,
+                },
                 options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
                 properties::QueryParams as OnRampProvidersPropertiesQueryParams,
                 providers::{
@@ -930,6 +933,12 @@ pub trait OnRampMultiProvider: Send + Sync + Debug {
         params: OnRampWidgetQueryParams,
         metrics: Arc<Metrics>,
     ) -> RpcResult<OnRampWidgetResponse>;
+
+    async fn get_quotes(
+        &self,
+        params: MultiQuotesQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<Vec<MultiQuotesResponse>>;
 }
 
 #[async_trait]

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -105,6 +105,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_DUNE_API_KEY", value = var.dune_api_key },
         { name = "RPC_PROXY_PROVIDER_SYNDICA_API_KEY", value = var.syndica_api_key },
         { name = "RPC_PROXY_PROVIDER_ALLNODES_API_KEY", value = var.allnodes_api_key },
+        { name = "RPC_PROXY_PROVIDER_MELD_API_KEY", value = var.meld_api_key },
 
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL", value = "http://127.0.0.1:${local.prometheus_proxy_port}/workspaces/${var.prometheus_workspace_id}" },
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_WORKSPACE_HEADER", value = "aps-workspaces.${module.this.region}.amazonaws.com" },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -278,6 +278,12 @@ variable "allnodes_api_key" {
   sensitive   = true
 }
 
+variable "meld_api_key" {
+  description = "Meld API key"
+  type        = string
+  sensitive   = true
+}
+
 variable "testing_project_id" {
   description = "Project ID used in a testing suite"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -82,6 +82,7 @@ module "ecs" {
   dune_api_key           = var.dune_api_key
   syndica_api_key        = var.syndica_api_key
   allnodes_api_key       = var.allnodes_api_key
+  meld_api_key           = var.meld_api_key
 
   # Project Registry
   registry_api_endpoint   = var.registry_api_endpoint

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -200,6 +200,12 @@ variable "allnodes_api_key" {
   sensitive   = true
 }
 
+variable "meld_api_key" {
+  description = "Meld API key"
+  type        = string
+  sensitive   = true
+}
+
 #-------------------------------------------------------------------------------
 # Analytics
 


### PR DESCRIPTION
# Description

This PR adds the following Meld API endpoints:
 * Get a list of available providers;
 * Providers properties:
   * countries,
   * crypto-currencies,
   * fiat-currencies,
   * payment-methods,
   * fiat-purchases-limits.
 * Get quotes;
 * Generate widget url.

The [API proposal document](https://www.notion.so/walletconnect/OnRamp-Meld-API-integration-1a43a661771e8021a482ebcbbbdb7053).

## How Has This Been Tested?

New integration tests were implemented.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence (before merging)

* [x] Update TFC `meld_api_key` to the production key
* [ ] Update API SPECs documentation
