### PR TITLE
feat(providers): adding Monad testnet endpoint to the dRPC

### DIFF
--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -131,5 +131,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Monad Testnet
+        (
+            "eip155:10143".into(),
+            (
+                "https://monad-testnet.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/tests/functional/http/drpc.rs
+++ b/tests/functional/http/drpc.rs
@@ -96,4 +96,13 @@ async fn drpc_provider_evm(ctx: &mut ServerContext) {
         "0x138de",
     )
     .await;
+
+    // Monad testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:10143",
+        "0x279f",
+    )
+    .await;
 }


### PR DESCRIPTION
# Description

This PR adds Monad Testnet `eip155:10143` chain support to the dRPC provider.

## How Has This Been Tested?

The provider integration test was updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
