### PR TITLE
fix(exchanges): fixing the Solana network name

### DIFF
--- a/src/handlers/wallet/exchanges/coinbase.rs
+++ b/src/handlers/wallet/exchanges/coinbase.rs
@@ -60,12 +60,12 @@ static CAIP19_TO_COINBASE_CRYPTO: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 
 static CHAIN_ID_TO_COINBASE_NETWORK: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     HashMap::from([
-        ("eip155:8453", "base"),                            // Base
-        ("eip155:10", "optimism"),                          // Optimism
-        ("eip155:42161", "arbitrum"),                       // Arbitrum
-        ("eip155:137", "polygon"),                          // Polygon
-        ("eip155:1", "ethereum"),                           // Ethereum
-        ("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "SOL"), // Solana
+        ("eip155:8453", "base"),                               // Base
+        ("eip155:10", "optimism"),                             // Optimism
+        ("eip155:42161", "arbitrum"),                          // Arbitrum
+        ("eip155:137", "polygon"),                             // Polygon
+        ("eip155:1", "ethereum"),                              // Ethereum
+        ("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "solana"), // Solana
     ])
 });
 


### PR DESCRIPTION
# Description

Fixing the Solana network name "SOL" -> "solana".

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
