### PR TITLE
fix: refactoring the token metadata cache to become a globally accessible

### DIFF
--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -3,14 +3,17 @@ use {
     crate::{
         analytics::{BalanceLookupInfo, MessageSource},
         error::RpcError,
+        providers::TokenMetadataCacheProvider,
         state::AppState,
-        storage::KeyValueStorage,
+        storage::{error::StorageError, KeyValueStorage},
         utils::{crypto, network},
     },
+    async_trait::async_trait,
     axum::{
         extract::{ConnectInfo, Path, Query, State},
         Json,
     },
+    deadpool_redis::{redis::AsyncCommands, Pool},
     ethers::{abi::Address, types::H160},
     hyper::HeaderMap,
     serde::{Deserialize, Serialize},
@@ -24,7 +27,7 @@ use {
 pub const H160_EMPTY_ADDRESS: H160 = H160::repeat_byte(0xee);
 
 const PROVIDER_MAX_CALLS: usize = 2;
-const METADATA_CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24); // 1 day
+const METADATA_CACHE_TTL: u64 = 60 * 60 * 24; // 1 day
 const BALANCE_CACHE_TTL: Duration = Duration::from_secs(10); // 10 seconds
 
 // List of SDK versions that should return an empty balance response
@@ -85,42 +88,11 @@ pub struct TokenMetadataCacheItem {
     pub name: String,
     pub symbol: String,
     pub icon_url: String,
-}
-
-fn token_metadata_cache_key(caip10_token_address: &str) -> String {
-    format!("token_metadata/{}", caip10_token_address)
+    pub decimals: u8,
 }
 
 fn address_balance_cache_key(address: &str) -> String {
     format!("address_balance/{}", address)
-}
-
-pub async fn get_cached_metadata(
-    cache: &Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
-    caip10_token_address: &str,
-) -> Option<TokenMetadataCacheItem> {
-    let cache = cache.as_ref()?;
-    cache
-        .get(&token_metadata_cache_key(caip10_token_address))
-        .await
-        .unwrap_or(None)
-}
-
-pub async fn set_cached_metadata(
-    cache: &Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
-    caip10_token_address: &str,
-    item: &TokenMetadataCacheItem,
-) {
-    if let Some(cache) = cache {
-        cache
-            .set(
-                &token_metadata_cache_key(caip10_token_address),
-                item,
-                Some(METADATA_CACHE_TTL),
-            )
-            .await
-            .unwrap_or_else(|e| error!("Failed to set metadata cache: {}", e));
-    }
 }
 
 pub async fn get_cached_balance(
@@ -241,7 +213,7 @@ async fn handler_internal(
             .get_balance(
                 address.clone(),
                 query.clone().0,
-                &state.token_metadata_cache,
+                &state.providers.token_metadata_cache,
                 state.metrics.clone(),
             )
             .await
@@ -394,6 +366,7 @@ async fn handler_internal(
                     &chain_id.clone(),
                     format!("{:#x}", contract_address).as_str(),
                     &query.currency,
+                    &state.providers.token_metadata_cache,
                     state.metrics.clone(),
                 )
                 .await
@@ -442,6 +415,78 @@ async fn handler_internal(
             }
         });
     }
-
     Ok(Json(response))
