### PR TITLE
fix(balances): adding an exclusion for the affected SDK version

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -79,14 +79,16 @@ describe('Account balance', () => {
   })
 
   it('empty balance Ethereum address affected SDK version', async () => {
-    const affected_sdk_version = '1.6.4'
-    let resp: any = await httpClient.get(
-      `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}&sv=${affected_sdk_version}`
-    )
-    // We should expect the empty balance response for the affected SDK version
-    expect(resp.status).toBe(200)
-    expect(typeof resp.data.balances).toBe('object')
-    expect(resp.data.balances).toHaveLength(0)
+    const affected_sdk_versions = ['1.6.4', '1.6.5']
+    for (const affected_sdk_version of affected_sdk_versions) {
+      let resp: any = await httpClient.get(
+        `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}&sv=${affected_sdk_version}`
+      )
+      // We should expect the empty balance response for the affected SDK version
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data.balances).toBe('object')
+      expect(resp.data.balances).toHaveLength(0)
+    }
   })
 
   it('empty balance Ethereum address', async () => {

--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -67,12 +67,23 @@ describe('Account balance', () => {
     }
   })
 
-  it('fulfilled balance Ethereum address no version header', async () => {
+  it('empty balance Ethereum address no version header', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}`
     )
     // We should expect the empty balance response for the sdk version prior to 4.1.9
     // that doesn't send the x-sdk-version header due to the bug in the SDK
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.balances).toBe('object')
+    expect(resp.data.balances).toHaveLength(0)
+  })
+
+  it('empty balance Ethereum address affected SDK version', async () => {
+    const affected_sdk_version = '1.6.4'
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}&sv=${affected_sdk_version}`
+    )
+    // We should expect the empty balance response for the affected SDK version
     expect(resp.status).toBe(200)
     expect(typeof resp.data.balances).toBe('object')
     expect(resp.data.balances).toHaveLength(0)

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -27,6 +27,10 @@ const PROVIDER_MAX_CALLS: usize = 2;
 const METADATA_CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24); // 1 day
 const BALANCE_CACHE_TTL: Duration = Duration::from_secs(10); // 10 seconds
 
+// List of SDK versions that should return an empty balance response
+// to fix the issue of redundant calls in SDK versions
+const EMPTY_BALANCE_RESPONSE_SDK_VERSIONS: [&str; 2] = ["1.6.4", "1.6.5"];
+
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 pub struct Config {
     /// List of project ids that are not allowed to use the balance RPC call
@@ -183,6 +187,18 @@ async fn handler_internal(
     // https://github.com/WalletConnect/web3modal/pull/2157
     if !headers.contains_key("x-sdk-version") && query.sdk_info.sv.is_none() {
         return Ok(Json(BalanceResponseBody { balances: vec![] }));
+    }
+
+    // Respond with an empty balance array if the sdk version is in the empty balance response list
+    // because the sdk version has a bug that causes excessive amount of calls to the balance RPC
+    if let Some(sdk_version) = query.sdk_info.sv.as_ref() {
+        if EMPTY_BALANCE_RESPONSE_SDK_VERSIONS.contains(&sdk_version.as_str()) {
+            debug!(
+                "Responding with an empty balance array for sdk version: {}",
+                sdk_version
+            );
+            return Ok(Json(BalanceResponseBody { balances: vec![] }));
+        }
     }
 
     // Get the cached balance and return it if found except if force_update is needed


### PR DESCRIPTION
# Description

This PR adds an exclusion for affected SDK versions `1.6.4`, and `1.6.5` to return an empty balance response. The affected SDK version makes an excessive request to the balance endpoint so this will prevent pressure to the balance provider until the version is upgraded by the users.

## How Has This Been Tested?

A new integration test was created.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
