### PR TITLE
fix(debug): adding debug message for the balance provider weights

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -58,7 +58,7 @@ use {
         hash::Hash,
         sync::Arc,
     },
-    tracing::{debug, error, log::warn},
+    tracing::{debug, error, info, log::warn},
     wc::metrics::TaskMetrics,
     yttrium::chain_abstraction::api::Transaction,
 };
@@ -645,6 +645,10 @@ impl ProviderRepository {
                 warn!("Failed to update weights from prometheus: {}", e);
             }
         }
+        info!(
+            "Balance providers weights: {:?}",
+            self.balance_weight_resolver
+        );
     }
 
     #[tracing::instrument(skip(self), level = "debug")]


### PR DESCRIPTION
# Description

This PR adds a debug info message on the weights update (every 15 seconds) to log the current balance providers' weights for debugging purposes.

## How Has This Been Tested?

Tested locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
