### PR TITLE
feat(rpc): adding Polygon to Quicknode and Sei to the dRPC

### DIFF
--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -171,5 +171,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Sei Mainnet
+        (
+            "eip155:1329".into(),
+            (
+                "https://sei.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/src/env/quicknode.rs
+++ b/src/env/quicknode.rs
@@ -98,6 +98,10 @@ fn extract_supported_chains_and_subdomains(
             ("crimson-spring-wind.ethereum-sepolia", Priority::Normal),
         ),
         (
+            "eip155:137",
+            ("chaotic-wandering-fire.matic", Priority::Low),
+        ),
+        (
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             ("indulgent-thrumming-bush.solana-mainnet", Priority::Minimal),
         ),


### PR DESCRIPTION
# Description

This PR adds a Polygon endpoint to the Quicknode provider with minimal weight and Sei to the dRPC.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
