### PR TITLE
feat(o11y): adding CA response types rate panel

### DIFF
--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -637,6 +637,15 @@ async fn handler_internal(
             ));
     }
 
+    state
+        .metrics
+        .add_ca_routes_found(construct_metrics_bridging_route(
+            bridge_chain_id.clone(),
+            bridge_contract.to_string(),
+            request_payload.transaction.chain_id.clone(),
+            asset_transfer_contract.to_string(),
+        ));
+
     return Ok(
         Json(PrepareResponse::Success(PrepareResponseSuccess::Available(
             PrepareResponseAvailable {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -88,6 +88,7 @@ pub struct Metrics {
     // Chain Abstracton
     pub ca_gas_estimation_tracker: Histogram<f64>,
     pub ca_no_routes_found_counter: Counter<u64>,
+    pub ca_routes_found_counter: Counter<u64>,
     pub ca_insufficient_funds_counter: Counter<u64>,
     pub ca_no_bridging_needed_counter: Counter<u64>,
 }
@@ -296,6 +297,11 @@ impl Metrics {
             .with_description("The number of times no routes were found for a CA")
             .init();
 
+        let ca_routes_found_counter = meter
+            .u64_counter("ca_routes_found")
+            .with_description("The number of times of sucess routes were found for a CA")
+            .init();
+
         let ca_insufficient_funds_counter = meter
             .u64_counter("ca_insufficient_funds")
             .with_description("The number of times insufficient funds were responded for a CA")
@@ -347,6 +353,7 @@ impl Metrics {
             rate_limited_responses_counter,
             ca_gas_estimation_tracker,
             ca_no_routes_found_counter,
+            ca_routes_found_counter,
             ca_insufficient_funds_counter,
             ca_no_bridging_needed_counter,
         }
@@ -703,6 +710,14 @@ impl Metrics {
     }
 
     pub fn add_ca_no_routes_found(&self, route: String) {
+        self.ca_no_routes_found_counter.add(
+            &otel::Context::new(),
+            1,
+            &[otel::KeyValue::new("route", route)],
+        );
+    }
+
+    pub fn add_ca_routes_found(&self, route: String) {
         self.ca_no_routes_found_counter.add(
             &otel::Context::new(),
             1,

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -196,10 +196,11 @@ dashboard.new(
     panels.names.registered(ds, vars)                { gridPos: pos_short._3 },
 
   row.new('Chain Abstraction'),
-    panels.chain_abstraction.gas_estimation(ds, vars)     { gridPos: pos_short._4 },
-    panels.chain_abstraction.insufficient_funds(ds, vars) { gridPos: pos_short._4 },
-    panels.chain_abstraction.no_bridging(ds, vars)        { gridPos: pos_short._4 },
-    panels.chain_abstraction.no_routes(ds, vars)          { gridPos: pos_short._4 },
+    panels.chain_abstraction.gas_estimation(ds, vars)       { gridPos: pos_short._4 },
+    panels.chain_abstraction.insufficient_funds(ds, vars)   { gridPos: pos_short._4 },
+    panels.chain_abstraction.no_bridging(ds, vars)          { gridPos: pos_short._4 },
+    panels.chain_abstraction.no_routes(ds, vars)            { gridPos: pos_short._4 },
+    panels.chain_abstraction.response_types_rates(ds, vars) { gridPos: pos_short._2 },
 
   row.new('Redis'),
     panels.redis.cpu(ds, vars)                    { gridPos: pos._2 },

--- a/terraform/monitoring/panels/chain_abstraction/response_types_rate.libsonnet
+++ b/terraform/monitoring/panels/chain_abstraction/response_types_rate.libsonnet
@@ -1,0 +1,38 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'CA response types rate',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(increase(ca_routes_found_total{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = 'Routes found (success)',
+    ))
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(increase(ca_insufficient_funds_total{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = 'Insufficient funds',
+    ))
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(increase(ca_no_bridging_needed_total{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = 'No bridging needed',
+    ))
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum(increase(ca_no_routes_found_total{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = 'No routes found',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -96,5 +96,6 @@ local redis  = panels.aws.redis;
     insufficient_funds: (import 'chain_abstraction/insufficient_funds.libsonnet').new,
     no_bridging: (import 'chain_abstraction/no_bridging.libsonnet').new,
     no_routes: (import 'chain_abstraction/no_routes.libsonnet').new,
+    response_types_rates: (import 'chain_abstraction/response_types_rate.libsonnet').new,
   },
 }


### PR DESCRIPTION
# Description

This PR adds tracking of the successful routes found responses compared to unsuccessful responses (no routes found, insufficient funds, no bridging needed).

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
