### PR TITLE
feat(providers): adding Moonbeam RPC chain support and Moonbeam RPC provider

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -21,6 +21,7 @@ Chain name with associated `chainId` query param to use.
 | Polygon Zkevm                                            | eip155:1101          |
 | Wemix Mainnet <sup>[1](#footnote1)</sup>                 | eip155:1111          |
 | Wemix Testnet <sup>[1](#footnote1)</sup>                 | eip155:1112          |
+| Moonbeam GLMR <sup>[1](#footnote1)</sup>                 | eip155:1284          |
 | Unichain Sepolia <sup>[1](#footnote1)</sup>              | eip155:1301          |
 | Sei Network <sup>[1](#footnote1)</sup>                   | eip155:1329          |
 | Morph Holesky <sup>[1](#footnote1)</sup>                 | eip155:2810          |

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -17,9 +17,9 @@ use {
 };
 pub use {
     allnodes::*, arbitrum::*, aurora::*, base::*, binance::*, callstatic::*, drpc::*, dune::*,
-    hiro::*, mantle::*, monad::*, morph::*, near::*, odyssey::*, onerpc::*, pokt::*, publicnode::*,
-    quicknode::*, server::*, solscan::*, sui::*, syndica::*, therpc::*, unichain::*, wemix::*,
-    zan::*, zerion::*, zksync::*, zora::*,
+    hiro::*, mantle::*, monad::*, moonbeam::*, morph::*, near::*, odyssey::*, onerpc::*, pokt::*,
+    publicnode::*, quicknode::*, server::*, solscan::*, sui::*, syndica::*, therpc::*, unichain::*,
+    wemix::*, zan::*, zerion::*, zksync::*, zora::*,
 };
 mod allnodes;
 mod arbitrum;
@@ -32,6 +32,7 @@ mod dune;
 mod hiro;
 mod mantle;
 mod monad;
+mod moonbeam;
 mod morph;
 mod near;
 mod odyssey;

--- a/src/env/moonbeam.rs
+++ b/src/env/moonbeam.rs
@@ -1,0 +1,47 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct MoonbeamConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for MoonbeamConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for MoonbeamConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Moonbeam
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Moonbeam Mainnet
+        (
+            "eip155:1284".into(),
+            (
+                "https://rpc.api.moonbeam.network".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@ use {
     },
     env::{
         AllnodesConfig, ArbitrumConfig, AuroraConfig, BaseConfig, BinanceConfig, CallStaticConfig,
-        DrpcConfig, DuneConfig, HiroConfig, MantleConfig, MonadConfig, MorphConfig, NearConfig,
-        OdysseyConfig, OneRpcConfig, PoktConfig, PublicnodeConfig, QuicknodeConfig, SolScanConfig,
-        SuiConfig, SyndicaConfig, TheRpcConfig, UnichainConfig, WemixConfig, ZKSyncConfig,
-        ZanConfig, ZerionConfig, ZoraConfig,
+        DrpcConfig, DuneConfig, HiroConfig, MantleConfig, MonadConfig, MoonbeamConfig, MorphConfig,
+        NearConfig, OdysseyConfig, OneRpcConfig, PoktConfig, PublicnodeConfig, QuicknodeConfig,
+        SolScanConfig, SuiConfig, SyndicaConfig, TheRpcConfig, UnichainConfig, WemixConfig,
+        ZKSyncConfig, ZanConfig, ZerionConfig, ZoraConfig,
     },
     error::RpcResult,
     http::Request,
@@ -32,11 +32,11 @@ use {
     providers::{
         AllnodesProvider, AllnodesWsProvider, ArbitrumProvider, AuroraProvider, BaseProvider,
         BinanceProvider, CallStaticProvider, DrpcProvider, DuneProvider, HiroProvider,
-        MantleProvider, MonadProvider, MorphProvider, NearProvider, OdysseyProvider,
-        OneRpcProvider, PoktProvider, ProviderRepository, PublicnodeProvider, QuicknodeProvider,
-        SolScanProvider, SuiProvider, SyndicaProvider, SyndicaWsProvider, TheRpcProvider,
-        UnichainProvider, WemixProvider, ZKSyncProvider, ZanProvider, ZerionProvider, ZoraProvider,
-        ZoraWsProvider,
+        MantleProvider, MonadProvider, MoonbeamProvider, MorphProvider, NearProvider,
+        OdysseyProvider, OneRpcProvider, PoktProvider, ProviderRepository, PublicnodeProvider,
+        QuicknodeProvider, SolScanProvider, SuiProvider, SyndicaProvider, SyndicaWsProvider,
+        TheRpcProvider, UnichainProvider, WemixProvider, ZKSyncProvider, ZanProvider,
+        ZerionProvider, ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -544,6 +544,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     ));
     providers
         .add_rpc_provider::<ZanProvider, ZanConfig>(ZanConfig::new(config.zan_api_key.clone()));
+    providers.add_rpc_provider::<MoonbeamProvider, MoonbeamConfig>(MoonbeamConfig::default());
     providers.add_rpc_provider::<OneRpcProvider, OneRpcConfig>(OneRpcConfig::default());
     providers.add_rpc_provider::<TheRpcProvider, TheRpcConfig>(TheRpcConfig::default());
     providers.add_ws_provider::<AllnodesWsProvider, AllnodesConfig>(AllnodesConfig::new(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -78,6 +78,7 @@ mod mantle;
 mod meld;
 pub mod mock_alto;
 mod monad;
+mod moonbeam;
 mod morph;
 mod near;
 mod odyssey;
@@ -114,6 +115,7 @@ pub use {
     mantle::MantleProvider,
     meld::MeldProvider,
     monad::MonadProvider,
+    moonbeam::MoonbeamProvider,
     morph::MorphProvider,
     near::NearProvider,
     odyssey::OdysseyProvider,
@@ -704,6 +706,7 @@ pub enum ProviderKind {
     OneRpc,
     TheRpc,
     Zan,
+    Moonbeam,
 }
 
 impl Display for ProviderKind {
@@ -745,6 +748,7 @@ impl Display for ProviderKind {
                 ProviderKind::OneRpc => "OneRpc",
                 ProviderKind::TheRpc => "TheRpc",
                 ProviderKind::Zan => "Zan",
+                ProviderKind::Moonbeam => "Moonbeam",
             }
         )
     }
@@ -787,6 +791,7 @@ impl ProviderKind {
             "OneRpc" => Some(Self::OneRpc),
             "TheRpc" => Some(Self::TheRpc),
             "Zan" => Some(Self::Zan),
+            "Moonbeam" => Some(Self::Moonbeam),
             _ => None,
         }
     }

--- a/src/providers/moonbeam.rs
+++ b/src/providers/moonbeam.rs
@@ -1,0 +1,99 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MoonbeamConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct MoonbeamProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for MoonbeamProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Moonbeam
+    }
+}
+
+#[async_trait]
+impl RateLimited for MoonbeamProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool
+    where
+        Self: Sized,
+    {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for MoonbeamProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     Moonbeam: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<MoonbeamConfig> for MoonbeamProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &MoonbeamConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        MoonbeamProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -95,6 +95,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'OneRpc', alert_period_free_tier)    { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'TheRpc', alert_period_free_tier)    { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Zan', alert_period_free_tier)       { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Moonbeam', alert_period_free_tier)  { gridPos: pos._4 },
 
   row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Pokt')        { gridPos: pos._4 },
@@ -120,6 +121,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'OneRpc')      { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'TheRpc')      { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Zan')         { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Moonbeam')    { gridPos: pos._4 },
 
   row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Pokt')         { gridPos: pos._4 },
@@ -145,6 +147,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'OneRpc')       { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'TheRpc')       { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Zan')          { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Moonbeam')     { gridPos: pos._4 },
 
   row.new('RPC Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._3 },

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod binance;
 pub(crate) mod drpc;
 pub(crate) mod mantle;
 pub(crate) mod monad;
+pub(crate) mod moonbeam;
 pub(crate) mod morph;
 pub(crate) mod near;
 pub(crate) mod odyssey;

--- a/tests/functional/http/moonbeam.rs
+++ b/tests/functional/http/moonbeam.rs
@@ -1,0 +1,18 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn moonbeam_provider_eip155_1284(ctx: &mut ServerContext) {
+    // Moonbeam GLMR
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Moonbeam,
+        "eip155:1284",
+        "0x504",
+    )
+    .await;
+}


### PR DESCRIPTION
# Description

This PR adds Moonbeam GLMR chain `eip155:1284` support and Moonbeam native RPC endpoint.

## How Has This Been Tested?

New integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
