### PR TITLE
fix(providers): adding a proper handling of connection resets to non-rpc providers

### DIFF
--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -97,7 +97,10 @@ impl DuneProvider {
         }
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url.clone()).await?;
+        let response = self.send_request(url.clone()).await.map_err(|e| {
+            error!("Error sending request to Dune EVM balance API: {:?}", e);
+            RpcError::BalanceProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -128,7 +131,10 @@ impl DuneProvider {
         url.query_pairs_mut().append_pair("metadata", "logo");
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url.clone()).await?;
+        let response = self.send_request(url.clone()).await.map_err(|e| {
+            error!("Error sending request to Dune svm balance API: {:?}", e);
+            RpcError::BalanceProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -186,7 +186,13 @@ impl OnRampMultiProvider for MeldProvider {
             .append_pair("categories", DEFAULT_CATEGORY);
 
         let latency_start = SystemTime::now();
-        let response = self.send_get_request(url).await?;
+        let response = self.send_get_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to Meld providers properties: {:?}",
+                e
+            );
+            RpcError::OnRampProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -243,7 +249,11 @@ impl OnRampMultiProvider for MeldProvider {
                     session_data: params.session_data,
                 },
             )
-            .await?;
+            .await
+            .map_err(|e| {
+                error!("Error sending request to Meld get widget: {:?}", e);
+                RpcError::OnRampProviderError
+            })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -291,7 +301,10 @@ impl OnRampMultiProvider for MeldProvider {
         let url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
 
         let latency_start = SystemTime::now();
-        let response = self.send_post_request(url, &params).await?;
+        let response = self.send_post_request(url, &params).await.map_err(|e| {
+            error!("Error sending request to Meld get quotes: {:?}", e);
+            RpcError::OnRampProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -82,7 +82,13 @@ impl OneInchProvider {
             .append_pair("currency", &currency.to_string());
 
         let latency_start = SystemTime::now();
-        let price_response = self.send_request(url).await?;
+        let price_response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for fungible price: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             price_response.status().into(),
@@ -145,7 +151,13 @@ impl OneInchProvider {
         .map_err(|_| RpcError::ConversionParseURLError)?;
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for token info: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -287,7 +299,13 @@ impl ConversionProvider for OneInchProvider {
         let url = Url::parse(&base).map_err(|_| RpcError::ConversionParseURLError)?;
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for token list: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -402,7 +420,13 @@ impl ConversionProvider for OneInchProvider {
         }
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for convertion quote: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -482,7 +506,13 @@ impl ConversionProvider for OneInchProvider {
         }
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for building approval tx: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -584,7 +614,13 @@ impl ConversionProvider for OneInchProvider {
         }
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for building convertion tx: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -659,7 +695,13 @@ impl ConversionProvider for OneInchProvider {
         let url = Url::parse(&base).map_err(|_| RpcError::ConversionParseURLError)?;
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for gas price: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -729,7 +771,13 @@ impl ConversionProvider for OneInchProvider {
             .append_pair("walletAddress", &wallet_address.to_lowercase());
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error sending request to 1inch provider for allowance: {:?}",
+                e
+            );
+            RpcError::ConversionProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -276,8 +276,12 @@ impl HistoryProvider for ZerionProvider {
         }
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await.tap_err(|e| {
-            error!("Error on request to zerion history endpoint with {}", e);
+        let response = self.send_request(url).await.map_err(|e| {
+            error!(
+                "Error on request to zerion transactions history endpoint with {}",
+                e
+            );
+            RpcError::TransactionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
@@ -414,7 +418,10 @@ impl PortfolioProvider for ZerionProvider {
             .append_pair("currency", &params.currency.unwrap_or("usd".to_string()));
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url).await?;
+        let response = self.send_request(url).await.map_err(|e| {
+            error!("Error on request to zerion portfolio endpoint with {}", e);
+            RpcError::PortfolioProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),
@@ -485,7 +492,13 @@ impl BalanceProvider for ZerionProvider {
         }
 
         let latency_start = SystemTime::now();
-        let response = self.send_request(url.clone()).await?;
+        let response = self.send_request(url.clone()).await.map_err(|e| {
+            error!(
+                "Error on request to zerion transactions history endpoint with {}",
+                e
+            );
+            RpcError::BalanceProviderError
+        })?;
         metrics.add_latency_and_status_code_for_provider(
             self.provider_kind,
             response.status().into(),


### PR DESCRIPTION
# Description

This PR adds proper handling of connection resets to non-RPC providers' endpoints for cases where the remote peer closes the connection. 
In this case, we should respond with the `HTTP 503 Temporarily unavailable` instead of the `HTTP 500`s.

## How Has This Been Tested?

Not tested, but the fix is based on the current HTTP 500 errors.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
