### PR TITLE
fix(CI): removing an unsupported bundler test

### DIFF
--- a/integration/bundler.test.ts
+++ b/integration/bundler.test.ts
@@ -7,21 +7,6 @@ describe('Bundler operations', () => {
   const mainnetChainId = 'eip155:1'
   const method = 'eth_getUserOperationReceipt'
   const successOperationTxHash = '0x772b10c68cb2470259be889b97e87618a4d8fc2b21767503724a9842bc83b5de'
-  const bundler = 'pimlico'
-
-  it('unsupported bundler', async () => {
-    let json_rpc = {
-      jsonrpc: '2.0',
-      method,
-      params: [successOperationTxHash],
-      id: 1
-    }
-    let resp: any = await httpClient.post(
-      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${sepoliaChainId}&bundler=test`,
-      json_rpc
-    )
-    expect(resp.status).toBe(400)
-  })
 
   it('unsupported method', async () => {
     let json_rpc = {
@@ -31,7 +16,7 @@ describe('Bundler operations', () => {
       id: 1
     }
     let resp: any = await httpClient.post(
-      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${sepoliaChainId}&bundler=${bundler}`,
+      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${sepoliaChainId}`,
       json_rpc
     )
     expect(resp.status).toBe(422)
@@ -45,7 +30,7 @@ describe('Bundler operations', () => {
       id: 1
     }
     let resp: any = await httpClient.post(
-      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${mainnetChainId}&bundler=${bundler}`,
+      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${mainnetChainId}`,
       json_rpc
     )
     expect(resp.status).toBe(200)
@@ -61,7 +46,7 @@ describe('Bundler operations', () => {
       id: 1
     }
     let resp: any = await httpClient.post(
-      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${sepoliaChainId}&bundler=${bundler}`,
+      `${baseUrl}/v1/bundler?projectId=${projectId}&chainId=${sepoliaChainId}`,
       json_rpc
     )
     expect(resp.status).toBe(200)


### PR DESCRIPTION
# Description

This PR removes an unsupported bundler integration test, since this parameter [was removed](https://github.com/reown-com/blockchain-api/pull/1024/files#diff-681cfcde03495e4d3d42606ceb4781672eb2defc804c8144fe307a36cc6da714L31) due to a using of a single bundler (Pimlico).


## How Has This Been Tested?

The updated integration tests were passed.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
