### PR TITLE
fix(providers): disabling CallStatic provider

### DIFF
--- a/src/env/callstatic.rs
+++ b/src/env/callstatic.rs
@@ -40,7 +40,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // BSC mainnet
         (
             "eip155:56".into(),
-            ("bsc".into(), Weight::new(Priority::Normal).unwrap()),
+            ("bsc".into(), Weight::new(Priority::Disabled).unwrap()),
         ),
     ])
 }


### PR DESCRIPTION
# Description

This PR disables the CallStatic provider due to the [flaky responses](https://reown-inc.slack.com/archives/C03SCF66K2T/p1749050663176459).

## How Has This Been Tested?

Not tested.
<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
