### PR TITLE
fix(CA): adding a proper USDs contract, fixing decimals amount conversion, fixing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,12 +2291,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -2449,7 +2443,7 @@ dependencies = [
  "hidapi-rusb",
  "js-sys",
  "log",
- "nix 0.26.4",
+ "nix",
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
@@ -2882,7 +2876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -4089,10 +4082,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -4143,26 +4134,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "governor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
-dependencies = [
- "cfg-if",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.1",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "spinning_top",
- "web-time",
 ]
 
 [[package]]
@@ -5445,15 +5416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metrics"
 version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
@@ -5627,28 +5589,9 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
  "pin-utils",
 ]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
- "memoffset 0.9.1",
-]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "no-std-net"
@@ -5671,12 +5614,6 @@ name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
@@ -6265,14 +6202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phi-accrual-failure-detector"
-version = "0.1.0"
-source = "git+https://github.com/heilhead/phi-accrual-failure-detector.git?rev=01e5706#01e5706e73cbb3f29fb5542a1bfb359502503a24"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6712,7 +6641,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -8108,15 +8037,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -9722,7 +9642,6 @@ dependencies = [
  "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
  "wcn_auth",
  "wcn_domain",
- "wcn_echo_api",
  "wcn_rpc",
 ]
 
@@ -9776,27 +9695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wcn_echo_api"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "futures",
- "governor",
- "phi-accrual-failure-detector",
- "serde",
- "tap",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tokio-serde",
- "tokio-serde-postcard",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
-]
-
-[[package]]
 name = "wcn_replication"
 version = "0.1.0"
 dependencies = [
@@ -9826,7 +9724,6 @@ dependencies = [
  "libp2p",
  "libp2p-tls",
  "metrics 0.23.0",
- "nix 0.28.0",
  "pin-project 1.1.10",
  "quinn",
  "quinn-proto",

--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -9,7 +9,7 @@ describe('Chain abstraction orchestrator', () => {
     'function approve(address spender, uint256 amount) public returns (bool)'
   ]);
 
-  // Funding address
+  // Default funding address
   const from_address_with_funds = "0x2aae531a81461f029cd55cb46703211c9227ba05";
 
   // Receiver address
@@ -22,36 +22,102 @@ describe('Chain abstraction orchestrator', () => {
   
   // Current funds on different chains
   const usdc_token_symbol = "USDC";
-  let usdc_funds = {};
+  const usdc_funds = {};
   usdc_funds[chain_id_base] = 3_000_000;
   usdc_funds[chain_id_optimism] = 1_057_151;
 
   const usdt_token_symbol = "USDT";
-  let usdt_funds = {};
+  const usdt_funds = {};
   usdt_funds[chain_id_arbitrum] = 3_388_000;
   usdt_funds[chain_id_optimism] = 1_050_000;
 
   const usds_token_symbol = "USDS";
-  let usds_funds = {};
-  // Using string amouns for USDS, as it has 18 decimals
-  usds_funds[chain_id_optimism] = "902165684795715063";
+  const usds_funds = {};
+  usds_funds[chain_id_optimism] = "902165684795715063"; // Using string amounts for USDS, as it has 18 decimals
+
+  // Token decimals
+  const token_decimals = {};
+  token_decimals[usdc_token_symbol] = 6;
+  token_decimals[usdt_token_symbol] = 6;
+  token_decimals[usds_token_symbol] = 18;
 
   // Amount to send to Optimism
   const amount_to_send = 3_000_000
   
-  let usdc_contracts = {};
+  // Asset contracts
+  const usdc_contracts = {};
   usdc_contracts[chain_id_optimism] = "0x0b2c639c533813f4aa9d7837caf62653d097ff85";
   usdc_contracts[chain_id_base] = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
   usdc_contracts[chain_id_arbitrum] = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
-  let usdt_contracts = {};
+  const usdt_contracts = {};
   usdt_contracts[chain_id_optimism] = "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58";
   usdt_contracts[chain_id_arbitrum] = "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9";
   usdt_contracts[chain_id_base] = "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2";
-  let usds_contracts = {};
-  usds_contracts[chain_id_optimism] = "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1";
-  usds_contracts[chain_id_arbitrum] = "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1";
+  const usds_contracts = {};
+  usds_contracts[chain_id_base] = "0x820c137fa70c8691f0e44dc420a5e53c168921dc";
 
+  // Mutable variable to store the orchestrationId for getting status
   let orchestration_id = "";
+
+  function checkRoutesResponse(
+    response_object,
+    sender_address,
+    receiver_address,
+    initial_tx_token_contract,
+    initial_tx_token_symbol,
+    initial_tx_amount,
+    bridging_tx_token_chain_id,
+    bridging_tx_token_contract,
+    bridging_tx_token_symbol,
+  ){
+      expect(typeof response_object.orchestrationId).toBe('string')
+
+      // Expecting 2 transactions in the route
+      expect(response_object.transactions.length).toBe(2)
+
+      // Check for the initialTransaction
+      const initialTransaction = response_object.initialTransaction;
+      expect(initialTransaction.from).toBe(sender_address.toLowerCase());
+      expect(initialTransaction.to).toBe(initial_tx_token_contract.toLowerCase());
+      expect(initialTransaction.gasLimit).not.toBe("0x00");
+
+      // Check the initialTransaction metadata
+      const initialTransactionMetadata = response_object.metadata.initialTransaction
+      expect(initialTransactionMetadata.symbol).toBe(initial_tx_token_symbol)
+      expect(initialTransactionMetadata.transferTo).toBe(receiver_address.toLowerCase())
+      expect(initialTransactionMetadata.tokenContract).toBe(initial_tx_token_contract.toLowerCase())
+      expect(BigInt(initialTransactionMetadata.amount)).toBe(BigInt(initial_tx_amount));
+      expect(initialTransactionMetadata.decimals).toBe(token_decimals[initial_tx_token_symbol])
+
+      // Check the metadata fundingFrom
+      const fundingFrom = response_object.metadata.fundingFrom[0]
+      expect(fundingFrom.chainId).toBe(bridging_tx_token_chain_id)
+      expect(fundingFrom.symbol).toBe(bridging_tx_token_symbol)
+      expect(fundingFrom.tokenContract).toBe(bridging_tx_token_contract.toLowerCase())
+      expect(fundingFrom.decimals).toBe(token_decimals[bridging_tx_token_symbol])
+      const bridging_amount = BigInt(fundingFrom.amount)
+
+      // First transaction expected to be the approval transaction
+      const approvalTransaction = response_object.transactions[0]
+      expect(approvalTransaction.chainId).toBe(bridging_tx_token_chain_id)
+      expect(approvalTransaction.nonce).not.toBe("0x00")
+      expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
+      const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
+      if (BigInt(decodedData.amount) < bridging_amount) {
+        throw new Error(`Expected approval amount is incorrect`);
+      }
+
+      // Second transaction expected to be the bridging to the Base
+      const bridgingTransaction = response_object.transactions[1]
+      expect(bridgingTransaction.chainId).toBe(bridging_tx_token_chain_id)
+      expect(bridgingTransaction.nonce).not.toBe("0x00")
+      expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
+
+      // Check the metadata checkIn
+      expect(typeof response_object.metadata.checkIn).toBe('number')
+
+      return response_object.orchestrationId;
+  }
 
   it('bridging unavailable (insufficient funds)', async () => {
     // Having the USDC balance on Base chain less then the amount to send
@@ -61,7 +127,7 @@ describe('Chain abstraction orchestrator', () => {
       amount_to_send_in_decimals,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: from_address_with_funds,
         to: usdc_contracts[chain_id_optimism],
@@ -88,7 +154,7 @@ describe('Chain abstraction orchestrator', () => {
       amount_to_send_in_decimals,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: empty_wallet_address,
         to: usdc_contracts[chain_id_optimism],
@@ -114,7 +180,7 @@ describe('Chain abstraction orchestrator', () => {
       amount_to_send_in_decimals,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: from_address_with_funds,
         to: usdc_contracts[chain_id_optimism],
@@ -133,7 +199,7 @@ describe('Chain abstraction orchestrator', () => {
 
   })
 
-  it('bridging routes (routes available, USDC Base → USDC Optimism)', async () => {
+  it('bridging routes (USDC Base → USDC Optimism)', async () => {
     // Sending USDC to Optimism, but having the balance of USDC on Base chain
     // which expected to be used for bridging
 
@@ -145,7 +211,7 @@ describe('Chain abstraction orchestrator', () => {
       amount_to_send,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: from_address_with_funds,
         to: usdc_contracts[chain_id_optimism],
@@ -161,58 +227,20 @@ describe('Chain abstraction orchestrator', () => {
     )
     expect(resp.status).toBe(200)
 
-    const data = resp.data
-    expect(typeof data.orchestrationId).toBe('string')
-    // Expecting 2 transactions in the route
-    expect(data.transactions.length).toBe(2)
-
-    // First transaction expected to be the approval transaction
-    const approvalTransaction = data.transactions[0]
-    expect(approvalTransaction.chainId).toBe(chain_id_base)
-    expect(approvalTransaction.nonce).not.toBe("0x00")
-    expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
-    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
-    if (decodedData.amount <= BigInt(amount_to_topup)) {
-      throw new Error(`Expected amount is lower then the minimal required`);
-    }
-
-    // Second transaction expected to be the bridging to the Base
-    const bridgingTransaction = data.transactions[1]
-    expect(bridgingTransaction.chainId).toBe(chain_id_base)
-    expect(bridgingTransaction.nonce).not.toBe("0x00")
-    expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
-
-    // Check for the initialTransaction
-    const initialTransaction = data.initialTransaction;
-    expect(initialTransaction.from).toBe(from_address_with_funds.toLowerCase());
-    expect(initialTransaction.to).toBe(usdc_contracts[chain_id_optimism].toLowerCase());
-    expect(initialTransaction.gasLimit).not.toBe("0x00");
-
-    // Check the metadata fundingFrom
-    const fundingFrom = data.metadata.fundingFrom[0]
-    expect(fundingFrom.chainId).toBe(chain_id_base)
-    expect(fundingFrom.symbol).toBe(usdc_token_symbol)
-    expect(fundingFrom.tokenContract).toBe(usdc_contracts[chain_id_base].toLowerCase())
-    if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup)) {
-      throw new Error(`Expected amount is lower then the minimal required`);
-    }
-    if (BigInt(fundingFrom.bridgingFee) < BigInt(fundingFrom.amount - amount_to_topup)){
-      throw new Error(`Expected bridging fee is incorrect. `);
-    }
-    // Check the initialTransaction metadata
-    const initialTransactionMetadata = data.metadata.initialTransaction
-    expect(initialTransactionMetadata.symbol).toBe(usdc_token_symbol)
-    expect(initialTransactionMetadata.transferTo).toBe(receiver_address.toLowerCase())
-    expect(initialTransactionMetadata.tokenContract).toBe(usdc_contracts[chain_id_optimism].toLowerCase())
-
-    // Check the metadata checkIn
-    expect(typeof data.metadata.checkIn).toBe('number')
-
-    // Set the Orchestration ID for the next test
-    orchestration_id = data.orchestrationId;
+    orchestration_id = checkRoutesResponse(
+      resp.data,
+      from_address_with_funds,
+      receiver_address,
+      usdc_contracts[chain_id_optimism],
+      usdc_token_symbol,
+      amount_to_send,
+      chain_id_base,
+      usdc_contracts[chain_id_base],
+      usdc_token_symbol,
+    )
   })
 
-  it('bridging routes (routes available, USDT Arbitrum → USDT Optimism)', async () => {
+  it('bridging routes (USDT Arbitrum → USDT Optimism)', async () => {
     // Sending USDT to Optimism, but having the USDT balance on Arbitrum.
 
     // How much needs to be topped up
@@ -223,7 +251,7 @@ describe('Chain abstraction orchestrator', () => {
       amount_to_send,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: from_address_with_funds,
         to: usdt_contracts[chain_id_optimism],
@@ -239,67 +267,29 @@ describe('Chain abstraction orchestrator', () => {
     )
     expect(resp.status).toBe(200)
 
-    const data = resp.data
-    expect(typeof data.orchestrationId).toBe('string')
-    // Expecting 2 transactions in the route
-    expect(data.transactions.length).toBe(2)
-
-    // First transaction expected to be the approval transaction
-    const approvalTransaction = data.transactions[0]
-    expect(approvalTransaction.chainId).toBe(chain_id_arbitrum)
-    expect(approvalTransaction.nonce).not.toBe("0x00")
-    expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
-    const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
-    if (decodedData.amount <= BigInt(amount_to_topup)) {
-      throw new Error(`Expected amount is lower then the minimal required`);
-    }
-
-    // Second transaction expected to be the bridging to the Arbitrum
-    const bridgingTransaction = data.transactions[1]
-    expect(bridgingTransaction.chainId).toBe(chain_id_arbitrum)
-    expect(bridgingTransaction.nonce).not.toBe("0x00")
-    expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
-
-    // Check for the initialTransaction
-    const initialTransaction = data.initialTransaction;
-    expect(initialTransaction.from).toBe(from_address_with_funds.toLowerCase());
-    expect(initialTransaction.to).toBe(usdt_contracts[chain_id_optimism].toLowerCase());
-    expect(initialTransaction.gasLimit).not.toBe("0x00");
-
-    // Check the metadata fundingFrom
-    const fundingFrom = data.metadata.fundingFrom[0]
-    expect(fundingFrom.chainId).toBe(chain_id_arbitrum)
-    expect(fundingFrom.symbol).toBe(usdt_token_symbol)
-    expect(fundingFrom.tokenContract).toBe(usdt_contracts[chain_id_arbitrum].toLowerCase())
-    if (BigInt(fundingFrom.amount) <= BigInt(amount_to_topup)) {
-      throw new Error(`Expected amount is lower then the minimal required`);
-    }
-    if (BigInt(fundingFrom.bridgingFee) < BigInt(fundingFrom.amount - amount_to_topup)){
-      throw new Error(`Expected bridging fee is incorrect. `);
-    }
-    // Check the initialTransaction metadata
-    const initialTransactionMetadata = data.metadata.initialTransaction
-    expect(initialTransactionMetadata.symbol).toBe(usdt_token_symbol)
-    expect(initialTransactionMetadata.transferTo).toBe(receiver_address.toLowerCase())
-    expect(initialTransactionMetadata.tokenContract).toBe(usdt_contracts[chain_id_optimism].toLowerCase())
-
-    // Check the metadata checkIn
-    expect(typeof data.metadata.checkIn).toBe('number')
-
-    // Set the Orchestration ID for the next test
-    orchestration_id = data.orchestrationId;
+    orchestration_id = checkRoutesResponse(
+      resp.data,
+      from_address_with_funds,
+      receiver_address,
+      usdt_contracts[chain_id_optimism],
+      usdt_token_symbol,
+      amount_to_send,
+      chain_id_arbitrum,
+      usdt_contracts[chain_id_arbitrum],
+      usdt_token_symbol,
+    )
   })
 
-  it('bridging routes (routes available, USDT Optimism → USDT Arbitrum)', async () => {
+  it('bridging routes (USDT Optimism → USDT Arbitrum)', async () => {
     // Sending USDT on Arbitrum, but having the USDT balance on Optimism.
-    let amount_to_send = usdt_funds[chain_id_arbitrum] + 500_000;
+    const amount_to_send = usdt_funds[chain_id_arbitrum] + 265_000;
 
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
       amount_to_send,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: from_address_with_funds,
         to: usdt_contracts[chain_id_arbitrum],
@@ -315,25 +305,74 @@ describe('Chain abstraction orchestrator', () => {
     )
     expect(resp.status).toBe(200)
 
-    const data = resp.data
-    expect(typeof data.orchestrationId).toBe('string')
-    // Expecting 2 transactions in the route
-    expect(data.transactions.length).toBe(2)
+    orchestration_id = checkRoutesResponse(
+      resp.data,
+      from_address_with_funds,
+      receiver_address,
+      usdt_contracts[chain_id_arbitrum],
+      usdt_token_symbol,
+      amount_to_send,
+      chain_id_optimism,
+      usdt_contracts[chain_id_optimism],
+      usdt_token_symbol,
+    )
   })
 
-  it('bridging routes (routes available, USDC Base → USDS(DAI) Optimism)', async () => {
-    // Sending USDS on Optimism, but having the USDC balance on Base.
-    let amount_to_send = "2802165684795715100";
+  it('bridging routes (USDC Base → USDS Base)', async () => {
+    // Override the default address to source from the USDC Base only.
+    const from_address_with_funds = "0xe6f8b93B0eed834816C5aDd2aA0989e2fF97616c";
+    // Sending USDS on Base, but having the USDC balance on Base.
+    const amount_to_send = "2000005684795715100";
 
     const data_encoded = erc20Interface.encodeFunctionData('transfer', [
       receiver_address,
       amount_to_send,
     ]);
 
-    let transactionObj = {
+    const transactionObj = {
       transaction: {
         from: from_address_with_funds,
-        to: usds_contracts[chain_id_optimism],
+        to: usds_contracts[chain_id_base],
+        value: "0x00", // Zero native tokens
+        input: data_encoded,
+        chainId: chain_id_base,
+      }
+    }
+
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/ca/orchestrator/route?projectId=${projectId}`,
+      transactionObj
+    )
+    expect(resp.status).toBe(200)
+
+    orchestration_id = checkRoutesResponse(
+      resp.data,
+      from_address_with_funds,
+      receiver_address,
+      usds_contracts[chain_id_base],
+      usds_token_symbol,
+      amount_to_send,
+      chain_id_base,
+      usdc_contracts[chain_id_base],
+      usdc_token_symbol,
+    )
+  })
+
+  it('bridging routes (USDS Base → USDC Optimism)', async () => {
+    // Override the default address to source from the USDS Base only.
+    const from_address_with_funds = "0xFB85fBfF17B35C3c2889Bcec1D38cf3B8Bb228e0";
+    // Sending USDC on Optimims, but having the USDS balance on Base.
+    const amount_to_send = "600000";
+
+    const data_encoded = erc20Interface.encodeFunctionData('transfer', [
+      receiver_address,
+      amount_to_send,
+    ]);
+
+    const transactionObj = {
+      transaction: {
+        from: from_address_with_funds,
+        to: usdc_contracts[chain_id_optimism],
         value: "0x00", // Zero native tokens
         input: data_encoded,
         chainId: chain_id_optimism,
@@ -346,11 +385,18 @@ describe('Chain abstraction orchestrator', () => {
     )
     expect(resp.status).toBe(200)
 
-    const data = resp.data
-    expect(typeof data.orchestrationId).toBe('string')
+    orchestration_id = checkRoutesResponse(
+      resp.data,
+      from_address_with_funds,
+      receiver_address,
+      usdc_contracts[chain_id_optimism],
+      usdc_token_symbol,
+      amount_to_send,
+      chain_id_base,
+      usds_contracts[chain_id_base],
+      usds_token_symbol,
+    )
 
-    // Expecting 2 transactions in the route
-    expect(data.transactions.length).toBe(2)
   })
 
   it('bridging status', async () => {

--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -49,7 +49,7 @@ describe('Fungible price', () => {
 
     for (const item of resp.data.fungibles) {
       expect(item.name).toBe('Wrapped SOL')
-      expect(item.symbol).toBe('SOL')
+      expect(item.symbol).toBe('WSOL')
       expect(typeof item.iconUrl).toBe('string')
       expect(typeof item.price).toBe('number')
       expect(item.address).toBe(wsol_token_address)

--- a/src/handlers/chain_agnostic/assets.rs
+++ b/src/handlers/chain_agnostic/assets.rs
@@ -39,10 +39,8 @@ static USDT_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
 };
 
 static USDS_CONTRACTS: phf::Map<&'static str, Address> = phf_map! {
-    // Optimism
-    "eip155:10" => address!("DA10009cBd5D07dd0CeCc66161FC93D7c9000da1"),
-    // Arbitrum
-    "eip155:42161" => address!("DA10009cBd5D07dd0CeCc66161FC93D7c9000da1"),
+    // Base
+    "eip155:8453" => address!("820c137fa70c8691f0e44dc420a5e53c168921dc"),
 };
 
 pub static BRIDGING_ASSETS: phf::Map<&'static str, AssetEntry> = phf_map! {
@@ -82,8 +80,7 @@ pub static BRIDGING_ASSETS: phf::Map<&'static str, AssetEntry> = phf_map! {
         simulation: SimulationParams {
             // Must be in sync with the `USDS_CONTRACTS` from above
             balance_storage_slots: &phf_map! {
-                "eip155:10" => 2u64,
-                "eip155:42161" => 2u64,
+                "eip155:8453" => 2u64,
             },
             balance: 99000000000000000000000,
         },


### PR DESCRIPTION
# Description

This PR removes DAI support in favor of the USDs (Base chain only) support. 
Fixing a bug in the final bridging fee calculations and amount checks between different asset decimals.
Fixing integration tests by removing repeated parts for route checks and using a reusable `checkRoutesResponse` function with a broader schema and values checks for each route test.

## How Has This Been Tested?

* New integration tests for sourcing to USDs and funding from USDs,
* Fixed USDC and USDT integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
