### PR TITLE
feat(Providers): adding Berachain Mainnet support

### DIFF
--- a/src/env/berachain.rs
+++ b/src/env/berachain.rs
@@ -35,6 +35,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
     HashMap::from([
+        // Berachain Mainnet
+        (
+            "eip155:80094".into(),
+            (
+                "https://rpc.berachain.com/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Berachain bArtio
         (
             "eip155:80084".into(),

--- a/tests/functional/http/berachain.rs
+++ b/tests/functional/http/berachain.rs
@@ -6,7 +6,15 @@ use {
 #[test_context(ServerContext)]
 #[tokio::test]
 #[ignore]
-async fn berachain_provider_eip155_80084(ctx: &mut ServerContext) {
+async fn berachain_provider(ctx: &mut ServerContext) {
+    // Berachain Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Berachain,
+        "eip155:80094",
+        "0x138de",
+    )
+    .await;
     // Berachain bArtio
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,


### PR DESCRIPTION
# Description

This PR adds Berachain Mainnet `eip155:80094` RPC support by adding the Berachain native mainnet RPC endpoint.

## How Has This Been Tested?

The integration test for the Berachain provider was updated and passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
