### PR TITLE
feat: middlewares reordering, writing metrics async

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,17 +368,17 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         // Health
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_layer)
-        .layer(cors);
+        .route_layer(cors);
 
     // Response statuses and latency metrics middleware
-    let app = app.route_layer(middleware::from_fn_with_state(
+    let app = app.layer(middleware::from_fn_with_state(
         state_arc.clone(),
         status_latency_metrics_middleware,
     ));
 
     // GeoBlock middleware
     let app = if let Some(geoblock) = geoblock {
-        app.layer(geoblock)
+        app.route_layer(geoblock)
     } else {
         app
     };


### PR DESCRIPTION
# Description

This PR reorders middlewares to execute **all middlewares** except `latency and status codes` middleware **only on existing routes** by using [route_layer](https://docs.rs/axum/latest/axum/routing/struct.Router.html#method.route_layer) instead of [layer](https://docs.rs/axum/latest/axum/routing/struct.Router.html#method.layer) on all routes (including not existing).
Also, changes to write metrics in the `latency and status codes` middleware async instead of sync which can lead to blocking or latency increase for responses.

## How Has This Been Tested?

Tested locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
