### PR TITLE
fix(Meld): proper handling of the bad request response

### DIFF
--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -12,6 +12,7 @@ use {
         Metrics,
     },
     async_trait::async_trait,
+    reqwest::StatusCode,
     serde::{Deserialize, Serialize},
     std::{sync::Arc, time::SystemTime},
     tracing::log::error,
@@ -116,7 +117,10 @@ impl OnRampMultiProvider for MeldProvider {
         if !response.status().is_success() {
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)
-            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+            if matches!(
+                response.status(),
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+            ) {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
@@ -194,7 +198,10 @@ impl OnRampMultiProvider for MeldProvider {
         if !response.status().is_success() {
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)
-            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+            if matches!(
+                response.status(),
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+            ) {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
@@ -248,7 +255,10 @@ impl OnRampMultiProvider for MeldProvider {
         if !response.status().is_success() {
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)
-            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+            if matches!(
+                response.status(),
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+            ) {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
@@ -293,7 +303,10 @@ impl OnRampMultiProvider for MeldProvider {
         if !response.status().is_success() {
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)
-            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+            if matches!(
+                response.status(),
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+            ) {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error,
                     Err(e) => {


### PR DESCRIPTION
# Description

This PR adds handling of the "bad request" Meld provider response, to handle both `HTTP 400` and `HTTP 422`, since the production endpoint uses `HTTP 422` and the sandbox uses `HTTP 400`.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
