### PR TITLE
feat(providers): decreasing BSC chain priority for the dRPC

### DIFF
--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -88,7 +88,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:56".into(),
             (
                 "https://bsc.drpc.org".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::Minimal).unwrap(),
             ),
         ),
         // Polygon


### PR DESCRIPTION
# Description

This PR decreases the BSC `eip155:56` chain priority for the dRPC provider since it's constantly rate-limited for this endpoint, and we need to re-route traffic to avoid increasing latency and retrying.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
