### PR TITLE
feat(providers): temporarily disabling Op, Base and Arb in the Pokt provider

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -59,10 +59,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ("gnosis".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Base mainnet
-        (
-            "eip155:8453".into(),
-            ("base".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
+        // TODO: Temporary disabled due to issues with the provider
+        // (
+        //     "eip155:8453".into(),
+        //     ("base".into(), Weight::new(Priority::Normal).unwrap()),
+        // ),
         // Base Sepolia
         (
             "eip155:84532".into(),
@@ -98,10 +99,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         // Optimism
-        (
-            "eip155:10".into(),
-            ("optimism".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
+        // TODO: Temporary disabled due to issues with the provider
+        // (
+        //     "eip155:10".into(),
+        //     ("optimism".into(), Weight::new(Priority::Normal).unwrap()),
+        // ),
         // Optimism Sepolia
         // TODO: Temporary disabled due to issues with the provider
         (
@@ -112,13 +114,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         // Arbitrum
-        (
-            "eip155:42161".into(),
-            (
-                "arbitrum-one".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
+        // TODO: Temporary disabled due to issues with the provider
+        // (
+        //     "eip155:42161".into(),
+        //     (
+        //         "arbitrum-one".into(),
+        //         Weight::new(Priority::Normal).unwrap(),
+        //     ),
+        // ),
         // Arbitrum Sepolia
         (
             "eip155:421614".into(),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -30,13 +30,13 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
         .await;
 
     // Base mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &provider,
-        "eip155:8453",
-        "0x2105",
-    )
-    .await;
+    // check_if_rpc_is_responding_correctly_for_supported_chain(
+    //     ctx,
+    //     &provider,
+    //     "eip155:8453",
+    //     "0x2105",
+    // )
+    // .await;
 
     // Base Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
@@ -74,8 +74,8 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     .await;
 
     // Optimism
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
-        .await;
+    // check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:10", "0xa")
+    //     .await;
 
     // Optimism Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
@@ -87,13 +87,13 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     .await;
 
     // Arbitrum
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &provider,
-        "eip155:42161",
-        "0xa4b1",
-    )
-    .await;
+    // check_if_rpc_is_responding_correctly_for_supported_chain(
+    //     ctx,
+    //     &provider,
+    //     "eip155:42161",
+    //     "0xa4b1",
+    // )
+    // .await;
 
     // Arbitrum Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(


### PR DESCRIPTION
# Description

This PR temporarily disables the Op, Base, Arb for the Pokt provider due to the flakiness.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
