### PR TITLE
fix: fixing unhandled errors

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -369,7 +369,9 @@ pub fn handle_rpc_error(error: ProviderError) -> Result<(), RpcError> {
         ProviderError::CustomError(e) if e.starts_with(SELF_PROVIDER_ERROR_PREFIX) => {
             let error_detail = e.trim_start_matches(SELF_PROVIDER_ERROR_PREFIX);
             // Exception for no available JSON-RPC providers
-            if error_detail.contains("503 Service Unavailable") {
+            if error_detail.contains("503 Service Unavailable")
+                || error_detail.contains("400 Bad Request")
+            {
                 return Err(RpcError::ProviderError);
             }
             // Proceed with Ok() if the error is related to the contract call error

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -143,7 +143,7 @@ pub struct ZerionTransactionTransfer {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionFungibleInfoAttribute {
-    pub name: String,
+    pub name: Option<String>,
     pub symbol: String,
     pub icon: Option<ZerionTransactionURLItem>,
     pub implementations: Vec<ZerionImplementation>,
@@ -351,7 +351,7 @@ impl HistoryProvider for ZerionProvider {
                         Some(HistoryTransactionTransfer {
                             fungible_info: f.fungible_info.map(|f| {
                                 HistoryTransactionFungibleInfo {
-                                    name: Some(f.name),
+                                    name: f.name,
                                     symbol: Some(f.symbol),
                                     icon: f.icon.map(|f| HistoryTransactionURLItem { url: f.url }),
                                 }
@@ -440,7 +440,11 @@ impl PortfolioProvider for ZerionProvider {
             .into_iter()
             .map(|f| PortfolioPosition {
                 id: f.id,
-                name: f.attributes.fungible_info.name,
+                name: f
+                    .attributes
+                    .fungible_info
+                    .name
+                    .unwrap_or(f.attributes.fungible_info.symbol.clone()),
                 symbol: f.attributes.fungible_info.symbol,
             })
             .collect();
@@ -519,7 +523,11 @@ impl BalanceProvider for ZerionProvider {
 
             // Set the default metadata from the response
             let mut token_metadata = TokenMetadataCacheItem {
-                name: f.attributes.fungible_info.name.clone(),
+                name: f
+                    .attributes
+                    .fungible_info
+                    .name
+                    .unwrap_or(f.attributes.fungible_info.symbol.clone()),
                 symbol: f.attributes.fungible_info.symbol.clone(),
                 icon_url: f
                     .attributes


### PR DESCRIPTION
# Description

This PR fixes unhandled errors that causing `HTTP 500 Internal server` errors:
* Fixes deserialization error in transactions history providers schema, by making `name` field optional;
* Fixes simulation error handling in a Chain Abstraction endpoint for a native token transfer;
* Fixes handling of the `400 Bad Request` identity provider responses.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
