### PR TITLE
chore: change the implementation to use string float instead of hex

### DIFF
--- a/src/handlers/wallet/exchanges/mod.rs
+++ b/src/handlers/wallet/exchanges/mod.rs
@@ -36,7 +36,7 @@ pub struct Exchange {
 pub struct GetBuyUrlParams {
     pub project_id: String,
     pub asset: Caip19Asset,
-    pub amount: usize,
+    pub amount: f64,
     pub recipient: String,
     pub session_id: String,
 }

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -111,15 +111,12 @@ async fn handler_internal(
         )));
     }
 
-    let amount = request
-        .amount
-        .parse::<f64>()
-        .map_err(|_| {
-            GetExchangeUrlError::ValidationError(format!(
-                "Invalid amount. Expected a valid number: {}",
-                request.amount
-            ))
-        })?;
+    let amount = request.amount.parse::<f64>().map_err(|_| {
+        GetExchangeUrlError::ValidationError(format!(
+            "Invalid amount. Expected a valid number: {}",
+            request.amount
+        ))
+    })?;
 
     // Removing dashes from the session id because binance only accepts alphanumeric characters
     let session_id = Uuid::new_v4().to_string().replace("-", "");

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -111,21 +111,17 @@ async fn handler_internal(
         )));
     }
 
-    
-
     let amount = match request.amount.parse::<f64>() {
         Ok(parsed_amount) => parsed_amount,
-        Err(_) => {
-            match usize::from_str_radix(request.amount.trim_start_matches("0x"), 16) {
-                Ok(parsed_hex_amount) => parsed_hex_amount as f64, 
-                Err(_) => {
-                    return Err(GetExchangeUrlError::ValidationError(format!(
-                        "Invalid amount. Expected a valid number or hexadecimal string: {}",
-                        request.amount
-                    )));
-                }
+        Err(_) => match usize::from_str_radix(request.amount.trim_start_matches("0x"), 16) {
+            Ok(parsed_hex_amount) => parsed_hex_amount as f64,
+            Err(_) => {
+                return Err(GetExchangeUrlError::ValidationError(format!(
+                    "Invalid amount. Expected a valid number or hexadecimal string: {}",
+                    request.amount
+                )));
             }
-        }
+        },
     };
 
     // Removing dashes from the session id because binance only accepts alphanumeric characters

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -111,15 +111,15 @@ async fn handler_internal(
         )));
     }
 
-    let amount = match usize::from_str_radix(request.amount.trim_start_matches("0x"), 16) {
-        Ok(amount) => amount,
-        Err(_) => {
-            return Err(GetExchangeUrlError::ValidationError(format!(
-                "Invalid amount. Expected a valid hexadecimal number: {}",
+    let amount = request
+        .amount
+        .parse::<f64>()
+        .map_err(|_| {
+            GetExchangeUrlError::ValidationError(format!(
+                "Invalid amount. Expected a valid number: {}",
                 request.amount
-            )))
-        }
-    };
+            ))
+        })?;
 
     // Removing dashes from the session id because binance only accepts alphanumeric characters
     let session_id = Uuid::new_v4().to_string().replace("-", "");

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -111,12 +111,22 @@ async fn handler_internal(
         )));
     }
 
-    let amount = request.amount.parse::<f64>().map_err(|_| {
-        GetExchangeUrlError::ValidationError(format!(
-            "Invalid amount. Expected a valid number: {}",
-            request.amount
-        ))
-    })?;
+    
+
+    let amount = match request.amount.parse::<f64>() {
+        Ok(parsed_amount) => parsed_amount,
+        Err(_) => {
+            match usize::from_str_radix(request.amount.trim_start_matches("0x"), 16) {
+                Ok(parsed_hex_amount) => parsed_hex_amount as f64, 
+                Err(_) => {
+                    return Err(GetExchangeUrlError::ValidationError(format!(
+                        "Invalid amount. Expected a valid number or hexadecimal string: {}",
+                        request.amount
+                    )));
+                }
+            }
+        }
+    };
 
     // Removing dashes from the session id because binance only accepts alphanumeric characters
     let session_id = Uuid::new_v4().to_string().replace("-", "");


### PR DESCRIPTION
# Description

Handling floats/decimals in Hex is challenging and implementation in JS and Rust is different. Switched to standard float

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
