### PR TITLE
feat(providers): removing hardcoded EVM native token icons for Dune, decreasing Zerion priority

### DIFF
--- a/src/env/zerion.rs
+++ b/src/env/zerion.rs
@@ -35,6 +35,6 @@ impl BalanceProviderConfig for ZerionConfig {
 fn default_supported_namespaces() -> HashMap<CaipNamespaces, Weight> {
     HashMap::from([(
         CaipNamespaces::Eip155,
-        Weight::new(Priority::Custom(10)).unwrap(),
+        Weight::new(Priority::Minimal).unwrap(),
     )])
 }


### PR DESCRIPTION
# Description

This PR removes hardcoded EVM native token icons for the Dune provider because currently they're provided by the response. Changes the order to use the metadata response icon first if available.
Decreasing Zerion provider weight to the minimum.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
