### PR TITLE
feat(Meld): adding Meld API base url as a variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ export RPC_PROXY_PROVIDER_DUNE_API_KEY=""
 export RPC_PROXY_PROVIDER_SYNDICA_API_KEY=""
 export RPC_PROXY_PROVIDER_ALLNODES_API_KEY=""
 export RPC_PROXY_PROVIDER_MELD_API_KEY=""
+export RPC_PROXY_PROVIDER_MELD_API_URL=""
 
 # PostgreSQL URI connection string
 export RPC_PROXY_POSTGRES_URI="postgres://postgres@localhost/postgres"

--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -90,6 +90,7 @@ jobs:
           RPC_PROXY_PROVIDER_SYNDICA_API_KEY: ""
           RPC_PROXY_PROVIDER_ALLNODES_API_KEY: ""
           RPC_PROXY_PROVIDER_MELD_API_KEY: ""
+          RPC_PROXY_PROVIDER_MELD_API_URL: ""
       - run: docker logs mock-bundler-anvil-1
         if: failure()
       - run: docker logs mock-bundler-alto-1

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -207,6 +207,7 @@ mod test {
             ("RPC_PROXY_PROVIDER_SYNDICA_API_KEY", "SYNDICA_API_KEY"),
             ("RPC_PROXY_PROVIDER_ALLNODES_API_KEY", "ALLNODES_API_KEY"),
             ("RPC_PROXY_PROVIDER_MELD_API_KEY", "MELD_API_KEY"),
+            ("RPC_PROXY_PROVIDER_MELD_API_URL", "MELD_API_URL"),
             (
                 "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL",
                 "PROMETHEUS_QUERY_URL",
@@ -319,6 +320,7 @@ mod test {
                     override_bundler_urls: None,
                     allnodes_api_key: "ALLNODES_API_KEY".to_string(),
                     meld_api_key: "MELD_API_KEY".to_string(),
+                    meld_api_url: "MELD_API_URL".to_string(),
                 },
                 rate_limiting: RateLimitingConfig {
                     max_tokens: Some(100),

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -18,7 +18,6 @@ use {
     url::Url,
 };
 
-const BASE_URL: &str = "https://api.meld.io";
 const API_VERSION: &str = "2023-12-19";
 const DEFAULT_CATEGORY: &str = "CRYPTO_ONRAMP";
 const DEFAULT_SESSION_TYPE: &str = "BUY";
@@ -27,14 +26,16 @@ const DEFAULT_SESSION_TYPE: &str = "BUY";
 pub struct MeldProvider {
     pub provider_kind: ProviderKind,
     pub api_key: String,
+    pub api_base_url: String,
     pub http_client: reqwest::Client,
 }
 
 impl MeldProvider {
-    pub fn new(api_key: String) -> Self {
+    pub fn new(api_base_url: String, api_key: String) -> Self {
         Self {
             provider_kind: ProviderKind::Meld,
             api_key,
+            api_base_url,
             http_client: reqwest::Client::new(),
         }
     }
@@ -94,7 +95,7 @@ impl OnRampMultiProvider for MeldProvider {
         params: ProvidersQueryParams,
         metrics: Arc<Metrics>,
     ) -> RpcResult<Vec<ProvidersResponse>> {
-        let base = format!("{}/service-providers", BASE_URL);
+        let base = format!("{}/service-providers", self.api_base_url);
         let mut url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
         if let Some(countries) = params.countries {
             url.query_pairs_mut().append_pair("countries", &countries);
@@ -147,21 +148,30 @@ impl OnRampMultiProvider for MeldProvider {
     ) -> RpcResult<serde_json::Value> {
         let base_url = match params.r#type {
             PropertyType::Countries => {
-                format!("{}/service-providers/properties/countries", BASE_URL)
+                format!(
+                    "{}/service-providers/properties/countries",
+                    self.api_base_url
+                )
             }
             PropertyType::CryptoCurrencies => format!(
                 "{}/service-providers/properties/crypto-currencies",
-                BASE_URL
+                self.api_base_url
             ),
             PropertyType::FiatCurrencies => {
-                format!("{}/service-providers/properties/fiat-currencies", BASE_URL)
+                format!(
+                    "{}/service-providers/properties/fiat-currencies",
+                    self.api_base_url
+                )
             }
             PropertyType::PaymentMethods => {
-                format!("{}/service-providers/properties/payment-methods", BASE_URL)
+                format!(
+                    "{}/service-providers/properties/payment-methods",
+                    self.api_base_url
+                )
             }
             PropertyType::FiatPurchasesLimits => format!(
                 "{}/service-providers/limits/fiat-currency-purchases",
-                BASE_URL
+                self.api_base_url
             ),
         };
         let mut url = Url::parse(&base_url).map_err(|_| RpcError::OnRampParseURLError)?;
@@ -214,7 +224,7 @@ impl OnRampMultiProvider for MeldProvider {
         params: WidgetQueryParams,
         metrics: Arc<Metrics>,
     ) -> RpcResult<WidgetResponse> {
-        let base = format!("{}/crypto/session/widget", BASE_URL);
+        let base = format!("{}/crypto/session/widget", self.api_base_url);
         let url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
 
         let latency_start = SystemTime::now();
@@ -267,7 +277,7 @@ impl OnRampMultiProvider for MeldProvider {
         params: MultiQuotesQueryParams,
         metrics: Arc<Metrics>,
     ) -> RpcResult<Vec<QuotesResponse>> {
-        let base = format!("{}/payments/crypto/quote", BASE_URL);
+        let base = format!("{}/payments/crypto/quote", self.api_base_url);
         let url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
 
         let latency_start = SystemTime::now();

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -174,6 +174,8 @@ pub struct ProvidersConfig {
     pub allnodes_api_key: String,
     /// Meld API key
     pub meld_api_key: String,
+    /// Meld API Base URL
+    pub meld_api_url: String,
 
     pub override_bundler_urls: Option<MockAltoUrls>,
 }
@@ -304,7 +306,10 @@ impl ProviderRepository {
             "https://pay.coinbase.com/api/v1".into(),
         ));
 
-        let meld_onramp_provider = Arc::new(MeldProvider::new(config.meld_api_key.clone()));
+        let meld_onramp_provider = Arc::new(MeldProvider::new(
+            config.meld_api_url.clone(),
+            config.meld_api_key.clone(),
+        ));
 
         let bundler_ops_provider: Arc<dyn BundlerOpsProvider> =
             if let Some(override_bundler_url) = config.override_bundler_urls.clone() {

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -106,6 +106,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_SYNDICA_API_KEY", value = var.syndica_api_key },
         { name = "RPC_PROXY_PROVIDER_ALLNODES_API_KEY", value = var.allnodes_api_key },
         { name = "RPC_PROXY_PROVIDER_MELD_API_KEY", value = var.meld_api_key },
+        { name = "RPC_PROXY_PROVIDER_MELD_API_URL", value = var.meld_api_url },
 
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL", value = "http://127.0.0.1:${local.prometheus_proxy_port}/workspaces/${var.prometheus_workspace_id}" },
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_WORKSPACE_HEADER", value = "aps-workspaces.${module.this.region}.amazonaws.com" },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -284,6 +284,12 @@ variable "meld_api_key" {
   sensitive   = true
 }
 
+variable "meld_api_url" {
+  description = "Meld API base URL. e.g. https://api.meld.io"
+  type        = string
+  sensitive   = true
+}
+
 variable "testing_project_id" {
   description = "Project ID used in a testing suite"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -83,6 +83,7 @@ module "ecs" {
   syndica_api_key        = var.syndica_api_key
   allnodes_api_key       = var.allnodes_api_key
   meld_api_key           = var.meld_api_key
+  meld_api_url           = var.meld_api_url
 
   # Project Registry
   registry_api_endpoint   = var.registry_api_endpoint

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -206,6 +206,12 @@ variable "meld_api_key" {
   sensitive   = true
 }
 
+variable "meld_api_url" {
+  description = "Meld API base URL. e.g. https://api.meld.io"
+  type        = string
+  sensitive   = true
+}
+
 #-------------------------------------------------------------------------------
 # Analytics
 


### PR DESCRIPTION
# Description

This PR adds Meld API base URL as a variable to distinguish staging and prod environments for swaps testing. Meld is using different API keys and API endpoints for testing and production environments.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
