### PR TITLE
feat: handle custom bundler URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8349,6 +8359,7 @@ dependencies = [
  "vergen",
  "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
  "wcn_replication",
+ "wiremock",
  "yttrium",
 ]
 
@@ -13932,6 +13943,30 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ ed25519-dalek = "2.1"
 # System CPU and Memory metrics
 sysinfo = "0.30"
 eyre = "0.6.12"
+wiremock = "0.6.3"
 
 [dev-dependencies]
 jsonrpc = "0.18.0"

--- a/justfile
+++ b/justfile
@@ -347,3 +347,6 @@ _check-string-in-set target set options='':
       exit 1
     fi
   fi
+
+docker:
+  docker compose up -d postgres redis

--- a/src/error.rs
+++ b/src/error.rs
@@ -264,6 +264,12 @@ pub enum RpcError {
 
     #[error("Join error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+
+    #[error("Unsupported bundler name (URL parse error): {0}")]
+    UnsupportedBundlerNameUrlParseError(url::ParseError),
+
+    #[error("Unsupported bundler name: {0}")]
+    UnsupportedBundlerName(String),
 }
 
 impl IntoResponse for RpcError {
@@ -283,6 +289,22 @@ impl IntoResponse for RpcError {
                     Json(new_error_response(
                         "currency".to_string(),
                         format!("Unsupported currency: {error_message}."),
+                    )),
+                )
+                    .into_response(),
+            Self::UnsupportedBundlerName(error_message) => (
+                    StatusCode::BAD_REQUEST,
+                    Json(new_error_response(
+                        "bundler_name".to_string(),
+                        format!("Unsupported bundler name: {error_message}."),
+                    )),
+                )
+                    .into_response(),
+            Self::UnsupportedBundlerNameUrlParseError(error_message) => (
+                    StatusCode::BAD_REQUEST,
+                    Json(new_error_response(
+                        "bundler_name".to_string(),
+                        format!("Unsupported bundler name: {error_message}."),
                     )),
                 )
                     .into_response(),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -42,7 +42,7 @@ pub async fn spawn_blockchain_api_with_params(params: Params) -> Url {
                 port: public_port,
                 prometheus_port,
                 host: hostname.to_string(),
-                log_level: "NONE".to_string(),
+                log_level: "DEBUG".to_string(),
                 validate_project_id: params.validate_project_id,
                 ..Default::default()
             };
@@ -79,7 +79,7 @@ async fn wait_for_server_to_start(port: u16) {
         }
     };
 
-    tokio::time::timeout(Duration::from_secs(5), poll_fut)
+    tokio::time::timeout(Duration::from_secs(10), poll_fut)
         .await
         .unwrap()
 }

--- a/tests/functional/bundler.rs
+++ b/tests/functional/bundler.rs
@@ -1,0 +1,177 @@
+use rpc_proxy::{
+    providers::mock_alto::MockAltoUrls, test_helpers::spawn_blockchain_api_with_params,
+};
+use serde_json::json;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn default_bundler() {
+    let bundler_server = MockServer::start().await;
+
+    let response = ResponseTemplate::new(200).set_body_json(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": "0x1"
+    }));
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_partial_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_getUserOperationReceipt",
+            "params": null
+        })))
+        .respond_with(response)
+        .mount(&bundler_server)
+        .await;
+
+    // tracing_subscriber::fmt()
+    //     .with_env_filter(
+    //         EnvFilter::builder()
+    //             .with_default_directive(LevelFilter::ERROR.into())
+    //             .parse("DEBUG")
+    //             .expect("Invalid log level"),
+    //     )
+    //     .with_span_events(FmtSpan::CLOSE)
+    //     .with_ansi(false)
+    //     .init();
+
+    let server_url = spawn_blockchain_api_with_params(rpc_proxy::test_helpers::Params {
+        validate_project_id: false,
+        override_bundler_urls: Some(MockAltoUrls {
+            bundler_url: bundler_server.uri().parse().unwrap(),
+            paymaster_url: bundler_server.uri().parse().unwrap(),
+        }),
+    })
+    .await;
+    let mut url = server_url.join("/v1/bundler").unwrap();
+    url.query_pairs_mut()
+        .append_pair("projectId", "test")
+        .append_pair("chainId", "eip155:1");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .json(&jsonrpc::Request {
+            method: "eth_getUserOperationReceipt",
+            params: None,
+            id: serde_json::Value::Number(1.into()),
+            jsonrpc: Some("2.0"),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response
+            .json::<serde_json::Value>()
+            .await
+            .unwrap()
+            .get("result")
+            .unwrap()
+            .as_str(),
+        Some("0x1")
+    );
+
+    let mut url = server_url.join("/v1/bundler").unwrap();
+    url.query_pairs_mut()
+        .append_pair("projectId", "test")
+        .append_pair("chainId", "eip155:1")
+        .append_pair("bundler", "pimlico");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .json(&jsonrpc::Request {
+            method: "eth_getUserOperationReceipt",
+            params: None,
+            id: serde_json::Value::Number(1.into()),
+            jsonrpc: Some("2.0"),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response
+            .json::<serde_json::Value>()
+            .await
+            .unwrap()
+            .get("result")
+            .unwrap()
+            .as_str(),
+        Some("0x1")
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn bundler_url() {
+    let bundler_server = MockServer::start().await;
+
+    let response = ResponseTemplate::new(200).set_body_json(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": "0x1"
+    }));
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_partial_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_getUserOperationReceipt",
+            "params": null
+        })))
+        .respond_with(response)
+        .mount(&bundler_server)
+        .await;
+
+    // tracing_subscriber::fmt()
+    //     .with_env_filter(
+    //         EnvFilter::builder()
+    //             .with_default_directive(LevelFilter::ERROR.into())
+    //             .parse("DEBUG")
+    //             .expect("Invalid log level"),
+    //     )
+    //     .with_span_events(FmtSpan::CLOSE)
+    //     .with_ansi(false)
+    //     .init();
+
+    let url = spawn_blockchain_api_with_params(rpc_proxy::test_helpers::Params {
+        validate_project_id: false,
+        override_bundler_urls: None,
+    })
+    .await;
+    let mut url = url.join("/v1/bundler").unwrap();
+    url.query_pairs_mut()
+        .append_pair("projectId", "test")
+        .append_pair("chainId", "eip155:1")
+        .append_pair("bundler", &bundler_server.uri());
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .json(&jsonrpc::Request {
+            method: "eth_getUserOperationReceipt",
+            params: None,
+            id: serde_json::Value::Number(1.into()),
+            jsonrpc: Some("2.0"),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response
+            .json::<serde_json::Value>()
+            .await
+            .unwrap()
+            .get("result")
+            .unwrap()
+            .as_str(),
+        Some("0x1")
+    );
+}

--- a/tests/functional/mod.rs
+++ b/tests/functional/mod.rs
@@ -1,3 +1,4 @@
+mod bundler;
 mod database;
 mod http;
 mod websocket;


### PR DESCRIPTION
# Description

[Design doc](https://www.notion.so/walletconnect/1Pager-WalletKit-Util-for-WalletService-1d83a661771e8093b014e2594f947c4e?pvs=4#1f53a661771e80cc935bd7156166ea19)

Resolves https://linear.app/reown/issue/CR-701/blockchain-api-bundler-endpoint-accept-bundler-url-as-bundler-name

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
