### PR TITLE
feat: improve RPC analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13628,6 +13628,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
+source = "git+https://github.com/reown-com/yttrium.git?rev=a190c18#a190c18c4c97b5e38159b833be01d8b217bddc99"
 dependencies = [
  "alloy 0.11.1",
  "alloy-provider 0.11.1",

--- a/src/handlers/bundler.rs
+++ b/src/handlers/bundler.rs
@@ -18,17 +18,10 @@ use {
 };
 
 #[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum SupportedBundlers {
-    Pimlico,
-}
-
-#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BundlerQueryParams {
     pub project_id: String,
     pub chain_id: String,
-    pub bundler: SupportedBundlers,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -5,7 +5,7 @@ use {
         error::RpcError,
         providers::ProviderKind,
         state::AppState,
-        utils::{crypto, network},
+        utils::{batch_json_rpc_request::MaybeBatchRequest, crypto, network},
     },
     axum::{
         body::Bytes,
@@ -15,6 +15,7 @@ use {
     hyper::{http, HeaderMap},
     std::{
         borrow::Borrow,
+        collections::HashSet,
         net::SocketAddr,
         sync::Arc,
         time::{Duration, SystemTime},
@@ -175,6 +176,8 @@ pub async fn rpc_call(
     Err(RpcError::ChainTemporarilyUnavailable(chain_id))
 }
 
+// TODO eventually refactor this to be called by the wallet handler (generic JSON-RPC)
+// However, dependency on us having an exaustive list of supported RPC methods is a blocker to merging these handlers.
 #[tracing::instrument(skip(state), level = "debug")]
 pub async fn rpc_provider_call(
     state: Arc<AppState>,
@@ -188,32 +191,69 @@ pub async fn rpc_provider_call(
     let chain_id = query_params.chain_id.clone();
     let origin = headers
         .get("origin")
-        .map(|v| v.to_str().unwrap_or("invalid_header").to_string());
+        .map(|v| Arc::from(v.to_str().unwrap_or("invalid_header").to_string()));
 
     state.metrics.add_rpc_call(chain_id.clone());
-    if let Ok(rpc_request) = serde_json::from_slice(&body) {
-        let (country, continent, region) = state
-            .analytics
-            .lookup_geo_data(network::get_forwarded_ip(&headers).unwrap_or_else(|| addr.ip()))
-            .map(|geo| (geo.country, geo.continent, geo.region))
-            .unwrap_or((None, None, None));
 
-        state.analytics.message(MessageInfo::new(
-            &query_params,
-            &headers,
-            &rpc_request,
-            region,
-            country,
-            continent,
-            &provider.provider_kind(),
-            origin,
-            query_params.sdk_info.sv.clone(),
-            query_params.sdk_info.st.clone(),
-        ));
+    let (country, continent, region) = state
+        .analytics
+        .lookup_geo_data(network::get_forwarded_ip(&headers).unwrap_or_else(|| addr.ip()))
+        .map(|geo| (geo.country, geo.continent, geo.region))
+        .unwrap_or((None, None, None));
+
+    match serde_json::from_slice::<MaybeBatchRequest>(&body) {
+        Ok(body) => {
+            let rpcs = match &body {
+                MaybeBatchRequest::Single(req) => {
+                    vec![(req.id.to_string(), req.method.to_string())]
+                }
+                MaybeBatchRequest::Batch(reqs) => {
+                    {
+                        // Validate unique RPC IDs
+                        let mut ids = HashSet::new();
+                        for req in reqs {
+                            if !ids.insert(&req.id) {
+                                return Err(RpcError::InvalidParameter(format!(
+                                    "Duplicate RPC ID: {:?}",
+                                    req.id
+                                )));
+                            }
+                        }
+                    }
+
+                    reqs.iter()
+                        .map(|req| (req.id.to_string(), req.method.to_string()))
+                        .collect()
+                }
+            };
+
+            for (rpc_id, rpc_method) in rpcs {
+                state.analytics.message(MessageInfo::new(
+                    &query_params,
+                    &headers,
+                    query_params.session_id.clone(),
+                    rpc_id,
+                    rpc_method,
+                    region.clone(),
+                    country.clone(),
+                    continent.clone(),
+                    &provider.provider_kind(),
+                    origin.clone(),
+                    query_params.sdk_info.sv.clone(),
+                    query_params.sdk_info.st.clone(),
+                ));
+            }
+        }
+        Err(e) => {
+            error!(
+                "TRIAGE: Invalid JSON-RPC request: {} for body: {}",
+                e,
+                String::from_utf8_lossy(&body)
+            );
+        }
     }
 
     let project_id = query_params.project_id.clone();
-
     // Start timing external provider added time
     let external_call_start = SystemTime::now();
 

--- a/src/handlers/wallet/handler.rs
+++ b/src/handlers/wallet/handler.rs
@@ -36,6 +36,7 @@ pub struct WalletQueryParams {
     pub sdk_info: SdkInfoParams,
 }
 
+// TODO support batch requests (and validate unique RPC IDs)
 pub async fn handler(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,

--- a/src/utils/batch_json_rpc_request.rs
+++ b/src/utils/batch_json_rpc_request.rs
@@ -1,0 +1,139 @@
+use alloy::rpc::json_rpc::Id;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum MaybeBatchRequest {
+    Single(Request),
+    Batch(Vec<Request>),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub method: String,
+    // params are optional
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+    // id is technically optional too, but requiring it for now since we need it for analytics and it seems all EVM methods require it
+    pub id: Id,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_most_permissive() {
+        let request = r#"{"jsonrpc":"2.0","method":"eth_chainId","id":1}"#;
+        let single_request: MaybeBatchRequest = serde_json::from_str(request).unwrap();
+        assert_eq!(
+            single_request,
+            MaybeBatchRequest::Single(Request {
+                jsonrpc: "2.0".to_string(),
+                method: "eth_chainId".to_string(),
+                params: None,
+                id: Id::Number(1),
+            })
+        );
+    }
+
+    #[test]
+    fn test_deserialize_single_request() {
+        let request = r#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}"#;
+        let single_request: MaybeBatchRequest = serde_json::from_str(request).unwrap();
+        assert_eq!(
+            single_request,
+            MaybeBatchRequest::Single(Request {
+                jsonrpc: "2.0".to_string(),
+                method: "eth_chainId".to_string(),
+                params: Some(serde_json::Value::Array(vec![])),
+                id: Id::Number(1),
+            })
+        );
+    }
+
+    #[test]
+    fn test_deserialize_batch_request() {
+        let request = r#"[
+            {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1},
+            {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}
+        ]"#;
+        let batch_request: MaybeBatchRequest = serde_json::from_str(request).unwrap();
+        assert_eq!(
+            batch_request,
+            MaybeBatchRequest::Batch(vec![
+                Request {
+                    jsonrpc: "2.0".to_string(),
+                    method: "eth_chainId".to_string(),
+                    params: Some(serde_json::Value::Array(vec![])),
+                    id: Id::Number(1),
+                },
+                Request {
+                    jsonrpc: "2.0".to_string(),
+                    method: "eth_chainId".to_string(),
+                    params: Some(serde_json::Value::Array(vec![])),
+                    id: Id::Number(2),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_single_request_raw() {
+        let request = r#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}"#;
+        let single_request: MaybeBatchRequest = serde_json::from_str(request).unwrap();
+        assert!(matches!(single_request, MaybeBatchRequest::Single(_)));
+        let single_request = match single_request {
+            MaybeBatchRequest::Single(request) => request,
+            _ => panic!("Expected a single request"),
+        };
+        assert_eq!(single_request.id, Id::Number(1));
+        assert_eq!(single_request.method, "eth_chainId");
+        assert_eq!(
+            single_request.params,
+            Some(serde_json::Value::Array(vec![]))
+        );
+    }
+
+    #[test]
+    fn test_deserialize_batch_request_raw() {
+        let request = r#"[
+            {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1},
+            {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}
+        ]"#;
+        let batch_request: MaybeBatchRequest = serde_json::from_str(request).unwrap();
+        assert_eq!(
+            batch_request,
+            MaybeBatchRequest::Batch(vec![
+                Request {
+                    jsonrpc: "2.0".to_string(),
+                    method: "eth_chainId".to_string(),
+                    params: Some(serde_json::Value::Array(vec![])),
+                    id: Id::Number(1),
+                },
+                Request {
+                    jsonrpc: "2.0".to_string(),
+                    method: "eth_chainId".to_string(),
+                    params: Some(serde_json::Value::Array(vec![])),
+                    id: Id::Number(2),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_single_request_no_params() {
+        let request = r#"{"jsonrpc":"2.0","method":"eth_chainId","id":1}"#;
+        let single_request: MaybeBatchRequest = serde_json::from_str(request).unwrap();
+        assert_eq!(
+            single_request,
+            MaybeBatchRequest::Single(Request {
+                jsonrpc: "2.0".to_string(),
+                method: "eth_chainId".to_string(),
+                params: None,
+                id: Id::Number(1),
+            })
+        );
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 use rand::{distributions::Alphanumeric, Rng};
 
+pub mod batch_json_rpc_request;
 pub mod build;
 pub mod crypto;
 pub mod erc4337;


### PR DESCRIPTION
# Description

Improves the RPC analytics as per [previous discussions](https://www.notion.so/walletconnect/Blockchain-API-analytics-handling-for-malformed-or-batch-RPC-requests-1a13a661771e80f084c2f1f8dce99a16?pvs=4).

- Fixes billing hole for batch requests: Logs multiple analytics events, one for each item in the batch
- Adds session_id to analytics
- Lays groundwork to soon begin validating RPC request structure

## Future work

- Understand if parse schema is correct or not & enforce it: https://linear.app/reown/issue/CR-684/enforce-valid-rpc-structure
- Add `raw_rpc_payload` column & collect some data

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
