### PR TITLE
fix(CA): properly handling of the initial transaction simulation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14107,7 +14107,7 @@ dependencies = [
 [[package]]
 name = "yttrium"
 version = "0.1.0"
-source = "git+https://github.com/reown-com/yttrium.git?rev=5b03b23#5b03b23cb448c094590c9305937464f514fe2de3"
+source = "git+https://github.com/reown-com/yttrium.git?rev=5e1b5f4#5e1b5f4d214f08819794d84f488178a64b1d5108"
 dependencies = [
  "alloy 0.11.1",
  "alloy-provider 0.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
-yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "5b03b23", features = ["solana"] }
+yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "5e1b5f4", features = ["solana"] }
 
 # Async
 async-trait = "0.1.82"


### PR DESCRIPTION
# Description

This PR adds proper handling of the initial transaction simulation error in a Chain Abstraction. This prevents an `HTTP 500` error in cases when the initial transaction is broken or can't be executed, and we know this when making the initial transaction simulation with overrides.

This PR is related to these yttrium changes:
* https://github.com/reown-com/yttrium/pull/175

## How Has This Been Tested?

Manually tested.

## Due Diligence

* [x] Update to the yttrium revision instead of the branch when merged.
