### PR TITLE
fix(balances): fixing the failover retrying, adding support for an optional chainId in a non CAIP-2 format, adding balance retries metrics

### DIFF
--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -82,9 +82,16 @@ impl DuneProvider {
         url.query_pairs_mut()
             .append_pair("exclude_spam_tokens", "true");
         url.query_pairs_mut().append_pair("metadata", "logo");
-        if let Some(caip2_chain_id) = params.chain_id {
-            let (_, chain_id) = crypto::disassemble_caip2(&caip2_chain_id)
-                .map_err(|_| RpcError::InvalidParameter(caip2_chain_id))?;
+        if let Some(chain_id_param) = params.chain_id {
+            // Check if it's a CAIP2 chain ID (contains a colon)
+            let chain_id = if chain_id_param.contains(':') {
+                let (_, chain_id) = crypto::disassemble_caip2(&chain_id_param)
+                    .map_err(|_| RpcError::InvalidParameter(chain_id_param))?;
+                chain_id
+            } else {
+                // It's already a plain chain ID, use it as EVM chain ID
+                chain_id_param
+            };
             url.query_pairs_mut().append_pair("chain_ids", &chain_id);
         }
 

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -452,12 +452,18 @@ impl BalanceProvider for ZerionProvider {
             .append_pair("currency", &params.currency.to_string());
         url.query_pairs_mut()
             .append_pair("filter[position_types]", "wallet");
+
         // Return only non-spam transactions
         add_filter_non_trash_only(&mut url);
 
         if let Some(chain_id) = params.chain_id {
-            let chain_name = crypto::ChainId::from_caip2(&chain_id)
-                .ok_or(RpcError::InvalidParameter(chain_id))?;
+            let chain_name = if chain_id.contains(':') {
+                crypto::ChainId::from_caip2(&chain_id)
+                    .ok_or(RpcError::InvalidParameter(chain_id))?
+            } else {
+                crypto::ChainId::from_caip2(&format!("eip155:{}", chain_id))
+                    .ok_or(RpcError::InvalidParameter(chain_id))?
+            };
             url.query_pairs_mut()
                 .append_pair("filter[chain_ids]", &chain_name);
         }

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -212,8 +212,9 @@ dashboard.new(
     panels.chain_abstraction.response_types_rates(ds, vars) { gridPos: pos_short._2 },
 
   row.new('Accounts balance'),
-    panels.balance.requests_distribution_evm(ds, vars)      { gridPos: pos_short._2 },
-    panels.balance.requests_distribution_solana(ds, vars)   { gridPos: pos_short._2 },
+    panels.balance.requests_distribution_evm(ds, vars)      { gridPos: pos_short._3 },
+    panels.balance.requests_distribution_solana(ds, vars)   { gridPos: pos_short._3 },
+    panels.balance.provider_retries(ds, vars)               { gridPos: pos_short._3 },
 
   row.new('Swaps'),
     panels.swaps.availability(ds, vars)           { gridPos: pos._1 },

--- a/terraform/monitoring/panels/balance/provider_retries.libsonnet
+++ b/terraform/monitoring/panels/balance/provider_retries.libsonnet
@@ -1,0 +1,24 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('cpm');
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Balance provider call retries',
+      datasource  = ds.prometheus,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = 'sum by (namespace)(rate(balance_lookup_retries_sum{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -102,6 +102,7 @@ local redis  = panels.aws.redis;
   balance: {
     requests_distribution_evm: (import 'balance/requests_distribution_evm.libsonnet').new,
     requests_distribution_solana: (import 'balance/requests_distribution_solana.libsonnet').new,
+    provider_retries: (import 'balance/provider_retries.libsonnet').new,
   },
 
   swaps: {


### PR DESCRIPTION
# Description

This PR introduces the following changes:

* Fixes balance providers failover logic;
* Adds a new balance lookup retries metrics and a Grafana `Balance provider call retries` panel to track how many retries we have until the balance response is reached;
* Adding backward compatibility support for the optional `ChainId` balance query parameter for the CAIP-2 and non-CAIP-2 chain IDs.

## How Has This Been Tested?

Current integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
