### PR TITLE
feat(providers): adding Solana Devnet to the Syndica provider

### DIFF
--- a/src/env/syndica.rs
+++ b/src/env/syndica.rs
@@ -45,5 +45,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Solana Devnet
+        (
+            "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1".into(),
+            (
+                "https://solana-devnet.api.syndica.io".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod odyssey;
 pub(crate) mod pokt;
 pub(crate) mod publicnode;
 pub(crate) mod quicknode;
+pub(crate) mod syndica;
 pub(crate) mod unichain;
 pub(crate) mod wemix;
 pub(crate) mod zksync;

--- a/tests/functional/http/syndica.rs
+++ b/tests/functional/http/syndica.rs
@@ -1,0 +1,26 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_solana, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn syndica_provider_solana(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Syndica;
+    // Solana mainnet
+    check_if_rpc_is_responding_correctly_for_solana(
+        ctx,
+        "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        &provider,
+    )
+    .await;
+
+    // Solana devnet
+    check_if_rpc_is_responding_correctly_for_solana(
+        ctx,
+        "EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+        &provider,
+    )
+    .await;
+}


### PR DESCRIPTION
# Description

This PR adds Solana Devnet `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` RPC endpoint to the Syndica provider.

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->


## How Has This Been Tested?

Integration tests for Syndica were updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