+}
+
+pub struct TokenMetadataCache {
+    cache_pool: Option<Arc<Pool>>,
+}
+
+impl TokenMetadataCache {
+    pub fn new(cache_pool: Option<Arc<Pool>>) -> Self {
+        Self { cache_pool }
+    }
+    fn token_metadata_cache_key(&self, caip10_token_address: &str) -> String {
+        format!("token_metadata/{}", caip10_token_address)
+    }
+
+    #[allow(dependency_on_unit_never_type_fallback)]
+    async fn set_cache(&self, key: &str, value: &str, ttl: u64) -> Result<(), StorageError> {
+        if let Some(redis_pool) = &self.cache_pool {
+            let mut cache = redis_pool.get().await.map_err(|e| {
+                StorageError::Connection(format!("Error when getting the Redis pool instance {e}"))
+            })?;
+            cache
+                .set_ex(key, value, ttl)
+                .await
+                .map_err(|e| StorageError::Connection(format!("Error when seting cache: {e}")))?;
+        }
+        Ok(())
+    }
+
+    #[allow(dependency_on_unit_never_type_fallback)]
+    async fn get_cache(&self, key: &str) -> Result<Option<String>, StorageError> {
+        if let Some(redis_pool) = &self.cache_pool {
+            let mut cache = redis_pool.get().await.map_err(|e| {
+                StorageError::Connection(format!("Error when getting the Redis pool instance {e}"))
+            })?;
+            let value = cache
+                .get(key)
+                .await
+                .map_err(|e| StorageError::Connection(format!("Error when getting cache: {e}")))?;
+            return Ok(value);
+        }
+        Ok(None)
+    }
+}
+
+#[async_trait]
+impl TokenMetadataCacheProvider for TokenMetadataCache {
+    async fn get_metadata(
+        &self,
+        caip10_token_address: &str,
+    ) -> Result<Option<TokenMetadataCacheItem>, RpcError> {
+        if let Some(redis_pool) = self
+            .get_cache(&self.token_metadata_cache_key(caip10_token_address))
+            .await?
+        {
+            let metadata: TokenMetadataCacheItem = serde_json::from_str(&redis_pool)?;
+            return Ok(Some(metadata));
+        }
+        Ok(None)
+    }
+
+    async fn set_metadata(
+        &self,
+        caip10_token_address: &str,
+        item: &TokenMetadataCacheItem,
+    ) -> Result<(), RpcError> {
+        self.set_cache(
+            &self.token_metadata_cache_key(caip10_token_address),
+            &serde_json::to_string(&item)?,
+            METADATA_CACHE_TTL,
+        )
+        .await?;
+        Ok(())
+    }
 }

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -80,7 +80,13 @@ async fn handler_internal(
         .ok_or_else(|| RpcError::UnsupportedNamespace(namespace))?;
 
     let response = provider
-        .get_price(&chain_id, &address, &query.currency, state.metrics.clone())
+        .get_price(
+            &chain_id,
+            &address,
+            &query.currency,
+            &state.providers.token_metadata_cache,
+            state.metrics.clone(),
+        )
         .await
         .tap_err(|e| {
             error!("Failed to call fungible price with {}", e);

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -168,7 +168,12 @@ async fn handler_internal(
             state
                 .providers
                 .coinbase_pay_provider
-                .get_transactions(address.clone(), query.clone().0, state.metrics.clone())
+                .get_transactions(
+                    address.clone(),
+                    query.clone().0,
+                    &state.providers.token_metadata_cache,
+                    state.metrics.clone(),
+                )
                 .await
                 .tap_err(|e| {
                     error!("Failed to call coinbase transactions history with {}", e);
@@ -185,7 +190,12 @@ async fn handler_internal(
             .ok_or_else(|| RpcError::UnsupportedNamespace(namespace))?;
         history_provider_kind = provider.provider_kind();
         provider
-            .get_transactions(address.clone(), query.0.clone(), state.metrics.clone())
+            .get_transactions(
+                address.clone(),
+                query.0.clone(),
+                &state.providers.token_metadata_cache,
+                state.metrics.clone(),
+            )
             .await
             .tap_err(|e| {
                 error!("Failed to call transactions history with {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,7 @@ use {
     crate::{
         env::Config,
         handlers::{
-            balance::{BalanceResponseBody, TokenMetadataCacheItem},
-            identity::IdentityResponse,
-            rate_limit_middleware,
+            balance::BalanceResponseBody, identity::IdentityResponse, rate_limit_middleware,
         },
         metrics::Metrics,
         project::Registry,
@@ -135,12 +133,6 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .map(|addr| redis::Redis::new(&addr, config.storage.redis_max_connections))
         .transpose()?
         .map(|r| Arc::new(r) as Arc<dyn KeyValueStorage<IdentityResponse> + 'static>);
-    let token_metadata_cache = config
-        .storage
-        .project_data_redis_addr()
-        .map(|addr| redis::Redis::new(&addr, config.storage.redis_max_connections))
-        .transpose()?
-        .map(|r| Arc::new(r) as Arc<dyn KeyValueStorage<TokenMetadataCacheItem> + 'static>);
     let balance_cache = config
         .storage
         .project_data_redis_addr()
@@ -204,7 +196,6 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         rate_limiting,
         irn_client,
         identity_cache,
-        token_metadata_cache,
         balance_cache,
     );
 

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -13,7 +13,7 @@ use {
                 quotes::{OnRampBuyQuotesParams, OnRampBuyQuotesResponse},
             },
         },
-        providers::ProviderKind,
+        providers::{ProviderKind, TokenMetadataCacheProvider},
         utils::crypto::ChainId,
         Metrics,
     },
@@ -96,11 +96,11 @@ pub struct CoinbasePurchaseAmount {
 
 #[async_trait]
 impl HistoryProvider for CoinbaseProvider {
-    #[tracing::instrument(skip(self, params), fields(provider = "Coinbase"), level = "debug")]
     async fn get_transactions(
         &self,
         address: String,
         params: HistoryQueryParams,
+        _metadata_cache: &Arc<dyn TokenMetadataCacheProvider>,
         metrics: Arc<Metrics>,
     ) -> RpcResult<HistoryResponseBody> {
         let base = format!("{}/buy/user/{}/transactions", &self.base_api_url, &address);

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -19,7 +19,10 @@ use {
             fungible_price::FungiblePriceItem,
             SupportedCurrencies,
         },
-        providers::{ConversionProvider, FungiblePriceProvider, PriceResponseBody, ProviderKind},
+        providers::{
+            ConversionProvider, FungiblePriceProvider, PriceResponseBody, ProviderKind,
+            TokenMetadataCacheProvider,
+        },
         utils::crypto,
         Metrics,
     },
@@ -769,12 +772,12 @@ impl ConversionProvider for OneInchProvider {
 
 #[async_trait]
 impl FungiblePriceProvider for OneInchProvider {
-    #[tracing::instrument(skip(self), fields(provider = "1inch"), level = "debug")]
     async fn get_price(
         &self,
         chain_id: &str,
         address: &str,
         currency: &SupportedCurrencies,
+        _metadata_cache: &Arc<dyn TokenMetadataCacheProvider>,
         metrics: Arc<Metrics>,
     ) -> RpcResult<PriceResponseBody> {
         let price = self

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,10 +3,7 @@ use {
         analytics::RPCAnalytics,
         env::Config,
         error::RpcError,
-        handlers::{
-            balance::{BalanceResponseBody, TokenMetadataCacheItem},
-            identity::IdentityResponse,
-        },
+        handlers::{balance::BalanceResponseBody, identity::IdentityResponse},
         metrics::Metrics,
         project::Registry,
         providers::ProviderRepository,
@@ -38,7 +35,6 @@ pub struct AppState {
     pub irn: Option<Irn>,
     // Redis caching
     pub identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
-    pub token_metadata_cache: Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
     pub balance_cache: Option<Arc<dyn KeyValueStorage<BalanceResponseBody>>>,
 }
 
@@ -54,7 +50,6 @@ pub fn new_state(
     rate_limit: Option<RateLimit>,
     irn: Option<Irn>,
     identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
-    token_metadata_cache: Option<Arc<dyn KeyValueStorage<TokenMetadataCacheItem>>>,
     balance_cache: Option<Arc<dyn KeyValueStorage<BalanceResponseBody>>>,
 ) -> AppState {
     AppState {
@@ -70,7 +65,6 @@ pub fn new_state(
         rate_limit,
         irn,
         identity_cache,
-        token_metadata_cache,
         balance_cache,
     }
 }


### PR DESCRIPTION
# Description

This PR refactors the tokens metadata cache to be globally accessible by the `TokenMetadataCacheProvider` to fix the cache inconsistency between different providers and metadata caching implementations between providers.

## How Has This Been Tested?

Current balance and history integration tests should pass.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
