### PR TITLE
feat(CA): enabling ERC20 transfer gas estimation caching

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -339,9 +339,7 @@ impl ProviderRepository {
             config.tenderly_api_key.clone(),
             config.tenderly_account_id.clone(),
             config.tenderly_project_id.clone(),
-            // Todo: Temporary disabling the gas estimation caching
-            // redis_pool.clone(),
-            None,
+            redis_pool.clone(),
         ));
 
         let token_metadata_cache = Arc::new(TokenMetadataCache::new(redis_pool.clone()));

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -17,7 +17,7 @@ use {
 };
 
 /// Gas estimation caching TTL paramters
-const GAS_ESTIMATE_CACHE_TTL: u64 = 60 * 60 * 2; // 2 hours
+const GAS_ESTIMATE_CACHE_TTL: u64 = 60 * 30; // 30 minutes
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SimulationRequest {


### PR DESCRIPTION
# Description

This PR enables the gas estimation caching for the ERC20 transfer CA initial transaction. The cache TTL decreased to 30 minutes, and the gas estimation slippage is x5 to cover the volatility.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
