### PR TITLE
fix: prepare use op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13628,7 +13628,6 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?rev=a190c18#a190c18c4c97b5e38159b833be01d8b217bddc99"
 dependencies = [
  "alloy 0.11.1",
  "alloy-provider 0.11.1",

--- a/src/handlers/wallet/prepare_calls.rs
+++ b/src/handlers/wallet/prepare_calls.rs
@@ -4,6 +4,8 @@ use crate::handlers::sessions::get::{
     get_session_context, GetSessionContextError, InternalGetSessionContextError,
 };
 use crate::handlers::wallet::types::SignatureRequestType;
+use crate::utils::erc4337::BundlerRpcClient;
+use crate::utils::erc7677::{PaymasterRpcClient, PmGetPaymasterDataParams};
 use crate::{handlers::HANDLER_TASK_METRICS, state::AppState};
 use alloy::primitives::{bytes, keccak256, Address, Bytes, FixedBytes, B256, U256, U64};
 use alloy::providers::{Provider, ProviderBuilder};
@@ -11,13 +13,13 @@ use alloy::sol_types::SolCall;
 use alloy::sol_types::SolValue;
 use axum::extract::State;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::error;
 use url::Url;
 use uuid::Uuid;
 use wc::future::FutureExt;
-use yttrium::bundler::pimlico::paymaster::client::PaymasterClient;
 use yttrium::erc7579::accounts::safe::encode_validator_key;
 use yttrium::erc7579::smart_sessions::ISmartSession::isPermissionEnabledReturn;
 use yttrium::erc7579::smart_sessions::{
@@ -144,14 +146,20 @@ pub enum PrepareCallsInternalError {
     #[error("Estimate user operation gas price: {0}")]
     EstimateUserOperationGasPrice(eyre::Error),
 
+    #[error("pm_getPaymasterStubData: {0}")]
+    PmGetPaymasterStubData(alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
+
+    #[error("Estimate user operation gas: {0}")]
+    EstimateUserOperationGas(alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
+
+    #[error("pm_getPaymasterData: {0}")]
+    PmGetPaymasterData(alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
+
     #[error("isSessionEnabled: {0}")]
     IsSessionEnabled(alloy::contract::Error),
 
     #[error("Compress session enabled: {0}")]
     CompressSessionEnabled(fastlz_rs::CompressError),
-
-    #[error("Sponsorship: {0}")]
-    Sponsorship(eyre::Error),
 
     #[error("IRN not configured")]
     IrnNotConfigured,
@@ -210,7 +218,7 @@ async fn handler_internal(
                 MessageSource::WalletPrepareCalls,
             )
             .parse()
-            .unwrap(),
+            .expect("Failed to parse provider URL"),
         );
 
         let irn_client = state.irn.as_ref().ok_or(PrepareCallsError::InternalError(
@@ -252,15 +260,15 @@ async fn handler_internal(
         .map_err(|e| PrepareCallsError::InternalError(PrepareCallsInternalError::GetNonce(e)))?;
 
         // TODO refactor to use bundler_rpc_call directly: https://github.com/WalletConnect/blockchain-api/blob/8be3ca5b08dec2387ee2c2ffcb4b7ca739443bcb/src/handlers/bundler.rs#L62
-        let pimlico_client = BundlerClient::new(BundlerConfig::new(
-            format!(
-                "https://rpc.walletconnect.com/v1/bundler?chainId={}&projectId={}&bundler=pimlico",
-                chain_id.caip2_identifier(),
-                project_id,
-            )
-            .parse()
-            .unwrap(),
-        ));
+        let bundler_url = format!(
+            "https://rpc.walletconnect.com/v1/bundler?chainId={}&projectId={}&bundler=pimlico",
+            chain_id.caip2_identifier(),
+            project_id,
+        )
+        .parse::<Url>()
+        .expect("Failed to parse bundler URL");
+        let pimlico_client = BundlerClient::new(BundlerConfig::new(bundler_url.clone()));
+        let bundler_provider = BundlerRpcClient::new(bundler_url);
 
         // TODO cache this
         let gas_price = pimlico_client
@@ -290,33 +298,85 @@ async fn handler_internal(
             signature: dummy_signature,
         };
 
-        let user_op = if let Some(paymaster_service) = request.capabilities.paymaster_service {
-            let paymaster_client = PaymasterClient::new(BundlerConfig::new(paymaster_service.url));
+        let (user_op, is_final) =
+            if let Some(paymaster_service) = &request.capabilities.paymaster_service {
+                let paymaster_client = PaymasterRpcClient::new(paymaster_service.url.clone());
 
-            let sponsor_user_op_result = paymaster_client
-                .sponsor_user_operation_v07(
-                    &user_op.clone().into(),
-                    &entry_point_config.address(),
-                    None,
+                let sponsor_user_op_result = paymaster_client
+                    .pm_get_paymaster_stub_data(PmGetPaymasterDataParams {
+                        user_op: user_op.clone(),
+                        entrypoint: entry_point_config.address().into(),
+                        chain_id: U64::from(chain_id.eip155_chain_id()),
+                        context: HashMap::new(),
+                    })
+                    .await
+                    .map_err(|e| {
+                        PrepareCallsError::InternalError(
+                            PrepareCallsInternalError::PmGetPaymasterStubData(e),
+                        )
+                    })?;
+
+                (
+                    UserOperationV07 {
+                        paymaster: Some(sponsor_user_op_result.paymaster),
+                        paymaster_data: Some(sponsor_user_op_result.paymaster_data),
+                        paymaster_verification_gas_limit: Some(
+                            sponsor_user_op_result.paymaster_verification_gas_limit,
+                        ),
+                        paymaster_post_op_gas_limit: Some(
+                            sponsor_user_op_result.paymaster_post_op_gas_limit,
+                        ),
+                        ..user_op
+                    },
+                    sponsor_user_op_result.is_final,
                 )
+            } else {
+                (user_op, false)
+            };
+
+        let user_op = {
+            let response = bundler_provider
+                .eth_estimate_user_operation_gas_v07(&user_op, entry_point_config.address().into())
                 .await
                 .map_err(|e| {
-                    PrepareCallsError::InternalError(PrepareCallsInternalError::Sponsorship(e))
+                    PrepareCallsError::InternalError(
+                        PrepareCallsInternalError::EstimateUserOperationGas(e),
+                    )
                 })?;
 
             UserOperationV07 {
-                call_gas_limit: sponsor_user_op_result.call_gas_limit,
-                verification_gas_limit: sponsor_user_op_result.verification_gas_limit,
-                pre_verification_gas: sponsor_user_op_result.pre_verification_gas,
-                paymaster: Some(sponsor_user_op_result.paymaster),
-                paymaster_verification_gas_limit: Some(
-                    sponsor_user_op_result.paymaster_verification_gas_limit,
-                ),
-                paymaster_post_op_gas_limit: Some(
-                    sponsor_user_op_result.paymaster_post_op_gas_limit,
-                ),
-                paymaster_data: Some(sponsor_user_op_result.paymaster_data),
+                call_gas_limit: response.call_gas_limit,
+                verification_gas_limit: response.verification_gas_limit,
+                pre_verification_gas: response.pre_verification_gas,
                 ..user_op
+            }
+        };
+
+        let user_op = if let Some(paymaster_service) = request.capabilities.paymaster_service {
+            if !is_final {
+                let paymaster_client = PaymasterRpcClient::new(paymaster_service.url);
+
+                let sponsor_user_op_result = paymaster_client
+                    .pm_get_paymaster_data(PmGetPaymasterDataParams {
+                        user_op: user_op.clone(),
+                        entrypoint: entry_point_config.address().into(),
+                        chain_id: U64::from(chain_id.eip155_chain_id()),
+                        context: HashMap::new(),
+                    })
+                    .await
+                    .map_err(|e| {
+                        PrepareCallsError::InternalError(
+                            PrepareCallsInternalError::PmGetPaymasterData(e),
+                        )
+                    })?;
+
+                UserOperationV07 {
+                    paymaster: Some(sponsor_user_op_result.paymaster),
+                    paymaster_data: Some(sponsor_user_op_result.paymaster_data),
+                    ..user_op
+                }
+            } else {
+                user_op
             }
         } else {
             user_op

--- a/src/utils/erc4337.rs
+++ b/src/utils/erc4337.rs
@@ -1,0 +1,39 @@
+use {
+    alloy::{
+        primitives::{Address, U256},
+        rpc::client::{ClientBuilder, RpcClient},
+        transports::TransportResult,
+    },
+    serde::{Deserialize, Serialize},
+    url::Url,
+    yttrium::user_operation::UserOperationV07,
+};
+
+pub struct BundlerRpcClient {
+    pub client: RpcClient,
+}
+
+impl BundlerRpcClient {
+    pub fn new(url: Url) -> Self {
+        let client = ClientBuilder::default().http(url);
+        Self { client }
+    }
+
+    pub async fn eth_estimate_user_operation_gas_v07(
+        &self,
+        user_op: &UserOperationV07,
+        entrypoint: Address,
+    ) -> TransportResult<EthEstimateUserOperationGasV07Response> {
+        self.client
+            .request("eth_estimateUserOperationGas", (user_op, entrypoint))
+            .await
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EthEstimateUserOperationGasV07Response {
+    pub pre_verification_gas: U256,
+    pub verification_gas_limit: U256,
+    pub call_gas_limit: U256,
+}

--- a/src/utils/erc7677.rs
+++ b/src/utils/erc7677.rs
@@ -1,0 +1,78 @@
+use {
+    alloy::{
+        primitives::{Address, Bytes, U256, U64},
+        rpc::client::{ClientBuilder, RpcClient},
+        transports::TransportResult,
+    },
+    serde::{Deserialize, Serialize},
+    std::collections::HashMap,
+    url::Url,
+    yttrium::user_operation::UserOperationV07,
+};
+
+pub struct PaymasterRpcClient {
+    pub client: RpcClient,
+}
+
+impl PaymasterRpcClient {
+    pub fn new(url: Url) -> Self {
+        // TODO reuse reqwest client
+        let client = ClientBuilder::default().http(url);
+        Self { client }
+    }
+
+    pub async fn pm_get_paymaster_stub_data(
+        &self,
+        params: PmGetPaymasterDataParams,
+    ) -> TransportResult<PmGetPaymasterStubDataResponse> {
+        self.client
+            .request("pm_getPaymasterStubData", params.into_tuple())
+            .await
+    }
+
+    pub async fn pm_get_paymaster_data(
+        &self,
+        params: PmGetPaymasterDataParams,
+    ) -> TransportResult<PmGetPaymasterStubDataResponse> {
+        self.client
+            .request("pm_getPaymasterData", params.into_tuple())
+            .await
+    }
+}
+
+pub struct PmGetPaymasterDataParams {
+    pub user_op: UserOperationV07,
+    pub entrypoint: Address,
+    pub chain_id: U64,
+    pub context: HashMap<String, serde_json::Value>,
+}
+
+impl PmGetPaymasterDataParams {
+    pub fn into_tuple(
+        self,
+    ) -> (
+        UserOperationV07,
+        Address,
+        U64,
+        HashMap<String, serde_json::Value>,
+    ) {
+        (self.user_op, self.entrypoint, self.chain_id, self.context)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmGetPaymasterStubDataResponse {
+    pub paymaster: Address,
+    pub paymaster_data: Bytes,
+    pub paymaster_verification_gas_limit: U256,
+    pub paymaster_post_op_gas_limit: U256,
+    pub is_final: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmGetPaymasterDataResponse {
+    pub paymaster: Address,
+    pub paymaster_data: Bytes,
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,8 @@ use rand::{distributions::Alphanumeric, Rng};
 
 pub mod build;
 pub mod crypto;
+pub mod erc4337;
+pub mod erc7677;
 pub mod network;
 pub mod permissions;
 pub mod rate_limit;


### PR DESCRIPTION
# Description

Fixes the prepare flow to use `eth_estimateUserOperationGas` as well as fully support the new 7677 paymaster spec. The full flow was not tested, but this is better than previously.

[Slack conversation](https://reown-inc.slack.com/archives/C06G97QSSUX/p1744113153391959?thread_ts=1744017462.368659&cid=C06G97QSSUX)

## How Has This Been Tested?

Somewhat manually

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
