### PR TITLE
fix: temporarily disabling the balance provider failover retrying

### DIFF
--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -208,29 +208,57 @@ async fn handler_internal(
         .get_balance_provider_for_namespace(&namespace, PROVIDER_MAX_CALLS)?;
 
     let mut balance_response = None;
-    for provider in providers.iter() {
-        let provider_response = provider
-            .get_balance(
-                address.clone(),
-                query.clone().0,
-                &state.providers.token_metadata_cache,
-                state.metrics.clone(),
-            )
-            .await
-            .tap_err(|e| {
-                error!("Failed to call balance with {}", e);
-            });
 
-        match provider_response {
-            Ok(response) => {
-                balance_response = Some((response, provider.provider_kind()));
-                break;
-            }
-            e => {
-                debug!("Balance provider returned an error {e:?}, trying the next provider");
-            }
-        };
-    }
+    // Temporarily using the first provider in the list
+    // for debugging purposes
+    let provider = providers
+        .first()
+        .ok_or_else(|| RpcError::UnsupportedNamespace(namespace))?;
+    let provider_response = provider
+        .get_balance(
+            address.clone(),
+            query.clone().0,
+            &state.providers.token_metadata_cache,
+            state.metrics.clone(),
+        )
+        .await
+        .tap_err(|e| {
+            error!("Failed to call balance with {}", e);
+        });
+    match provider_response {
+        Ok(response) => {
+            balance_response = Some((response, provider.provider_kind()));
+        }
+        e => {
+            debug!("Balance provider returned an error {e:?}, trying the next provider");
+        }
+    };
+
+    // Temporarily disabling the balance provider failover loop
+    //
+    // for provider in providers.iter() {
+    //     let provider_response = provider
+    //         .get_balance(
+    //             address.clone(),
+    //             query.clone().0,
+    //             &state.providers.token_metadata_cache,
+    //             state.metrics.clone(),
+    //         )
+    //         .await
+    //         .tap_err(|e| {
+    //             error!("Failed to call balance with {}", e);
+    //         });
+
+    //     match provider_response {
+    //         Ok(response) => {
+    //             balance_response = Some((response, provider.provider_kind()));
+    //             break;
+    //         }
+    //         e => {
+    //             debug!("Balance provider returned an error {e:?}, trying the next provider");
+    //         }
+    //     };
+    // }
     let (mut response, provider_kind) = balance_response.ok_or(
         RpcError::BalanceTemporarilyUnavailable(namespace.to_string()),
     )?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -58,7 +58,7 @@ use {
         hash::Hash,
         sync::Arc,
     },
-    tracing::{debug, error, info, log::warn},
+    tracing::{debug, error, log::warn},
     wc::metrics::TaskMetrics,
     yttrium::chain_abstraction::api::Transaction,
 };
@@ -645,10 +645,6 @@ impl ProviderRepository {
                 warn!("Failed to update weights from prometheus: {}", e);
             }
         }
-        info!(
-            "Balance providers weights: {:?}",
-            self.balance_weight_resolver
-        );
     }
 
     #[tracing::instrument(skip(self), level = "debug")]


### PR DESCRIPTION
# Description

This PR temporarily disables the balance provider's failover retrying for debugging purposes and removes the debugging log for the current balance providers' weights.

## How Has This Been Tested?

Current balance integration tests passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
