### PR TITLE
fix(transactions): adding a filtering by `chainId`

### DIFF
--- a/integration/history.test.ts
+++ b/integration/history.test.ts
@@ -33,6 +33,23 @@ describe('Transactions history', () => {
     }
   })
 
+  it('fulfilled history Ethereum address (filtered by chainId)', async () => {
+    const chainId = 'eip155:1'
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/account/${fulfilled_eth_address}/history?projectId=${projectId}&chainId=${chainId}`,
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.data).toBe('object')
+
+    for (const item of resp.data.data) {
+      expect(item.id).toBeDefined()
+      expect(typeof item.metadata).toBe('object')
+      expect(item.metadata.chain).toBe(chainId);
+      expect(typeof item.metadata.application).toBe('object')
+      expect(typeof item.transfers).toBe('object')
+    }
+  })
+
   it('fulfilled history Solana address', async () => {
     let chainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
     let resp: any = await httpClient.get(

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -263,6 +263,18 @@ impl HistoryProvider for ZerionProvider {
             url.query_pairs_mut().append_pair("page[after]", &cursor);
         }
 
+        if let Some(chain_id) = params.chain_id {
+            let chain_name = if chain_id.contains(':') {
+                crypto::ChainId::from_caip2(&chain_id)
+                    .ok_or(RpcError::InvalidParameter(chain_id))?
+            } else {
+                crypto::ChainId::from_caip2(&format!("eip155:{}", chain_id))
+                    .ok_or(RpcError::InvalidParameter(chain_id))?
+            };
+            url.query_pairs_mut()
+                .append_pair("filter[chain_ids]", &chain_name);
+        }
+
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.tap_err(|e| {
             error!("Error on request to zerion history endpoint with {}", e);


### PR DESCRIPTION
# Description

This PR adds a filtering by `chainId` by using an optional `chainId` parameter in the transactions history endpoint.

## How Has This Been Tested?

The new integration test was created.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
