### PR TITLE
feat: enable more pairs for exchanges

### DIFF
--- a/src/handlers/wallet/exchanges/binance.rs
+++ b/src/handlers/wallet/exchanges/binance.rs
@@ -41,7 +41,7 @@ static CAIP19_TO_BINANCE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
             "USDC",
         ), // USDC on Arbitrum
         ("eip155:1/slip44:60", "ETH"), // Native ETH
-        ("solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ/slip44:501", "SOL"), // Native SOL
+        ("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501", "SOL"), // Native SOL
         (
             "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
             "USDT",
@@ -58,7 +58,14 @@ static CAIP19_TO_BINANCE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
             "eip155:137/erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
             "USDT",
         ), // USDT on Polygon
-      
+        (
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "USDC",
+        ), // USDC on Solana
+        (
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+            "USDT",
+        ), // USDT on Solana
     ])
 });
 
@@ -70,7 +77,7 @@ static CHAIN_ID_TO_BINANCE_NETWORK: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
         ("eip155:8453", "BASE"),                            // Base
         ("eip155:42161", "ARBITRUM"),                       // Arbitrum
         ("eip155:10", "OPTIMISM"),                          // Optimism
-        ("solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ", "SOL"), // Solana
+        ("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "SOL"), // Solana
     ])
 });
 

--- a/src/handlers/wallet/exchanges/binance.rs
+++ b/src/handlers/wallet/exchanges/binance.rs
@@ -42,6 +42,23 @@ static CAIP19_TO_BINANCE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
         ), // USDC on Arbitrum
         ("eip155:1/slip44:60", "ETH"), // Native ETH
         ("solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ/slip44:501", "SOL"), // Native SOL
+        (
+            "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+            "USDT",
+        ), // USDT on Ethereum
+        (
+            "eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+            "USDT",
+        ), // USDT on Arbitrum
+        (
+            "eip155:10/erc20:0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+            "USDT",
+        ), // USDT on Optimism
+        (
+            "eip155:137/erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+            "USDT",
+        ), // USDT on Polygon
+      
     ])
 });
 

--- a/src/handlers/wallet/exchanges/coinbase.rs
+++ b/src/handlers/wallet/exchanges/coinbase.rs
@@ -60,13 +60,12 @@ static CAIP19_TO_COINBASE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 
 static CHAIN_ID_TO_COINBASE_NETWORK: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     HashMap::from([
-        ("eip155:8453", "base"), // Base
-        ("eip155:10", "optimism"), // Optimism
-        ("eip155:42161", "arbitrum"), // Arbitrum
-        ("eip155:137", "polygon"), // Polygon
-        ("eip155:1", "ethereum"), // Ethereum
+        ("eip155:8453", "base"),                            // Base
+        ("eip155:10", "optimism"),                          // Optimism
+        ("eip155:42161", "arbitrum"),                       // Arbitrum
+        ("eip155:137", "polygon"),                          // Polygon
+        ("eip155:1", "ethereum"),                           // Ethereum
         ("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "SOL"), // Solana
-
     ])
 });
 

--- a/src/handlers/wallet/exchanges/coinbase.rs
+++ b/src/handlers/wallet/exchanges/coinbase.rs
@@ -30,12 +30,37 @@ static CAIP19_TO_COINBASE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
             "eip155:8453/erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
             "USDC",
         ), // USDC on Base
+        (
+            "eip155:10/erc20:0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+            "USDC",
+        ), // USDC on Optimism
+        (
+            "eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+            "USDC",
+        ), // USDC on Arbitrum
+        (
+            "eip155:137/erc20:0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+            "USDC",
+        ), // USDC on Polygon
+        (
+            "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "USDC",
+        ), // USDC on Ethereum
+        ("eip155:1/slip44:60", "ETH"), // Native ETH
+        (
+            "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+            "USDT",
+        ), // USDT on Ethereum
     ])
 });
 
 static CHAIN_ID_TO_COINBASE_NETWORK: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     HashMap::from([
         ("eip155:8453", "base"), // Base
+        ("eip155:10", "optimism"), // Optimism
+        ("eip155:42161", "arbitrum"), // Arbitrum
+        ("eip155:137", "polygon"), // Polygon
+        ("eip155:1", "ethereum"), // Ethereum
     ])
 });
 

--- a/src/handlers/wallet/exchanges/coinbase.rs
+++ b/src/handlers/wallet/exchanges/coinbase.rs
@@ -51,6 +51,10 @@ static CAIP19_TO_COINBASE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
             "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
             "USDT",
         ), // USDT on Ethereum
+        (
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "USDC",
+        ), // USDC on Solana
     ])
 });
 
@@ -61,6 +65,8 @@ static CHAIN_ID_TO_COINBASE_NETWORK: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
         ("eip155:42161", "arbitrum"), // Arbitrum
         ("eip155:137", "polygon"), // Polygon
         ("eip155:1", "ethereum"), // Ethereum
+        ("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "SOL"), // Solana
+
     ])
 });
 


### PR DESCRIPTION
# Description

Add more assets to the list of supported ones for both Binance and Coinbase

Resolves PAY-26,PAY-27,PAY-28

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
