### PR TITLE
fix: FAUCET_REQUEST_API_KEY env var

### DIFF
--- a/.github/workflows/sub-yttrium-integration.yml
+++ b/.github/workflows/sub-yttrium-integration.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           REOWN_PROJECT_ID: ${{ secrets.PROJECT_ID }}
           FAUCET_MNEMONIC: ${{ secrets.FAUCET_MNEMONIC }}
+          FAUCET_REQUEST_API_KEY: ${{ secrets.FAUCET_REQUEST_API_KEY }}
           RUST_BACKTRACE: 1
           RUST_LOG: yttrium=trace
           BLOCKCHAIN_API_URL: ${{ inputs.stage-url }}
@@ -61,6 +62,7 @@ jobs:
         env:
           REOWN_PROJECT_ID: ${{ secrets.PROJECT_ID }}
           FAUCET_MNEMONIC: ${{ secrets.FAUCET_MNEMONIC }}
+          FAUCET_REQUEST_API_KEY: ${{ secrets.FAUCET_REQUEST_API_KEY }}
           RUST_BACKTRACE: 1
           RUST_LOG: yttrium=trace
           BLOCKCHAIN_API_URL: ${{ inputs.stage-url }}


### PR DESCRIPTION
# Description

Fixes [failing CD](https://github.com/reown-com/blockchain-api/actions/runs/14855676498/job/41794272476#step:5:2248). This new secret was added to organization secrets but not passed-through here.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
