### PR TITLE
fix(CA): proper nonce calculation for the same chain swaps

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -388,6 +388,14 @@ describe('Chain abstraction orchestrator', () => {
       usdc_contracts[funding_chain_id],
       usdc_token_symbol,
     )
+
+    // Check nonce for the same chain swap
+    const approval_nonce = Number(resp.data.transactions[0].nonce);
+    const bridging_nonce = Number(resp.data.transactions[1].nonce);
+    const initial_tx_nonce = Number(resp.data.initialTransaction.nonce);
+    expect(bridging_nonce).toBe(approval_nonce + 1);
+    expect(initial_tx_nonce).toBe(bridging_nonce + 1);
+
     await checkStatus(orchestration_id)
   })
 


### PR DESCRIPTION
# Description

This PR fixes the nonce calculation for the initial transaction for cases where there is only a swap on the same chain performing.

Also, handling the negative bridging fee on USDs swaps considering it as a zero fee.

## How Has This Been Tested?

The integration test was updated to check this case.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
