### PR TITLE
feat(Tenderly): properly handling of the native currency token standard

### DIFF
--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -298,10 +298,14 @@ pub async fn get_assets_changes_from_simulation(
         if asset_changed.asset_type.clone() == AssetChangeType::Transfer
             && asset_changed.token_info.standard.clone() == TokenStandard::Erc20
             && asset_changed.to.is_some()
+            && asset_changed.token_info.contract_address.is_some()
         {
             asset_changes.push(Erc20AssetChange {
                 chain_id: transaction.chain_id.clone(),
-                asset_contract: asset_changed.token_info.contract_address,
+                asset_contract: asset_changed
+                    .token_info
+                    .contract_address
+                    .unwrap_or_default(),
                 amount: asset_changed.raw_amount,
                 receiver: asset_changed.to.unwrap_or_default(),
             })

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -84,7 +84,7 @@ pub enum AssetChangeType {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TokenInfo {
     pub standard: TokenStandard,
-    pub contract_address: Address,
+    pub contract_address: Option<Address>,
     pub decimals: Option<u8>,
 }
 
@@ -93,6 +93,7 @@ pub struct TokenInfo {
 pub enum TokenStandard {
     Erc20,
     Erc721,
+    #[serde(rename = "NativeCurrency")]
     NativeCurrency,
 }
 


### PR DESCRIPTION
# Description

This PR fixes the `NativeCurrency` token standard name in the Tenderly simulation result. The Tenderly response for this type is `NativeCurrency` and not in a screaming case like `ERC20`. Adding an exception for this type to avoid an internal server error. Also, the contract address is optional for this type.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
