### PR TITLE
fix(CI): making a provider default amount can be null

### DIFF
--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -132,7 +132,7 @@ describe('OnRamp', () => {
     expect(resp.status).toBe(200)
     expect(resp.data.length).toBeGreaterThan(0)
     expect(typeof resp.data[0].currencyCode).toBe('string')
-    expect(typeof resp.data[0].defaultAmount).toBe('number')
+    expect(resp.data[0].defaultAmount === null || typeof resp.data[0].defaultAmount === 'number').toBeTruthy()
     expect(typeof resp.data[0].minimumAmount).toBe('number')
     expect(typeof resp.data[0].maximumAmount).toBe('number')
   })


### PR DESCRIPTION
# Description

This small change allows passing the CI gate tests since the Meld provider property `defaulAmount` can respond with a number or can be null.

## How Has This Been Tested?

Tested locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
