### PR TITLE
fix(Meld): changing the source amount type to be f64

### DIFF
--- a/src/handlers/onramp/widget.rs
+++ b/src/handlers/onramp/widget.rs
@@ -28,7 +28,7 @@ pub struct SessionData {
     pub payment_method_type: Option<String>,
     pub redirect_url: Option<String>,
     pub service_provider: String,
-    pub source_amount: String,
+    pub source_amount: f64,
     pub source_currency_code: String,
     pub wallet_address: String,
     pub wallet_tag: Option<String>,


### PR DESCRIPTION
# Description

This PR fixes the Meld input parameter for the onramp for the source amount from `String` to be `f64` since we are using just a float number here.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
