### PR TITLE
fix: adding Zan API key to terraform variables

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -105,6 +105,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_MELD_API_KEY", value = var.meld_api_key },
         { name = "RPC_PROXY_PROVIDER_MELD_API_URL", value = var.meld_api_url },
         { name = "RPC_PROXY_PROVIDER_CALLSTATIC_API_KEY", value = var.callstatic_api_key },
+        { name = "RPC_PROXY_PROVIDER_ZAN_API_KEY", value = var.zan_api_key },
 
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_ENDPOINT", value = var.prometheus_endpoint },
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_WORKSPACE_ID", value = var.prometheus_workspace_id },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -278,6 +278,12 @@ variable "callstatic_api_key" {
   sensitive   = true
 }
 
+variable "zan_api_key" {
+  description = "Zan API key"
+  type        = string
+  sensitive   = true
+}
+
 variable "testing_project_id" {
   description = "Project ID used in a testing suite"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -82,6 +82,7 @@ module "ecs" {
   meld_api_key         = var.meld_api_key
   meld_api_url         = var.meld_api_url
   callstatic_api_key   = var.callstatic_api_key
+  zan_api_key          = var.zan_api_key
 
   # Project Registry
   registry_api_endpoint   = var.registry_api_endpoint

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -200,6 +200,12 @@ variable "callstatic_api_key" {
   sensitive   = true
 }
 
+variable "zan_api_key" {
+  description = "Zan API key"
+  type        = string
+  sensitive   = true
+}
+
 #-------------------------------------------------------------------------------
 # Analytics
 


### PR DESCRIPTION
# Description

This PR adds `zan_api_key` terraform variables and passes the API key to the ECS container, which was lost in #1099

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
