### PR TITLE
fix(test): temporarily disabling bundler functional test

### DIFF
--- a/tests/functional/bundler.rs
+++ b/tests/functional/bundler.rs
@@ -6,6 +6,7 @@ use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
+#[ignore]
 async fn default_bundler() {
     let bundler_server = MockServer::start().await;
 


### PR DESCRIPTION
# Description

This PR temporarily disables the `functional::bundler::default_bundler` test due to non-provided env variables in the CI.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
