### PR TITLE
fix(metrics): using the matched path instead of the URI in status and latency metrics

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -150,7 +150,11 @@ pub async fn status_latency_metrics_middleware<B>(
     req: Request<B>,
     next: Next<B>,
 ) -> Response {
-    let uri = req.uri().path().to_string();
+    // Extract the matched path from the request
+    let path = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map_or("/unknown".to_string(), |mp| mp.as_str().to_string());
     let request_started = Instant::now();
 
     // Execute the request and get the response.
@@ -159,14 +163,16 @@ pub async fn status_latency_metrics_middleware<B>(
 
     // Record metrics async
     let state_clone = state.clone();
-    let uri_clone = uri.clone();
+    let path_clone = path.clone();
     let status = response.status().as_u16();
     let latency_secs = request_latency.as_secs_f64();
     tokio::spawn(async move {
-        state_clone.metrics.add_http_call(status, uri_clone.clone());
         state_clone
             .metrics
-            .add_http_latency(status, uri_clone, latency_secs);
+            .add_http_call(status, path_clone.clone());
+        state_clone
+            .metrics
+            .add_http_latency(status, path_clone, latency_secs);
     });
 
     response


### PR DESCRIPTION
# Description

This PR fixes a metrics overflow bug when using the URI as a latency and status metrics key that results into a metrics overflow due to use of the `/route/:address` routes. The fix is to use the matched path extractor instead.

## How Has This Been Tested?

Tested locally: a middleware using the matched path instead of the URI.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
