### PR TITLE
fix(tests): adding a country code to the Meld quotes

### DIFF
--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -143,6 +143,7 @@ describe('OnRamp', () => {
       destinationCurrencyCode: 'BTC',
       sourceAmount: 100,
       sourceCurrencyCode: 'USD',
+      countryCode: 'US',
     };
 
     let resp: any = await httpClient.post(


### PR DESCRIPTION
# Description

This PR adds a `countryCode` parameter to the Meld onramp quotes request.

## How Has This Been Tested?

OnRamp integration tests were passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
