### PR TITLE
feat(providers): adding Monad Testnet RPC support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -27,6 +27,7 @@ Chain name with associated `chainId` query param to use.
 | Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5003          |
 | Kaia Mainnet                                             | eip155:8217          |
 | Base                                                     | eip155:8453          |
+| Monad Testnet                                            | eip155:10143         |
 | Ethereum Holesky                                         | eip155:17000         |
 | Arbitrum                                                 | eip155:42161         |
 | Celo                                                     | eip155:42220         |

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -16,7 +16,7 @@ use {
 };
 pub use {
     allnodes::*, arbitrum::*, aurora::*, base::*, berachain::*, binance::*, drpc::*, dune::*,
-    getblock::*, infura::*, lava::*, mantle::*, morph::*, near::*, odyssey::*, pokt::*,
+    getblock::*, infura::*, lava::*, mantle::*, monad::*, morph::*, near::*, odyssey::*, pokt::*,
     publicnode::*, quicknode::*, server::*, solscan::*, syndica::*, unichain::*, wemix::*,
     zerion::*, zksync::*, zora::*,
 };
@@ -32,6 +32,7 @@ mod getblock;
 mod infura;
 mod lava;
 mod mantle;
+mod monad;
 mod morph;
 mod near;
 mod odyssey;

--- a/src/env/monad.rs
+++ b/src/env/monad.rs
@@ -1,0 +1,47 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct MonadConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for MonadConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for MonadConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Monad
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Monad testnet
+        (
+            "eip155:10143".into(),
+            (
+                "https://testnet-rpc.monad.xyz/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@ use {
     env::{
         AllnodesConfig, ArbitrumConfig, AuroraConfig, BaseConfig, BerachainConfig, BinanceConfig,
         DrpcConfig, DuneConfig, GetBlockConfig, InfuraConfig, LavaConfig, MantleConfig,
-        MorphConfig, NearConfig, OdysseyConfig, PoktConfig, PublicnodeConfig, QuicknodeConfig,
-        SolScanConfig, SyndicaConfig, UnichainConfig, WemixConfig, ZKSyncConfig, ZerionConfig,
-        ZoraConfig,
+        MonadConfig, MorphConfig, NearConfig, OdysseyConfig, PoktConfig, PublicnodeConfig,
+        QuicknodeConfig, SolScanConfig, SyndicaConfig, UnichainConfig, WemixConfig, ZKSyncConfig,
+        ZerionConfig, ZoraConfig,
     },
     error::RpcResult,
     http::Request,
@@ -34,7 +34,7 @@ use {
     providers::{
         AllnodesProvider, ArbitrumProvider, AuroraProvider, BaseProvider, BerachainProvider,
         BinanceProvider, DrpcProvider, DuneProvider, GetBlockProvider, InfuraProvider,
-        InfuraWsProvider, LavaProvider, MantleProvider, MorphProvider, NearProvider,
+        InfuraWsProvider, LavaProvider, MantleProvider, MonadProvider, MorphProvider, NearProvider,
         OdysseyProvider, PoktProvider, ProviderRepository, PublicnodeProvider, QuicknodeProvider,
         SolScanProvider, SyndicaProvider, UnichainProvider, WemixProvider, ZKSyncProvider,
         ZerionProvider, ZoraProvider, ZoraWsProvider,
@@ -552,6 +552,7 @@ async fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     providers.add_rpc_provider::<AllnodesProvider, AllnodesConfig>(AllnodesConfig::new(
         config.allnodes_api_key.clone(),
     ));
+    providers.add_rpc_provider::<MonadProvider, MonadConfig>(MonadConfig::default());
 
     if let Some(getblock_access_tokens) = &config.getblock_access_tokens {
         providers.add_rpc_provider::<GetBlockProvider, GetBlockConfig>(GetBlockConfig::new(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -77,6 +77,7 @@ mod lava;
 mod mantle;
 mod meld;
 pub mod mock_alto;
+mod monad;
 mod morph;
 mod near;
 mod odyssey;
@@ -110,6 +111,7 @@ pub use {
     lava::LavaProvider,
     mantle::MantleProvider,
     meld::MeldProvider,
+    monad::MonadProvider,
     morph::MorphProvider,
     near::NearProvider,
     odyssey::OdysseyProvider,
@@ -699,6 +701,7 @@ pub enum ProviderKind {
     Syndica,
     Allnodes,
     Meld,
+    Monad,
 }
 
 impl Display for ProviderKind {
@@ -737,6 +740,7 @@ impl Display for ProviderKind {
                 ProviderKind::Syndica => "Syndica",
                 ProviderKind::Allnodes => "Allnodes",
                 ProviderKind::Meld => "Meld",
+                ProviderKind::Monad => "Monad",
             }
         )
     }
@@ -776,6 +780,7 @@ impl ProviderKind {
             "Syndica" => Some(Self::Syndica),
             "Allnodes" => Some(Self::Allnodes),
             "Meld" => Some(Self::Meld),
+            "Monad" => Some(Self::Monad),
             _ => None,
         }
     }

--- a/src/providers/monad.rs
+++ b/src/providers/monad.rs
@@ -1,0 +1,96 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MonadConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct MonadProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for MonadProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Monad
+    }
+}
+
+#[async_trait]
+impl RateLimited for MonadProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for MonadProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Monad: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<MonadConfig> for MonadProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &MonadConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        MonadProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -91,6 +91,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Odyssey')       { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Syndica')       { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Allnodes')      { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Monad')         { gridPos: pos._4 },
 
   row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
@@ -115,6 +116,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'Odyssey')     { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Syndica')     { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Allnodes')    { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Monad')       { gridPos: pos._4 },
 
   row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
@@ -139,6 +141,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Odyssey')      { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Syndica')      { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Allnodes')     { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Monad')        { gridPos: pos._4 },
 
   row.new('RPC Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._3 },

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod getblock;
 pub(crate) mod infura;
 pub(crate) mod lava;
 pub(crate) mod mantle;
+pub(crate) mod monad;
 pub(crate) mod morph;
 pub(crate) mod near;
 pub(crate) mod odyssey;

--- a/tests/functional/http/monad.rs
+++ b/tests/functional/http/monad.rs
@@ -1,0 +1,18 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn monad_provider(ctx: &mut ServerContext) {
+    // Monad testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Monad,
+        "eip155:10143",
+        "0x279f",
+    )
+    .await;
+}


### PR DESCRIPTION
# Description

This PR adds Monad Testnet `eip155:10143` and Monad native RPC endpoint as a provider.

## How Has This Been Tested?

New integration test for the Monad provider.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
