### PR TITLE
fix: ws provider fix

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -78,9 +78,4 @@ WebSocket RPC **is not recommended for production use**, and may be removed in t
 | Network            | Chain ID        |
 |--------------------|-----------------|
 | Ethereum           | eip155:1        |
-| Optimism           | eip155:10       |
-| Arbitrum           | eip155:42161    |
-| Arbitrum Sepolia   | eip155:421614   |
 | Zora               | eip155:7777777  |
-| Ethereum Sepolia   | eip155:11155111 |
-| Optimism Sepolia   | eip155:11155420 |

--- a/src/env/allnodes.rs
+++ b/src/env/allnodes.rs
@@ -7,6 +7,7 @@ use {
 #[derive(Debug)]
 pub struct AllnodesConfig {
     pub supported_chains: HashMap<String, (String, Weight)>,
+    pub supported_ws_chains: HashMap<String, (String, Weight)>,
     pub api_key: String,
 }
 
@@ -14,6 +15,7 @@ impl AllnodesConfig {
     pub fn new(api_key: String) -> Self {
         Self {
             supported_chains: default_supported_chains(),
+            supported_ws_chains: default_ws_supported_chains(),
             api_key,
         }
     }
@@ -25,7 +27,7 @@ impl ProviderConfig for AllnodesConfig {
     }
 
     fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
-        HashMap::new()
+        self.supported_ws_chains
     }
 
     fn provider_kind(&self) -> crate::providers::ProviderKind {
@@ -41,6 +43,18 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:1".into(),
             ("eth57873".into(), Weight::new(Priority::Max).unwrap()),
+        ),
+    ])
+}
+
+fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Ethereum
+        (
+            "eip155:1".into(),
+            ("eth57873".into(), Weight::new(Priority::Normal).unwrap()),
         ),
     ])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,12 @@ use {
     http::Request,
     hyper::{header::HeaderName, http, server::conn::AddrIncoming, Body, Server},
     providers::{
-        AllnodesProvider, ArbitrumProvider, AuroraProvider, BaseProvider, BinanceProvider,
-        DrpcProvider, DuneProvider, GetBlockProvider, MantleProvider, MonadProvider, MorphProvider,
-        NearProvider, OdysseyProvider, PoktProvider, ProviderRepository, PublicnodeProvider,
-        QuicknodeProvider, SolScanProvider, SyndicaProvider, UnichainProvider, WemixProvider,
-        ZKSyncProvider, ZerionProvider, ZoraProvider, ZoraWsProvider,
+        AllnodesProvider, AllnodesWsProvider, ArbitrumProvider, AuroraProvider, BaseProvider,
+        BinanceProvider, DrpcProvider, DuneProvider, GetBlockProvider, MantleProvider,
+        MonadProvider, MorphProvider, NearProvider, OdysseyProvider, PoktProvider,
+        ProviderRepository, PublicnodeProvider, QuicknodeProvider, SolScanProvider,
+        SyndicaProvider, UnichainProvider, WemixProvider, ZKSyncProvider, ZerionProvider,
+        ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -541,6 +542,9 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
         ));
     };
 
+    providers.add_ws_provider::<AllnodesWsProvider, AllnodesConfig>(AllnodesConfig::new(
+        config.allnodes_api_key.clone(),
+    ));
     providers.add_ws_provider::<ZoraWsProvider, ZoraConfig>(ZoraConfig::default());
 
     providers.add_balance_provider::<ZerionProvider, ZerionConfig>(

--- a/src/providers/allnodes.rs
+++ b/src/providers/allnodes.rs
@@ -1,18 +1,24 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    super::{
+        Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams,
+        RpcWsProvider, WS_PROXY_TASK_METRICS,
+    },
     crate::{
         env::AllnodesConfig,
         error::{RpcError, RpcResult},
+        ws,
     },
     async_trait::async_trait,
     axum::{
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
+    axum_tungstenite::WebSocketUpgrade,
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
+    wc::future::FutureExt,
 };
 
 #[derive(Debug)]
@@ -20,6 +26,60 @@ pub struct AllnodesProvider {
     pub client: Client<HttpsConnector<HttpConnector>>,
     pub supported_chains: HashMap<String, String>,
     pub api_key: String,
+}
+
+#[derive(Debug)]
+pub struct AllnodesWsProvider {
+    pub supported_chains: HashMap<String, String>,
+    pub api_key: String,
+}
+
+impl Provider for AllnodesWsProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Allnodes
+    }
+}
+
+#[async_trait]
+impl RpcWsProvider for AllnodesWsProvider {
+    #[tracing::instrument(skip_all, fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(
+        &self,
+        ws: WebSocketUpgrade,
+        query_params: RpcQueryParams,
+    ) -> RpcResult<Response> {
+        let chain = &self
+            .supported_chains
+            .get(&query_params.chain_id.to_lowercase())
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let project_id = query_params.project_id;
+        let uri = format!("wss://{}.allnodes.me:8546/{}", chain, &self.api_key);
+        let (websocket_provider, _) = async_tungstenite::tokio::connect_async(uri).await?;
+
+        Ok(ws.on_upgrade(move |socket| {
+            ws::proxy(project_id, socket, websocket_provider)
+                .with_metrics(WS_PROXY_TASK_METRICS.with_name("allnodes"))
+        }))
+    }
+}
+
+#[async_trait]
+impl RateLimited for AllnodesWsProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool
+    where
+        Self: Sized,
+    {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 impl Provider for AllnodesProvider {
@@ -93,6 +153,22 @@ impl RpcProviderFactory<AllnodesConfig> for AllnodesProvider {
 
         AllnodesProvider {
             client: forward_proxy_client,
+            supported_chains,
+            api_key: provider_config.api_key.clone(),
+        }
+    }
+}
+
+impl RpcProviderFactory<AllnodesConfig> for AllnodesWsProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &AllnodesConfig) -> Self {
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_ws_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        AllnodesWsProvider {
             supported_chains,
             api_key: provider_config.api_key.clone(),
         }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -96,7 +96,7 @@ mod zksync;
 mod zora;
 
 pub use {
-    allnodes::AllnodesProvider,
+    allnodes::{AllnodesProvider, AllnodesWsProvider},
     arbitrum::ArbitrumProvider,
     aurora::AuroraProvider,
     base::BaseProvider,

--- a/tests/functional/http/allnodes.rs
+++ b/tests/functional/http/allnodes.rs
@@ -1,0 +1,20 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn allnodes_provider(ctx: &mut ServerContext) {
+    let provider_kind = ProviderKind::Allnodes;
+
+    // Ethereum Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider_kind,
+        "eip155:1",
+        "0x1",
+    )
+    .await;
+}

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -6,6 +6,7 @@ use {
     test_context::test_context,
 };
 
+pub(crate) mod allnodes;
 pub(crate) mod arbitrum;
 pub(crate) mod aurora;
 pub(crate) mod base;


### PR DESCRIPTION
# Description

This PR makes the following changes:
* Adding Allnodes as a WS RPC provider for the Ethereum mainnet instead of the removed Infura,
* Updating the list of supported WS chains,
* Fixing the supported chains CI test.

## How Has This Been Tested?

Tested by running the current integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
