### PR TITLE
fix(providers): adding Linea chain to the dRPC and Publicnode, removing from Pokt

### DIFF
--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -155,5 +155,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Linea Mainnet
+        (
+            "eip155:59144".into(),
+            (
+                "https://linea.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -94,7 +94,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:11155111".into(),
             (
                 "eth-sepolia-testnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::Minimal).unwrap(),
             ),
         ),
         // Optimism
@@ -147,11 +147,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:42220".into(),
             ("celo".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
-        // Linea
-        (
-            "eip155:59144".into(),
-            ("linea".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Kaia Mainnet
         (

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -214,6 +214,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Linea Mainnet
+        (
+            "eip155:59144".into(),
+            ("linea-rpc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Bitcoin mainnet
         (
             "bip122:000000000019d6689c085ae165831e93".into(),


### PR DESCRIPTION
# Description

This Pr adjusting chains according to the latest Pokt provider changes:
* Removing Linea endpoint from the Pokt provider because it has a consistent `HTTP 404` response;
* Adding Linea chain to the dRPC and Publicnode;
* Decreasing the Ethereum Sepolia endpoint to the minimum in Pokt due to an excessive amount of `HTTP 500` responses.

## How Has This Been Tested?

Tested manually and by the current integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
