### PR TITLE
chore: add Caip19Asset and Caip2ChainId

### DIFF
--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -61,6 +61,11 @@ static CAIP19_TOKEN_ID_REGEX: Lazy<Regex> = Lazy::new(|| {
         .expect("Failed to initialize regexp for the CAIP-19 token ID format")
 });
 
+static CAIP2_REFERENCE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^[-a-zA-Z0-9]{1,32}$")
+        .expect("Failed to initialize regexp for the CAIP-2 reference format")
+});
+
 static CAIP2_NAMESPACE_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^[-a-z0-9]{3,8}$")
         .expect("Failed to initialize regexp for the CAIP-2 namespace format")
@@ -817,7 +822,7 @@ impl Caip2ChainId {
                 namespace
             )));
         }
-        if !CAIP_CHAIN_ID_REGEX.is_match(&reference) {
+        if !CAIP2_REFERENCE_REGEX.is_match(&reference) {
             return Err(CryptoUitlsError::WrongChainIdFormat(format!(
                 "CAIP-2 reference must be 1-32 characters of letters, digits, hyphens, or underscores: {}",
                 reference

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -1233,7 +1233,7 @@ mod tests {
         assert_eq!(eth_asset.asset_namespace(), "slip44");
         assert_eq!(eth_asset.asset_reference(), "60");
         assert!(eth_asset.token_id().is_none());
-        assert!(!eth_asset.token_id().is_some());
+        assert!(eth_asset.token_id().is_none());
         assert_eq!(eth_asset.to_string(), eth_asset_str);
 
         let erc20_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
@@ -1244,7 +1244,7 @@ mod tests {
         assert_eq!(erc20_asset.asset_namespace(), "erc20");
         assert_eq!(erc20_asset.asset_reference(), erc20_address);
         assert!(erc20_asset.token_id().is_none());
-        assert!(!erc20_asset.token_id().is_some());
+        assert!(erc20_asset.token_id().is_none());
         assert_eq!(erc20_asset.to_string(), erc20_asset_str);
 
         // Test parsing valid CAIP-19 identifiers with token ID


### PR DESCRIPTION
# Description

Adding `Caip2ChainId` and `Caip19Asset`

Note: Didn't change the current implementation of `ChainId` and its usage

Introduced a new regex that matches the CAIP2 spec exactly, which is not the case with `CAIP_CHAIN_ID_REGEX`

Resolves # (issue)

## How Has This Been Tested?

Automated test coverage

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
