### PR TITLE
feat(Dune): updating the SVM balance endpoint

### DIFF
--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -120,7 +120,7 @@ impl DuneProvider {
         address: String,
         metrics: Arc<Metrics>,
     ) -> RpcResult<DuneBalanceResponseBody> {
-        let base = format!("{}/echo/beta/balances/svm/{}", DUNE_API_BASE_URL, &address);
+        let base = format!("{}/echo/beta2/balances/svm/{}", DUNE_API_BASE_URL, &address);
         let mut url = Url::parse(&base).map_err(|_| RpcError::BalanceParseURLError)?;
         url.query_pairs_mut()
             .append_pair("exclude_spam_tokens", "true");


### PR DESCRIPTION
# Description

This PR updates the Dune SVM balance endpoint to an updated one. The change is from `beta` -> `beta2`.
The old endpoint will sunset by the end of the month.

## How Has This Been Tested?

Current integration tests should pass.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
