### PR TITLE
chore: update monitoring-role TF module to accept more than one trusted role

### DIFF
--- a/terraform/monitoring/data_sources.tf
+++ b/terraform/monitoring/data_sources.tf
@@ -1,8 +1,9 @@
 module "monitoring-role" {
   source          = "app.terraform.io/wallet-connect/monitoring-role/aws"
-  version         = "1.0.2"
+  version         = "1.1.0"
   context         = module.this
   remote_role_arn = var.monitoring_role_arn
+  trusted_arns    = var.trusted_arns
 }
 
 resource "grafana_data_source" "prometheus" {

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -3,6 +3,10 @@ variable "monitoring_role_arn" {
   type        = string
 }
 
+variable "trusted_arns" {
+  type = list(string)
+}
+
 variable "notification_channels" {
   description = "The notification channels to send alerts to"
   type        = list(any)

--- a/terraform/res_monitoring.tf
+++ b/terraform/res_monitoring.tf
@@ -2,7 +2,10 @@ module "monitoring" {
   source  = "./monitoring"
   context = module.this
 
-  monitoring_role_arn   = data.terraform_remote_state.monitoring.outputs.grafana_workspaces.central.iam_role_arn
+  monitoring_role_arn = data.terraform_remote_state.monitoring.outputs.grafana_workspaces.central.iam_role_arn
+
+  trusted_arns = [data.terraform_remote_state.monitoring.outputs.grafana_workspaces.business.iam_role_arn]
+
   notification_channels = var.notification_channels
   prometheus_endpoint   = aws_prometheus_workspace.prometheus.prometheus_endpoint
   ecs_service_name      = module.ecs.ecs_service_name


### PR DESCRIPTION
# Description

This fixes dashboards more permanently by letting the role Grafana assumes to assume the role provisioned by Blockchain API in order to pull metrics.

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
