### PR TITLE
fix(terraform): updating the RDS engine version

### DIFF
--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -13,7 +13,7 @@ module "db_cluster" {
   name               = module.this.id
   database_name      = var.db_name
   engine             = "aurora-postgresql"
-  engine_version     = "15.5"
+  engine_version     = "15.10"
   engine_mode        = "provisioned"
   ca_cert_identifier = "rds-ca-ecc384-g1"
   instance_class     = "db.serverless"


### PR DESCRIPTION
# Description

This PR updates the AWS RDS engine version `15.5` -> `15.10` because the engine version was updated during the maintenance window, and now it's causing a downgrading error during the terraform apply: `api error InvalidParameterCombination: Cannot upgrade aurora-postgresql from 15.10 to 15.5`

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
