### PR TITLE
fix: allow simple requests with JSON

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod network;
 pub mod permissions;
 pub mod rate_limit;
 pub mod sessions;
+pub mod simple_request_json;
 
 pub fn generate_random_string(len: usize) -> String {
     let rng = rand::thread_rng();

--- a/src/utils/simple_request_json.rs
+++ b/src/utils/simple_request_json.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use axum::extract::rejection::JsonRejection;
+use axum::http::{HeaderValue, Request};
+use axum::Json;
+use axum::{body::HttpBody, extract::FromRequest, BoxError};
+use serde::de::DeserializeOwned;
+
+/// Same as axum::Json but doesn't care what the Content-Type header is
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct SimpleRequestJson<T>(pub T);
+
+#[async_trait]
+impl<T, S, B> FromRequest<S, B> for SimpleRequestJson<T>
+where
+    T: DeserializeOwned,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<BoxError>,
+    S: Send + Sync,
+{
+    type Rejection = JsonRejection;
+
+    async fn from_request(mut req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+        // Fake the header to make the extractor happy
+        req.headers_mut()
+            .entry("content-type")
+            .or_insert(HeaderValue::from_static("application/json"));
+
+        let inner = Json::from_request(req, state).await?;
+
+        Ok(Self(inner.0))
+    }
+}


### PR DESCRIPTION
# Description

Adds a `SimpleRequestJson` extractor which is the same as the normal `Json` extractor except that it's compatible with any Content-Type. It does this by modifying the request to have the `application/json` content type and then passing it to the normal `Json` extractor.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
