### PR TITLE
fix(CI): fixing rate-limiting test and enabling sessions and chain abstraction tests on staging

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -98,15 +98,7 @@ jobs:
       - name: Yarn Install
         run: yarn install
 
-      # Temporary ignoring `Sessions and CA tests` for staging until IRN peering for staging is ready
-      - name: Run Yarn Integration Tests (no IRN tests)
-        if: ${{ inputs.stage == 'staging' }}
-        run: yarn integration --testPathIgnorePatterns='(sessions.test.ts|chain_orchestrator.test.ts)'
-        env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
-          RPC_URL: ${{ inputs.stage-url }}
       - name: Yarn Integration Tests
-        if: ${{ inputs.stage == 'prod' }}
         run: yarn integration
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/integration/ratelimiting.test.ts
+++ b/integration/ratelimiting.test.ts
@@ -5,10 +5,10 @@ describe('Rate limiting', () => {
 
   it('Simulate flood and check is rate limited', async () => {
     // Using default max tokens of 30
-    const max_tokens = 30;
+    const max_tokens = 200;
 
-    // Flooding requests twice then max tokens
-    const requests_to_send = max_tokens * 2;
+    // Flooding requests x1.5 then max tokens
+    const requests_to_send = max_tokens * 1.5;
     
     // Sending flood requests to the generators endpoint since it's not dependent on the third parties
     const payload = {


### PR DESCRIPTION
# Description

This PR increases max tokens for the rate-limiting integration test to 200 to fix the integration test running on a prod environment. This PR enables sessions and chain abstraction integration tests on a staging environment, which were temporarily disabled due to the WCN limitations, but can now be enabled.

## How Has This Been Tested?

Updated integration tests passed successfully.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
