### PR TITLE
feat(providers): adding Sui chain RPC support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -69,6 +69,14 @@ Chain name with associated `chainId` query param to use.
 | Bitcoin Mainnet                       | bip122:000000000019d6689c085ae165831e93 |
 | Bitcoin Testnet                       | bip122:000000000933ea01ad0ee984209779ba |
 
+### Sui
+
+| Network                               | Chain ID    |
+|---------------------------------------|-------------|
+| Sui Mainnet                           | sui:mainnet |
+| Sui Devnet                            | sui:devnet  |
+| Sui Testnet                           | sui:testnet |
+
 <a id="footnote1"><sup>1</sup></a> The availability of this chain in our RPC is not guaranteed.
 
 ## WebSocket RPC

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -18,7 +18,7 @@ use {
 pub use {
     allnodes::*, arbitrum::*, aurora::*, base::*, binance::*, drpc::*, dune::*, mantle::*,
     monad::*, morph::*, near::*, odyssey::*, pokt::*, publicnode::*, quicknode::*, server::*,
-    solscan::*, syndica::*, unichain::*, wemix::*, zerion::*, zksync::*, zora::*,
+    solscan::*, sui::*, syndica::*, unichain::*, wemix::*, zerion::*, zksync::*, zora::*,
 };
 mod allnodes;
 mod arbitrum;
@@ -37,6 +37,7 @@ mod publicnode;
 mod quicknode;
 mod server;
 pub mod solscan;
+mod sui;
 mod syndica;
 mod unichain;
 mod wemix;

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -183,5 +183,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "near:mainnet".into(),
             ("near".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Sui mainnet
+        (
+            "sui:mainnet".into(),
+            ("sui".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
     ])
 }

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -232,5 +232,19 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into(),
             ("solana-rpc".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Sui mainnet
+        (
+            "sui:mainnet".into(),
+            ("sui-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // Sui testnet
+        (
+            "sui:testnet".into(),
+            (
+                "sui-testnet-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        //
     ])
 }

--- a/src/env/sui.rs
+++ b/src/env/sui.rs
@@ -1,0 +1,63 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct SuiConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for SuiConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for SuiConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Sui
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Sui mainnet
+        (
+            "sui:mainnet".into(),
+            (
+                "https://fullnode.mainnet.sui.io".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Sui testnet
+        (
+            "sui:testnet".into(),
+            (
+                "https://fullnode.testnet.sui.io".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Sui devnet
+        (
+            "sui:devnet".into(),
+            (
+                "https://fullnode.devnet.sui.io".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use {
     env::{
         AllnodesConfig, ArbitrumConfig, AuroraConfig, BaseConfig, BinanceConfig, DrpcConfig,
         DuneConfig, MantleConfig, MonadConfig, MorphConfig, NearConfig, OdysseyConfig, PoktConfig,
-        PublicnodeConfig, QuicknodeConfig, SolScanConfig, SyndicaConfig, UnichainConfig,
+        PublicnodeConfig, QuicknodeConfig, SolScanConfig, SuiConfig, SyndicaConfig, UnichainConfig,
         WemixConfig, ZKSyncConfig, ZerionConfig, ZoraConfig,
     },
     error::RpcResult,
@@ -32,8 +32,9 @@ use {
         AllnodesProvider, AllnodesWsProvider, ArbitrumProvider, AuroraProvider, BaseProvider,
         BinanceProvider, DrpcProvider, DuneProvider, MantleProvider, MonadProvider, MorphProvider,
         NearProvider, OdysseyProvider, PoktProvider, ProviderRepository, PublicnodeProvider,
-        QuicknodeProvider, SolScanProvider, SyndicaProvider, SyndicaWsProvider, UnichainProvider,
-        WemixProvider, ZKSyncProvider, ZerionProvider, ZoraProvider, ZoraWsProvider,
+        QuicknodeProvider, SolScanProvider, SuiProvider, SyndicaProvider, SyndicaWsProvider,
+        UnichainProvider, WemixProvider, ZKSyncProvider, ZerionProvider, ZoraProvider,
+        ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -534,6 +535,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
         config.allnodes_api_key.clone(),
     ));
     providers.add_rpc_provider::<MonadProvider, MonadConfig>(MonadConfig::default());
+    providers.add_rpc_provider::<SuiProvider, SuiConfig>(SuiConfig::default());
     providers.add_ws_provider::<AllnodesWsProvider, AllnodesConfig>(AllnodesConfig::new(
         config.allnodes_api_key.clone(),
     ));

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -85,6 +85,7 @@ mod pokt;
 mod publicnode;
 mod quicknode;
 mod solscan;
+mod sui;
 mod syndica;
 pub mod tenderly;
 mod unichain;
@@ -115,6 +116,7 @@ pub use {
     publicnode::PublicnodeProvider,
     quicknode::QuicknodeProvider,
     solscan::SolScanProvider,
+    sui::SuiProvider,
     syndica::{SyndicaProvider, SyndicaWsProvider},
     tenderly::TenderlyProvider,
     unichain::UnichainProvider,
@@ -682,6 +684,7 @@ pub enum ProviderKind {
     Allnodes,
     Meld,
     Monad,
+    Sui,
 }
 
 impl Display for ProviderKind {
@@ -717,6 +720,7 @@ impl Display for ProviderKind {
                 ProviderKind::Allnodes => "Allnodes",
                 ProviderKind::Meld => "Meld",
                 ProviderKind::Monad => "Monad",
+                ProviderKind::Sui => "Sui",
             }
         )
     }
@@ -753,6 +757,7 @@ impl ProviderKind {
             "Allnodes" => Some(Self::Allnodes),
             "Meld" => Some(Self::Meld),
             "Monad" => Some(Self::Monad),
+            "Sui" => Some(Self::Sui),
             _ => None,
         }
     }

--- a/src/providers/sui.rs
+++ b/src/providers/sui.rs
@@ -1,0 +1,96 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::SuiConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct SuiProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for SuiProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Sui
+    }
+}
+
+#[async_trait]
+impl RateLimited for SuiProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for SuiProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Sui: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<SuiConfig> for SuiProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &SuiConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        SuiProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -2,6 +2,7 @@ use {
     super::{
         check_if_rpc_is_responding_correctly_for_near_protocol,
         check_if_rpc_is_responding_correctly_for_solana,
+        check_if_rpc_is_responding_correctly_for_sui,
         check_if_rpc_is_responding_correctly_for_supported_chain,
     },
     crate::context::ServerContext,
@@ -207,4 +208,13 @@ async fn pokt_provider_solana(ctx: &mut ServerContext) {
 #[ignore]
 async fn pokt_provider_near(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_near_protocol(ctx, &ProviderKind::Pokt).await;
+}
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn pokt_provider_sui(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Quicknode;
+    // Sui mainnet
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "mainnet", "35834a8a").await;
 }

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -214,7 +214,7 @@ async fn pokt_provider_near(ctx: &mut ServerContext) {
 #[tokio::test]
 #[ignore]
 async fn pokt_provider_sui(ctx: &mut ServerContext) {
-    let provider = ProviderKind::Quicknode;
     // Sui mainnet
-    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "mainnet", "35834a8a").await;
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &ProviderKind::Pokt, "mainnet", "35834a8a")
+        .await;
 }

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -233,7 +233,7 @@ async fn publicnode_provider_bitcoin(ctx: &mut ServerContext) {
 #[test_context(ServerContext)]
 #[tokio::test]
 #[ignore]
-async fn quicknode_provider_solana(ctx: &mut ServerContext) {
+async fn publicnode_provider_solana(ctx: &mut ServerContext) {
     let provider = ProviderKind::Publicnode;
     // Solana mainnet
     check_if_rpc_is_responding_correctly_for_solana(
@@ -247,7 +247,7 @@ async fn quicknode_provider_solana(ctx: &mut ServerContext) {
 #[test_context(ServerContext)]
 #[tokio::test]
 #[ignore]
-async fn quicknode_provider_sui(ctx: &mut ServerContext) {
+async fn publicnode_provider_sui(ctx: &mut ServerContext) {
     let provider = ProviderKind::Publicnode;
     // Sui mainnet
     check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "mainnet", "35834a8a").await;

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -2,6 +2,7 @@ use {
     super::{
         check_if_rpc_is_responding_correctly_for_bitcoin,
         check_if_rpc_is_responding_correctly_for_solana,
+        check_if_rpc_is_responding_correctly_for_sui,
         check_if_rpc_is_responding_correctly_for_supported_chain,
     },
     crate::context::ServerContext,
@@ -241,4 +242,15 @@ async fn quicknode_provider_solana(ctx: &mut ServerContext) {
         &provider,
     )
     .await;
+}
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn quicknode_provider_sui(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Publicnode;
+    // Sui mainnet
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "mainnet", "35834a8a").await;
+    // Sui testnet
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "testnet", "4c78adac").await;
 }

--- a/tests/functional/http/sui.rs
+++ b/tests/functional/http/sui.rs
@@ -1,0 +1,17 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_sui, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn quicknode_provider_sui(ctx: &mut ServerContext) {
+    let provider = ProviderKind::Publicnode;
+    // Sui mainnet
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "mainnet", "35834a8a").await;
+    // Sui testnet
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "testnet", "4c78adac").await;
+    // Sui devnet
+    check_if_rpc_is_responding_correctly_for_sui(ctx, &provider, "devnet", "6ee96fc3").await;
+}


### PR DESCRIPTION
# Description

This PR adds Sui chain RPC support for the mainnet, testnet and devnet using the following RPC providers:
* Publicnode,
* Grove/Pokt,
* Native RPC endpoint.

## How Has This Been Tested?

New provider tests were implemented.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
