### PR TITLE
fix: some internal wallet RPC errors were not being logged

### DIFF
--- a/src/handlers/wallet/get_assets.rs
+++ b/src/handlers/wallet/get_assets.rs
@@ -36,21 +36,11 @@ pub enum GetAssetsErrorInternalError {
     GetBalance(RpcError),
 }
 
-impl IntoResponse for GetAssetsError {
-    fn into_response(self) -> Response {
-        #[allow(unreachable_patterns)] // TODO remove
+impl GetAssetsError {
+    pub fn is_internal(&self) -> bool {
         match self {
-            Self::InternalError(e) => {
-                error!("HTTP server error: (get_assets) {e:?}");
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-            e => (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": e.to_string(),
-                })),
-            )
-                .into_response(),
+            GetAssetsError::InternalError(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/handlers/wallet/get_calls_status.rs
+++ b/src/handlers/wallet/get_calls_status.rs
@@ -71,21 +71,11 @@ pub enum GetCallsStatusInternalError {
     UserOperationReceiptError(String),
 }
 
-impl IntoResponse for GetCallsStatusError {
-    fn into_response(self) -> Response {
-        #[allow(unreachable_patterns)] // TODO remove
+impl GetCallsStatusError {
+    pub fn is_internal(&self) -> bool {
         match self {
-            Self::InternalError(e) => {
-                error!("HTTP server error: (get_calls_status) {e:?}");
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-            e => (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": e.to_string(),
-                })),
-            )
-                .into_response(),
+            GetCallsStatusError::InternalError(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -53,6 +53,15 @@ pub enum GetExchangeUrlError {
     InternalError(String),
 }
 
+impl GetExchangeUrlError {
+    pub fn is_internal(&self) -> bool {
+        match self {
+            GetExchangeUrlError::InternalError(_) => true,
+            _ => false,
+        }
+    }
+}
+
 pub async fn handler(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,

--- a/src/handlers/wallet/get_exchanges.rs
+++ b/src/handlers/wallet/get_exchanges.rs
@@ -59,6 +59,15 @@ pub enum GetExchangesInternalError {
     InternalError(String),
 }
 
+impl GetExchangesError {
+    pub fn is_internal(&self) -> bool {
+        match self {
+            GetExchangesError::InternalError(_) => true,
+            _ => false,
+        }
+    }
+}
+
 pub async fn handler(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,

--- a/src/handlers/wallet/prepare_calls.rs
+++ b/src/handlers/wallet/prepare_calls.rs
@@ -168,6 +168,15 @@ pub enum PrepareCallsInternalError {
     GetSessionContextError(InternalGetSessionContextError),
 }
 
+impl PrepareCallsError {
+    pub fn is_internal(&self) -> bool {
+        match self {
+            PrepareCallsError::InternalError(_) => true,
+            _ => false,
+        }
+    }
+}
+
 pub async fn handler(
     state: State<Arc<AppState>>,
     project_id: String,

--- a/src/handlers/wallet/send_prepared_calls.rs
+++ b/src/handlers/wallet/send_prepared_calls.rs
@@ -134,6 +134,15 @@ pub enum SendPreparedCallsInternalError {
     IsSessionEnabled(alloy::contract::Error),
 }
 
+impl SendPreparedCallsError {
+    pub fn is_internal(&self) -> bool {
+        match self {
+            SendPreparedCallsError::InternalError(_) => true,
+            _ => false,
+        }
+    }
+}
+
 pub async fn handler(
     state: State<Arc<AppState>>,
     project_id: String,


### PR DESCRIPTION
# Description

Generalizes what #813 tried to do for all errors.

This introduces an OOP-based way to determine if an error is internal or not, self-reported by the error itself.

[Slack conversation](https://reown-inc.slack.com/archives/C03SCF66K2T/p1745484302400629?thread_ts=1744378976.546939&cid=C03SCF66K2T)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
