### PR TITLE
fix(RPC): disabling Polygon for Pokt provider

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -128,10 +128,12 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         // Polygon
-        (
-            "eip155:137".into(),
-            ("polygon".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
+        // Temprarily disabled due to issues with the provider until the Pokt infra
+        // migration is complete
+        // (
+        //     "eip155:137".into(),
+        //     ("polygon".into(), Weight::new(Priority::Normal).unwrap()),
+        // ),
         (
             "eip155:1101".into(),
             ("polygon-zkevm".into(), Weight::new(Priority::High).unwrap()),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -105,8 +105,9 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     .await;
 
     // Polygon mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
-        .await;
+    // Temporarily disabled due to issues with the provider
+    // check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
+    //     .await;
 
     // Polygon zkevm
     check_if_rpc_is_responding_correctly_for_supported_chain(


### PR DESCRIPTION
# Description

This PR disables the Polygon `eip155:137` support for the Pokt/Grove RPC provider due to a faulty response.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
