### PR TITLE
feat(RPC): adding Stacks transactions RPC support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -83,10 +83,10 @@ Chain name with associated `chainId` query param to use.
 *Important note:* The Stacks support is currently in a Beta. Endpoints and schema
 can be changed in a near future.
 
-| Network                                   | Chain ID       |
-|-------------------------------------------|----------------|
-| Stacks Mainnet <sup>[1](#footnote1)</sup> | stacks:mainnet |
-| Stacks Devnet <sup>[1](#footnote1)</sup>  | stacks:devnet  |
+| Network                                   | Chain ID          |
+|-------------------------------------------|-------------------|
+| Stacks Mainnet <sup>[1](#footnote1)</sup> | stacks:1          |
+| Stacks Testnet <sup>[1](#footnote1)</sup> | stacks:2147483648 |
 
 <a id="footnote1"><sup>1</sup></a> The availability of this chain in our RPC is not guaranteed.
 

--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -77,6 +77,17 @@ Chain name with associated `chainId` query param to use.
 | Sui Devnet                            | sui:devnet  |
 | Sui Testnet                           | sui:testnet |
 
+
+### Stacks
+
+*Important note:* The Stacks support is currently in a Beta. Endpoints and schema
+can be changed in a near future.
+
+| Network                                   | Chain ID       |
+|-------------------------------------------|----------------|
+| Stacks Mainnet <sup>[1](#footnote1)</sup> | stacks:mainnet |
+| Stacks Devnet <sup>[1](#footnote1)</sup>  | stacks:devnet  |
+
 <a id="footnote1"><sup>1</sup></a> The availability of this chain in our RPC is not guaranteed.
 
 ## WebSocket RPC

--- a/src/env/hiro.rs
+++ b/src/env/hiro.rs
@@ -1,0 +1,55 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct HiroConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for HiroConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for HiroConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Hiro
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Stacks mainnet
+        (
+            "stacks:mainnet".into(),
+            (
+                "https://api.mainnet.hiro.so/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Stacks testnet
+        (
+            "stacks:testnet".into(),
+            (
+                "https://api.testnet.hiro.so/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/env/hiro.rs
+++ b/src/env/hiro.rs
@@ -35,17 +35,17 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
     HashMap::from([
-        // Stacks mainnet
+        // Stacks Mainnet
         (
-            "stacks:mainnet".into(),
+            "stacks:1".into(),
             (
                 "https://api.mainnet.hiro.so/".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Stacks testnet
+        // Stacks Testnet
         (
-            "stacks:testnet".into(),
+            "stacks:2147483648".into(),
             (
                 "https://api.testnet.hiro.so/".into(),
                 Weight::new(Priority::Normal).unwrap(),

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -16,7 +16,7 @@ use {
     std::{collections::HashMap, fmt::Display},
 };
 pub use {
-    allnodes::*, arbitrum::*, aurora::*, base::*, binance::*, drpc::*, dune::*, mantle::*,
+    allnodes::*, arbitrum::*, aurora::*, base::*, binance::*, drpc::*, dune::*, hiro::*, mantle::*,
     monad::*, morph::*, near::*, odyssey::*, pokt::*, publicnode::*, quicknode::*, server::*,
     solscan::*, sui::*, syndica::*, unichain::*, wemix::*, zerion::*, zksync::*, zora::*,
 };
@@ -27,6 +27,7 @@ mod base;
 mod binance;
 mod drpc;
 mod dune;
+mod hiro;
 mod mantle;
 mod monad;
 mod morph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,20 +21,20 @@ use {
     },
     env::{
         AllnodesConfig, ArbitrumConfig, AuroraConfig, BaseConfig, BinanceConfig, DrpcConfig,
-        DuneConfig, MantleConfig, MonadConfig, MorphConfig, NearConfig, OdysseyConfig, PoktConfig,
-        PublicnodeConfig, QuicknodeConfig, SolScanConfig, SuiConfig, SyndicaConfig, UnichainConfig,
-        WemixConfig, ZKSyncConfig, ZerionConfig, ZoraConfig,
+        DuneConfig, HiroConfig, MantleConfig, MonadConfig, MorphConfig, NearConfig, OdysseyConfig,
+        PoktConfig, PublicnodeConfig, QuicknodeConfig, SolScanConfig, SuiConfig, SyndicaConfig,
+        UnichainConfig, WemixConfig, ZKSyncConfig, ZerionConfig, ZoraConfig,
     },
     error::RpcResult,
     http::Request,
     hyper::{header::HeaderName, http, server::conn::AddrIncoming, Body, Server},
     providers::{
         AllnodesProvider, AllnodesWsProvider, ArbitrumProvider, AuroraProvider, BaseProvider,
-        BinanceProvider, DrpcProvider, DuneProvider, MantleProvider, MonadProvider, MorphProvider,
-        NearProvider, OdysseyProvider, PoktProvider, ProviderRepository, PublicnodeProvider,
-        QuicknodeProvider, SolScanProvider, SuiProvider, SyndicaProvider, SyndicaWsProvider,
-        UnichainProvider, WemixProvider, ZKSyncProvider, ZerionProvider, ZoraProvider,
-        ZoraWsProvider,
+        BinanceProvider, DrpcProvider, DuneProvider, HiroProvider, MantleProvider, MonadProvider,
+        MorphProvider, NearProvider, OdysseyProvider, PoktProvider, ProviderRepository,
+        PublicnodeProvider, QuicknodeProvider, SolScanProvider, SuiProvider, SyndicaProvider,
+        SyndicaWsProvider, UnichainProvider, WemixProvider, ZKSyncProvider, ZerionProvider,
+        ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -536,6 +536,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     ));
     providers.add_rpc_provider::<MonadProvider, MonadConfig>(MonadConfig::default());
     providers.add_rpc_provider::<SuiProvider, SuiConfig>(SuiConfig::default());
+    providers.add_rpc_provider::<HiroProvider, HiroConfig>(HiroConfig::default());
     providers.add_ws_provider::<AllnodesWsProvider, AllnodesConfig>(AllnodesConfig::new(
         config.allnodes_api_key.clone(),
     ));

--- a/src/providers/hiro.rs
+++ b/src/providers/hiro.rs
@@ -1,0 +1,136 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::HiroConfig,
+        error::{RpcError, RpcResult},
+        json_rpc::JsonRpcRequest,
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    serde::Serialize,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct HiroProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TransactionsRequest {
+    pub tx: String,
+}
+
+impl Provider for HiroProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Hiro
+    }
+}
+
+#[async_trait]
+impl RateLimited for HiroProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for HiroProvider {
+    /// Proxies the request to the Stacks `/v2/transactions` endpoint only
+    /// using the JSON-RPC schema with the `stacks_transactions` method
+    /// and a single parameter as `tx`.
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+        let uri = format!("{uri}/v2/transactions");
+        let uri = uri.parse::<hyper::Uri>().map_err(|_| {
+            RpcError::InvalidParameter("Failed to parse URI for stacks_transactions".into())
+        })?;
+
+        let json_rpc_request: JsonRpcRequest = serde_json::from_slice(&body)
+            .map_err(|_| RpcError::InvalidParameter("Invalid JSON-RPC schema provided".into()))?;
+
+        if json_rpc_request.method != "stacks_transactions".into() {
+            return Err(RpcError::InvalidParameter(
+                "Invalid method provided. Only 'stacks_transactions' is currently supported".into(),
+            ));
+        }
+
+        // Create the request body for stacks transactions endpoint schema
+        // by extracting the first parameter from the JSON-RPC request and using it as `tx`.
+        let tx_param = json_rpc_request
+            .params
+            .as_array()
+            .and_then(|arr| arr.first())
+            .unwrap_or(&json_rpc_request.params);
+
+        let tx = if let serde_json::Value::String(s) = tx_param {
+            s.clone()
+        } else {
+            tx_param.to_string()
+        };
+
+        let stacks_transactions_request =
+            serde_json::to_string(&TransactionsRequest { tx }).unwrap();
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(stacks_transactions_request))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Hiro: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<HiroConfig> for HiroProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &HiroConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        HiroProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/src/providers/hiro.rs
+++ b/src/providers/hiro.rs
@@ -60,7 +60,7 @@ impl RpcProvider for HiroProvider {
             .supported_chains
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
-        let uri = format!("{uri}/v2/transactions");
+        let uri = format!("{}/v2/transactions", uri.trim_end_matches('/'));
         let uri = uri.parse::<hyper::Uri>().map_err(|_| {
             RpcError::InvalidParameter("Failed to parse URI for stacks_transactions".into())
         })?;

--- a/src/providers/hiro.rs
+++ b/src/providers/hiro.rs
@@ -88,8 +88,10 @@ impl RpcProvider for HiroProvider {
             tx_param.to_string()
         };
 
-        let stacks_transactions_request =
-            serde_json::to_string(&TransactionsRequest { tx }).unwrap();
+        let stacks_transactions_request = serde_json::to_string(&TransactionsRequest { tx })
+            .map_err(|e| {
+                RpcError::InvalidParameter(format!("Failed to serialize transaction: {}", e))
+            })?;
 
         let hyper_request = hyper::http::Request::builder()
             .method(Method::POST)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -72,6 +72,7 @@ mod bungee;
 mod coinbase;
 mod drpc;
 mod dune;
+mod hiro;
 mod mantle;
 mod meld;
 pub mod mock_alto;
@@ -104,6 +105,7 @@ pub use {
     bungee::BungeeProvider,
     drpc::DrpcProvider,
     dune::DuneProvider,
+    hiro::HiroProvider,
     mantle::MantleProvider,
     meld::MeldProvider,
     monad::MonadProvider,
@@ -685,6 +687,7 @@ pub enum ProviderKind {
     Meld,
     Monad,
     Sui,
+    Hiro,
 }
 
 impl Display for ProviderKind {
@@ -721,6 +724,7 @@ impl Display for ProviderKind {
                 ProviderKind::Meld => "Meld",
                 ProviderKind::Monad => "Monad",
                 ProviderKind::Sui => "Sui",
+                ProviderKind::Hiro => "Hiro",
             }
         )
     }


### PR DESCRIPTION
# Description

This PR is a minimal implementation for Stacks RPC support.
Currently, the only `/v2/transactions` support was added by using the `stacks:1` or `stacks:2147483648` chain ID with the `stacks_transactions` JSON-RPC method.
Example Stacks transaction request within the JSON-RPC schema:

```
{"id":"1", "method":"stacks_transactions", "params":["0x...tx_binary_data"], "jsonrpc":"2.0"}
```

Hiro provider was added as a Stacks RPC provider.

## How Has This Been Tested?

Manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
