### PR TITLE
feat(o11y): adding swaps availability chart and monitoring

### DIFF
--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -70,7 +70,7 @@ pub fn get_forwarded_ip(headers: &HeaderMap) -> Option<IpAddr> {
     headers
         .get("X-Forwarded-For")
         .and_then(|header| header.to_str().ok())
-        .and_then(|header| header.split(',').last())
+        .and_then(|header| header.split(',').next_back())
         .and_then(|client_ip| client_ip.trim().parse::<IpAddr>().ok())
 }
 

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -211,6 +211,9 @@ dashboard.new(
     panels.balance.requests_distribution_evm(ds, vars)      { gridPos: pos_short._2 },
     panels.balance.requests_distribution_solana(ds, vars)   { gridPos: pos_short._2 },
 
+  row.new('Swaps'),
+    panels.swaps.availability(ds, vars)           { gridPos: pos._1 },
+
   row.new('Redis'),
     panels.redis.cpu(ds, vars)                    { gridPos: pos._2 },
     panels.redis.memory(ds, vars)                 { gridPos: pos._2 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -103,4 +103,8 @@ local redis  = panels.aws.redis;
     requests_distribution_evm: (import 'balance/requests_distribution_evm.libsonnet').new,
     requests_distribution_solana: (import 'balance/requests_distribution_solana.libsonnet').new,
   },
+
+  swaps: {
+    availability: (import 'swaps/availability.libsonnet').new,
+  },
 }

--- a/terraform/monitoring/panels/swaps/availability.libsonnet
+++ b/terraform/monitoring/panels/swaps/availability.libsonnet
@@ -1,0 +1,96 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels         = grafana.panels;
+local targets        = grafana.targets;
+local alert          = grafana.alert;
+local alertCondition = grafana.alertCondition;
+
+local error_alert(vars) = alert.new(
+  namespace   = 'Blockchain API',
+  name        = "%s - Swaps availability" % vars.environment,
+  message     = "%s - Swaps availability" % vars.environment,
+  period      = '5m',
+  frequency   = '1m',
+  noDataState = 'alerting',
+  notifications = vars.notifications,
+  alertRuleTags = {
+    'og_priority': 'P3',
+  },
+  
+  conditions  = [
+    alertCondition.new(
+      evaluatorParams = [ 95 ],
+      evaluatorType   = 'lt',
+      operatorType    = 'or',
+      queryRefId      = 'swaps_availability',
+      queryTimeStart  = '5m',
+      reducerType     = 'avg',
+    ),
+  ]
+);
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Swaps availability',
+      datasource  = ds.prometheus,
+    )
+    .configure(
+      defaults.configuration.timeseries
+        .withUnit('percent')
+        .withSoftLimit(
+          axisSoftMin = 98,
+          axisSoftMax = 100,
+        )
+    )
+    .setAlert(vars.environment, error_alert(vars))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/tokens"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/tokens"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Tokens list',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/quotes"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/quotes"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Quotes',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/build-approve"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-approve"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Build approve',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/build-transaction"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-transaction"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Build transaction',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/gas-price"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-transaction"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Gas price',
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/allowance"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/allowance"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Allowance check',
+    ))
+}


### PR DESCRIPTION
# Description

This PR adds a new Grafana "Swaps" section with the availability chart for the following swap endpoints:

* Tokens list: `/v1/convert/tokens`,
* Quotes: `/v1/convert/quotes"`,
* Build approve: `/v1/convert/build-approve"`,
* Build swap transaction: `/v1/convert/build-transaction"`,
* Gas price: `/v1/convert/gas-price"`,
* Allowance check: `/v1/convert/allowance"`.

An alert for an availability drop below 95% is also added.

This PR also fixes the `http_call_counter` metrics where all endpoints were hardcoded as "proxy". It's fixed to use the endpoint path instead.

## How Has This Been Tested?

Tested locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
