### PR TITLE
feat(providers): adding Kaia chain to the dRPC provider

### DIFF
--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -107,5 +107,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Kaia / Klaytn
+        (
+            "eip155:8217".into(),
+            (
+                "https://klaytn.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/tests/functional/http/drpc.rs
+++ b/tests/functional/http/drpc.rs
@@ -69,4 +69,13 @@ async fn drpc_provider_evm(ctx: &mut ServerContext) {
         "0x515",
     )
     .await;
+
+    // Kaia mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:8217",
+        "0x2019",
+    )
+    .await;
 }


### PR DESCRIPTION
# Description

This PR adds the Kaia chain endpoint to the dRPC provider for a failover of the chain RPC.

## How Has This Been Tested?

A new integration test was added.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
