### PR TITLE
fix(rpc): using the Publicnode provider when session was provided

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -103,11 +103,12 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ("optimism".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Optimism Sepolia
+        // TODO: Temporary disabled due to issues with the provider
         (
             "eip155:11155420".into(),
             (
                 "optimism-sepolia-testnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::Disabled).unwrap(),
             ),
         ),
         // Arbitrum

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -198,6 +198,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:146".into(),
             ("sonic-rpc".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Optimism Sepolia
+        (
+            "eip155:11155420".into(),
+            (
+                "optimism-sepolia-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Sonic Testnet
         (
             "eip155:57054".into(),

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -71,8 +71,8 @@ pub async fn rpc_call(
     if query_params.session_id.is_some() {
         let provider_kind = match chain_id.as_str() {
             "eip155:10" => Some(ProviderKind::Quicknode), // Optimism
-            "eip155:8453" => Some(ProviderKind::Pokt),    // Base
-            "eip155:42161" => Some(ProviderKind::Pokt),   // Arbitrum One
+            "eip155:8453" => Some(ProviderKind::Publicnode), // Base
+            "eip155:42161" => Some(ProviderKind::Publicnode), // Arbitrum One
             _ => {
                 debug!(
                     "Requested sessionId for chain {chain_id} but no hardcoded provider was configured"

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -147,6 +147,15 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
         .await;
 
+    // Optimism Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:11155420",
+        "0xaa37dc",
+    )
+    .await;
+
     // Arbitrum One
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,


### PR DESCRIPTION
# Description

This PR changes the default provider for RPC call when session_id was provided to the `Publicnode`.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
