### PR TITLE
fix(Prometheus): adding a check that the Prometheus server is ready in a constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2226,22 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -4865,6 +4892,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex_fmt"
@@ -13627,11 +13660,13 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
+source = "git+https://github.com/reown-com/yttrium.git?rev=e305639fb44832b1c2ce834c240b63dfac692bec#e305639fb44832b1c2ce834c240b63dfac692bec"
 dependencies = [
  "alloy 0.11.1",
  "alloy-provider 0.11.1",
  "async-trait",
  "bincode",
+ "bip39",
  "data-encoding",
  "dotenvy",
  "erc6492",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .transpose()?
         .map(|r| Arc::new(r) as Arc<dyn KeyValueStorage<BalanceResponseBody> + 'static>);
 
-    let providers = init_providers(&config.providers);
+    let providers = init_providers(&config.providers).await;
 
     let external_ip = config
         .server
@@ -495,7 +495,7 @@ fn create_server(
     axum::Server::bind(addr).serve(app.into_make_service_with_connect_info::<SocketAddr>())
 }
 
-fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
+async fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     // Redis pool for providers responses caching where needed
     let mut redis_pool = None;
     if let Some(redis_addr) = &config.cache_redis_addr {
@@ -518,7 +518,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
 
     // Keep in-sync with SUPPORTED_CHAINS.md
 
-    let mut providers = ProviderRepository::new(config);
+    let mut providers = ProviderRepository::new(config).await;
     providers.add_rpc_provider::<AuroraProvider, AuroraConfig>(AuroraConfig::default());
     providers.add_rpc_provider::<ArbitrumProvider, ArbitrumConfig>(ArbitrumConfig::default());
     providers.add_rpc_provider::<PoktProvider, PoktConfig>(PoktConfig::new(


### PR DESCRIPTION
# Description

This PR adds a check that the Prometheus server is ready in a constructor for better error messaging.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
