### PR TITLE
fix(Pimlico): injecting state overrides only if not provided

### DIFF
--- a/src/providers/pimlico.rs
+++ b/src/providers/pimlico.rs
@@ -48,16 +48,20 @@ impl BundlerOpsProvider for PimlicoProvider {
         // balance override during estimation to prevent AA21 errors
         if method == &SupportedBundlerOps::EthEstimateUserOperationGas {
             if let Some(array) = params.as_array_mut() {
-                if let Some(sender) = array
-                    .first()
-                    .and_then(|first| first.get("sender"))
-                    .and_then(serde_json::Value::as_str)
-                {
-                    // Adding 100 ETH to the smart account
-                    let new_param = serde_json::json!({
-                        sender: BalanceOverride { balance: "0x56BC75E2D63100000".into() },
-                    });
-                    array.push(new_param);
+                // Apply the balance override injection only if the array
+                // length is 2 parameters (no status override passed as a third parameter)
+                if array.len() == 2 {
+                    if let Some(sender) = array
+                        .first()
+                        .and_then(|first| first.get("sender"))
+                        .and_then(serde_json::Value::as_str)
+                    {
+                        // Adding 100 ETH to the smart account
+                        let new_param = serde_json::json!({
+                            sender: BalanceOverride { balance: "0x56BC75E2D63100000".into() },
+                        });
+                        array.push(new_param);
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

This PR fixes a bug when the state overrides injecting when the parameter provides it. 
This is a follow-up to #982, which adds the state overrides only if the parameter length is 2 and only when the state override was not provided. 

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
