### PR TITLE
feat(RPC): adding Rootstock mainnet support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -10,6 +10,7 @@ Chain name with associated `chainId` query param to use.
 |----------------------------------------------------------|----------------------|
 | Ethereum                                                 | eip155:1             |
 | Optimism                                                 | eip155:10            |
+| Rootstock Mainnet <sup>[1](#footnote1)</sup>             | eip155:30            |
 | Binance Smart Chain                                      | eip155:56            |
 | Binance Smart Chain Testnet <sup>[1](#footnote1)</sup>   | eip155:97            |
 | Gnosis Chain                                             | eip155:100           |

--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -171,6 +171,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Rootstock Mainnet
+        (
+            "eip155:30".into(),
+            (
+                "https://rootstock.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Sei Mainnet
         (
             "eip155:1329".into(),


### PR DESCRIPTION
# Description

This PR adds Rootstock mainnet `eip155:30` support for RPC calls.

## How Has This Been Tested?

Current tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
