### PR TITLE
feat(chains): adding Sonic Mainnet and Testnet RPC support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -14,6 +14,7 @@ Chain name with associated `chainId` query param to use.
 | Binance Smart Chain Testnet <sup>[1](#footnote1)</sup>   | eip155:97            |
 | Gnosis Chain                                             | eip155:100           |
 | Polygon                                                  | eip155:137           |
+| Sonic                                                    | eip155:146           |
 | zkSync Era Sepolia Testnet <sup>[1](#footnote1)</sup>    | eip155:300           |
 | zkSync Era                                               | eip155:324           |
 | Polygon Zkevm                                            | eip155:1101          |
@@ -33,6 +34,7 @@ Chain name with associated `chainId` query param to use.
 | Celo                                                     | eip155:42220         |
 | Avalanche Fuji Testnet <sup>[1](#footnote1)</sup>        | eip155:43113         |
 | Avalanche C-Chain                                        | eip155:43114         |
+| Sonic Testnet <sup>[1](#footnote1)</sup>                 | eip155:57054         |
 | Linea <sup>[1](#footnote1)</sup>                         | eip155:59144         |
 | Polygon Amoy <sup>[1](#footnote1)</sup>                  | eip155:80002         |
 | Berachain Bepolia <sup>[1](#footnote)</sup>              | eip155:80069         |

--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -139,5 +139,21 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Sonic Mainnet
+        (
+            "eip155:146".into(),
+            (
+                "https://sonic.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Sonic Testnet
+        (
+            "eip155:57054".into(),
+            (
+                "https://sonic-testnet.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -172,6 +172,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:80094".into(),
             ("berachain".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Sonic Mainnet
+        (
+            "eip155:146".into(),
+            ("sonic".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Near protocol
         (
             "near:mainnet".into(),

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -193,6 +193,19 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Sonic Mainnet
+        (
+            "eip155:146".into(),
+            ("sonic-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // Sonic Testnet
+        (
+            "eip155:57054".into(),
+            (
+                "sonic-blaze-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Bitcoin mainnet
         (
             "bip122:000000000019d6689c085ae165831e93".into(),

--- a/tests/functional/http/drpc.rs
+++ b/tests/functional/http/drpc.rs
@@ -105,4 +105,17 @@ async fn drpc_provider_evm(ctx: &mut ServerContext) {
         "0x279f",
     )
     .await;
+
+    // Sonic Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:146", "0x92")
+        .await;
+
+    // Sonic Testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:57054",
+        "0xdede",
+    )
+    .await;
 }

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -173,6 +173,10 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
         "0x138de",
     )
     .await;
+
+    // Sonic Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:146", "0x92")
+        .await;
 }
 
 #[test_context(ServerContext)]

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -182,6 +182,19 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
         "0x515",
     )
     .await;
+
+    // Sonic Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:146", "0x92")
+        .await;
+
+    // Sonic Testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:57054",
+        "0xdede",
+    )
+    .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR adds Sonic Mainnet `eip155:146 ` and Tesnet `eip155:57054` RPC support according to the new chain's priority.

## How Has This Been Tested?

Providers' integration tests were updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
