### PR TITLE
feat(onRamp): adding country properties defaults

### DIFF
--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -135,6 +135,20 @@ describe('OnRamp', () => {
     expect(resp.data[0].defaultAmount === null || typeof resp.data[0].defaultAmount === 'number').toBeTruthy()
     expect(typeof resp.data[0].minimumAmount).toBe('number')
     expect(typeof resp.data[0].maximumAmount).toBe('number')
+
+    // Check for `countries-defaults` type
+    type = 'countries-defaults'
+    const defaultCountry = 'US'
+    resp = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}` +
+      `&countries=${defaultCountry}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(resp.data[0].countryCode).toBe(defaultCountry)
+    expect(resp.data[0].defaultCurrencyCode).toBe('USD')
   })
 
   it('get multi provider quotes', async () => {

--- a/src/handlers/onramp/properties.rs
+++ b/src/handlers/onramp/properties.rs
@@ -28,6 +28,7 @@ pub enum PropertyType {
     FiatCurrencies,
     PaymentMethods,
     FiatPurchasesLimits,
+    CountriesDefaults,
 }
 
 pub async fn handler(

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -177,6 +177,10 @@ impl OnRampMultiProvider for MeldProvider {
                 "{}/service-providers/limits/fiat-currency-purchases",
                 self.api_base_url
             ),
+            PropertyType::CountriesDefaults => format!(
+                "{}/service-providers/properties/defaults/by-country",
+                self.api_base_url
+            ),
         };
         let mut url = Url::parse(&base_url).map_err(|_| RpcError::OnRampParseURLError)?;
         if let Some(countries) = params.countries {


### PR DESCRIPTION
# Description

This PR exposes default values by country properties from the Meld API by extending the current properties endpoint and introducing a new `countries-defaults` type.

## How Has This Been Tested?

A new integration test was created.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
