### PR TITLE
fix: proper SDK version check for an empty balance response

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -80,9 +80,25 @@ describe('Account balance', () => {
 
   it('empty balance Ethereum address affected SDK version', async () => {
     const affected_sdk_versions = ['1.6.4', '1.6.5']
+    // Check for the version in query parameter
     for (const affected_sdk_version of affected_sdk_versions) {
       let resp: any = await httpClient.get(
         `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}&sv=${affected_sdk_version}`
+      )
+      // We should expect the empty balance response for the affected SDK version
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data.balances).toBe('object')
+      expect(resp.data.balances).toHaveLength(0)
+    }
+    // Check for the version in header
+    for (const affected_sdk_version of affected_sdk_versions) {
+      let resp: any = await httpClient.get(
+        `${baseUrl}/v1/account/${fulfilled_eth_address}/balance?projectId=${projectId}&currency=${currency}`,
+        {
+          headers: {
+              'x-sdk-version': `react-wagmi-${affected_sdk_version}`,
+          }
+        }
       )
       // We should expect the empty balance response for the affected SDK version
       expect(resp.status).toBe(200)


### PR DESCRIPTION
# Description

This PR makes the following modification to the SDK version check for an empty balance response:
* For the SDK version, checking the query `sv` parameter first and using `x-sdk-version` header if not present;
* Checking for the `version` and `type-version` formats for the version comparison for backward compatibility.

## How Has This Been Tested?

The integration test for this case was updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
