### PR TITLE
feat(o11y): adding requests distribution by provider charts for balances

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -205,6 +205,10 @@ dashboard.new(
     panels.chain_abstraction.no_routes(ds, vars)            { gridPos: pos_short._4 },
     panels.chain_abstraction.response_types_rates(ds, vars) { gridPos: pos_short._2 },
 
+  row.new('Accounts balance'),
+    panels.balance.requests_distribution_evm(ds, vars)      { gridPos: pos_short._2 },
+    panels.balance.requests_distribution_solana(ds, vars)   { gridPos: pos_short._2 },
+
   row.new('Redis'),
     panels.redis.cpu(ds, vars)                    { gridPos: pos._2 },
     panels.redis.memory(ds, vars)                 { gridPos: pos._2 },

--- a/terraform/monitoring/panels/balance/requests_distribution_evm.libsonnet
+++ b/terraform/monitoring/panels/balance/requests_distribution_evm.libsonnet
@@ -1,0 +1,24 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = "Requests distribution by provider (EVM)",
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum (increase(provider_status_code_counter_total{provider="Dune", endpoint="evm_balances"}[$__rate_interval]))',
+      legendFormat  = 'Dune',
+    ))
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum (increase(provider_status_code_counter_total{provider="Zerion", endpoint="positions"}[$__rate_interval]))',
+      legendFormat  = 'Zerion',
+    ))
+}

--- a/terraform/monitoring/panels/balance/requests_distribution_solana.libsonnet
+++ b/terraform/monitoring/panels/balance/requests_distribution_solana.libsonnet
@@ -1,0 +1,24 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = "Requests distribution by provider (Solana)",
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum (increase(provider_status_code_counter_total{provider="Dune", endpoint="solana_balances"}[$__rate_interval]))',
+      legendFormat  = 'Dune',
+    ))
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum (increase(provider_status_code_counter_total{provider="SolScan", endpoint="https://pro-api.solscan.io/v2.0/account/detail"}[$__rate_interval]))',
+      legendFormat  = 'SolScan',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -98,4 +98,9 @@ local redis  = panels.aws.redis;
     no_routes: (import 'chain_abstraction/no_routes.libsonnet').new,
     response_types_rates: (import 'chain_abstraction/response_types_rate.libsonnet').new,
   },
+
+  balance: {
+    requests_distribution_evm: (import 'balance/requests_distribution_evm.libsonnet').new,
+    requests_distribution_solana: (import 'balance/requests_distribution_solana.libsonnet').new,
+  },
 }


### PR DESCRIPTION
# Description

This PR adds requests distribution by provider charts for account balances.
A new `Accounts balance` row and two charts were added:
* Requests distribution by provider for EVM,
* Requests distribution by provider for Solana.

## How Has This Been Tested?

Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
