### PR TITLE
feat(CA): adding a proper simulation balance override for ETH

### DIFF
--- a/integration/chain_orchestrator.test.ts
+++ b/integration/chain_orchestrator.test.ts
@@ -108,7 +108,7 @@ describe('Chain abstraction orchestrator', () => {
         expect(approvalTransaction.nonce).not.toBe("0x00")
         expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();
         const decodedData = erc20Interface.decodeFunctionData('approve', approvalTransaction.input);
-        if (BigInt(decodedData.amount) < bridging_amount) {
+        if ((BigInt(decodedData.amount) * BigInt(1005) / BigInt(1000)) < bridging_amount) {
           throw new Error(`Expected approval amount is incorrect`);
         }
         expect(() => BigInt(approvalTransaction.gasLimit)).not.toThrow();


### PR DESCRIPTION
# Description

This PR adds ETH balance state override for simulations to not fail on CA initial transaction simulation if the source address doesn't have enough balance, and for the gas sponsorship.

## How Has This Been Tested?

The current integration test for ETH shouldn't fail.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
