### PR TITLE
feat(Meld): getting quotes for all possible payment types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12314,9 +12314,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "5e1b5f4", f
 
 # Async
 async-trait = "0.1.82"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.45", features = ["full"] }
 
 # Web
 hyper = "0.14"

--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -169,5 +169,10 @@ describe('OnRamp', () => {
     expect(typeof resp.data[0].destinationAmount).toBe('number')
     expect(resp.data[0].destinationCurrencyCode).toBe('BTC')
     expect(typeof resp.data[0].sourceAmount).toBe('number')
+    
+    // Check that we have more than one different paymentMethodType
+    // This verifies that the parallel requests for different payment types are working
+    const paymentMethodTypes = Array.from(new Set(resp.data.map((quote: any) => quote.paymentMethodType)));
+    expect(paymentMethodTypes.length).toBeGreaterThan(1);
   })
 })

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,9 @@ pub enum RpcError {
     #[error("Invalid conversion parameter with code: {0} and description: {1}")]
     ConversionInvalidParameterWithCode(String, String),
 
+    #[error("Conversion provider internal error: {0}")]
+    ConversionProviderInternalError(String),
+
     // Profile names errors
     #[error("Name is already registered: {0}")]
     NameAlreadyRegistered(String),

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -12,9 +12,11 @@ use {
         Metrics,
     },
     async_trait::async_trait,
+    futures_util::future::join_all,
     reqwest::StatusCode,
     serde::{Deserialize, Serialize},
     std::{sync::Arc, time::SystemTime},
+    tokio::task,
     tracing::log::error,
     url::Url,
 };
@@ -86,6 +88,14 @@ pub struct MeldQuotesResponse {
 pub struct MeldErrorResponse {
     pub code: String,
     pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentMethod {
+    pub name: String,
+    pub payment_method: String,
+    pub payment_type: String,
 }
 
 #[async_trait]
@@ -304,55 +314,122 @@ impl OnRampMultiProvider for MeldProvider {
         let base = format!("{}/payments/crypto/quote", self.api_base_url);
         let url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
 
-        let latency_start = SystemTime::now();
-        let response = self.send_post_request(url, &params).await.map_err(|e| {
-            error!("Error sending request to Meld get quotes: {:?}", e);
-            RpcError::OnRampProviderError
-        })?;
-        metrics.add_latency_and_status_code_for_provider(
-            self.provider_kind,
-            response.status().into(),
-            latency_start,
-            None,
-            Some("onramp_multi_quotes".to_string()),
-        );
-
-        if !response.status().is_success() {
-            // Passing through error description for the error context
-            // if user parameter is invalid (got 400 status code from the provider)
-            if matches!(
-                response.status(),
-                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
-            ) {
-                let response_error = match response.json::<MeldErrorResponse>().await {
-                    Ok(response_error) => response_error,
-                    Err(e) => {
-                        error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {:?}",
-                            e
-                        );
-                        // Respond to the client with a generic error message and HTTP 400 anyway
-                        MeldErrorResponse {
-                            code: "BAD_REQUEST".to_string(),
-                            message: "Invalid parameter".to_string(),
-                        }
-                    }
-                };
-                return Err(RpcError::ConversionInvalidParameterWithCode(
-                    response_error.code,
-                    response_error.message,
-                ));
+        // Get all payment-types based on the country if not payment type was provided.
+        // Country is optional, but we are providing it anyways and it's required
+        // to get the payment types we will use the fallback to the US as a default.
+        let mut payment_types: Vec<String> = Vec::new();
+        if let Some(payment_type) = &params.payment_method_type {
+            payment_types.push(payment_type.to_string());
+        } else {
+            let country = params.clone().country_code.unwrap_or("US".to_string());
+            let providers_properties_response = self
+                .get_providers_properties(
+                    ProvidersPropertiesQueryParams {
+                        project_id: params.project_id.clone(),
+                        r#type: PropertyType::PaymentMethods,
+                        countries: Some(country.to_string()),
+                    },
+                    metrics.clone(),
+                )
+                .await?;
+            let payment_methods: Vec<PaymentMethod> =
+                serde_json::from_value(providers_properties_response)?;
+            for payment_method in payment_methods {
+                payment_types.push(payment_method.payment_type);
             }
+        };
 
-            error!(
-                "Error on Meld get quotes. Status is not OK: {:?}",
-                response.status(),
-            );
-            return Err(RpcError::OnRampProviderError);
+        // Get quotes for each payment type in parallel and aggregate results
+        // otherwise only the card payment is provided in quotes if there are no
+        // payment type was provided to the request, but we want to get all
+        // available quotes for all payment types.
+        let mut handles = Vec::new();
+
+        for payment_type in payment_types {
+            let mut params = params.clone();
+            params.payment_method_type = Some(payment_type);
+            let url = url.clone();
+            let metrics = metrics.clone();
+            let http_client = self.http_client.clone();
+            let api_version = API_VERSION.to_string();
+            let api_key = self.api_key.clone();
+
+            let handle = task::spawn(async move {
+                let latency_start = SystemTime::now();
+                let response = http_client
+                    .post(url)
+                    .json(&params)
+                    .header("Meld-Version", api_version)
+                    .header("Authorization", format!("BASIC {}", api_key))
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        error!("Error sending request to Meld get quotes: {:?}", e);
+                        RpcError::OnRampProviderError
+                    })?;
+                metrics.add_latency_and_status_code_for_provider(
+                    ProviderKind::Meld,
+                    response.status().into(),
+                    latency_start,
+                    None,
+                    Some("onramp_multi_quotes".to_string()),
+                );
+
+                if !response.status().is_success() {
+                    // Passing through error description for the error context
+                    // if user parameter is invalid (got 400 status code from the provider)
+                    if matches!(
+                        response.status(),
+                        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+                    ) {
+                        let response_error = match response.json::<MeldErrorResponse>().await {
+                            Ok(response_error) => response_error,
+                            Err(e) => {
+                                error!(
+                                    "Error parsing Meld HTTP 400 Bad Request error response {:?}",
+                                    e
+                                );
+                                // Respond to the client with a generic error message and HTTP 400 anyway
+                                MeldErrorResponse {
+                                    code: "BAD_REQUEST".to_string(),
+                                    message: "Invalid parameter".to_string(),
+                                }
+                            }
+                        };
+                        return Err(RpcError::ConversionInvalidParameterWithCode(
+                            response_error.code,
+                            response_error.message,
+                        ));
+                    }
+
+                    error!(
+                        "Error on Meld get quotes. Status is not OK: {:?}",
+                        response.status(),
+                    );
+                    return Err(RpcError::OnRampProviderError);
+                }
+
+                let response_quotes = response.json::<MeldQuotesResponse>().await?;
+                Ok(response_quotes.quotes)
+            });
+
+            handles.push(handle);
         }
 
-        let response_quotes = response.json::<MeldQuotesResponse>().await?;
+        let mut quotes = Vec::new();
+        let results = join_all(handles).await;
 
-        Ok(response_quotes.quotes)
+        for result in results {
+            match result {
+                Ok(Ok(quotes_response)) => quotes.extend(quotes_response),
+                Ok(Err(e)) => return Err(e),
+                Err(e) => {
+                    error!("Meld parallel quotes tasks join error: {:?}", e);
+                    return Err(RpcError::OnRampProviderError);
+                }
+            }
+        }
+
+        Ok(quotes)
     }
 }

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -410,7 +410,7 @@ impl OnRampMultiProvider for MeldProvider {
         // We are not expecting more than 20 payment types, we should stop
         // if we have more than 20 payment types.
         if payment_types.len() > 20 {
-            return Err(RpcError::ConversionInvalidParameter(
+            return Err(RpcError::ConversionProviderInternalError(
                 "Too many payment types".to_string(),
             ));
         }
@@ -446,7 +446,7 @@ impl OnRampMultiProvider for MeldProvider {
                 Ok(Ok(quotes_response)) => quotes.extend(quotes_response),
                 Ok(Err(e)) => return Err(e),
                 Err(e) => {
-                    error!("Meld parallel quotes tasks join error: {:?}", e);
+                    error!("Error on getting Meld quotes in parallel: {:?}", e);
                     return Err(RpcError::OnRampProviderError);
                 }
             }

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -12,11 +12,10 @@ use {
         Metrics,
     },
     async_trait::async_trait,
-    futures_util::future::join_all,
     reqwest::StatusCode,
     serde::{Deserialize, Serialize},
     std::{sync::Arc, time::SystemTime},
-    tokio::task,
+    tokio::task::JoinSet,
     tracing::log::error,
     url::Url,
 };
@@ -67,6 +66,75 @@ impl MeldProvider {
             .header("Authorization", format!("BASIC {}", self.api_key))
             .send()
             .await
+    }
+
+    /// Fetches quotes for a single payment type
+    async fn fetch_quotes_for_payment_type(
+        payment_type: String,
+        mut params: MultiQuotesQueryParams,
+        url: Url,
+        metrics: Arc<Metrics>,
+        http_client: reqwest::Client,
+        api_key: String,
+    ) -> RpcResult<Vec<QuotesResponse>> {
+        params.payment_method_type = Some(payment_type);
+
+        let latency_start = SystemTime::now();
+        let response = http_client
+            .post(url)
+            .json(&params)
+            .header("Meld-Version", API_VERSION)
+            .header("Authorization", format!("BASIC {}", api_key))
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Error sending request to Meld get quotes: {:?}", e);
+                RpcError::OnRampProviderError
+            })?;
+        metrics.add_latency_and_status_code_for_provider(
+            ProviderKind::Meld,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("onramp_multi_quotes".to_string()),
+        );
+
+        if !response.status().is_success() {
+            // Passing through error description for the error context
+            // if user parameter is invalid (got 400 status code from the provider)
+            if matches!(
+                response.status(),
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+            ) {
+                let response_error = match response.json::<MeldErrorResponse>().await {
+                    Ok(response_error) => response_error,
+                    Err(e) => {
+                        error!(
+                            "Error parsing Meld HTTP 400 Bad Request error response {:?}",
+                            e
+                        );
+                        // Respond to the client with a generic error message and HTTP 400 anyway
+                        MeldErrorResponse {
+                            code: "BAD_REQUEST".to_string(),
+                            message: "Invalid parameter".to_string(),
+                        }
+                    }
+                };
+                return Err(RpcError::ConversionInvalidParameterWithCode(
+                    response_error.code,
+                    response_error.message,
+                ));
+            }
+
+            error!(
+                "Error on Meld get quotes. Status is not OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::OnRampProviderError);
+        }
+
+        let response_quotes = response.json::<MeldQuotesResponse>().await?;
+        Ok(response_quotes.quotes)
     }
 }
 
@@ -339,87 +407,41 @@ impl OnRampMultiProvider for MeldProvider {
             }
         };
 
+        // We are not expecting more than 20 payment types, we should stop
+        // if we have more than 20 payment types.
+        if payment_types.len() > 20 {
+            return Err(RpcError::ConversionInvalidParameter(
+                "Too many payment types".to_string(),
+            ));
+        }
+
         // Get quotes for each payment type in parallel and aggregate results
         // otherwise only the card payment is provided in quotes if there are no
         // payment type was provided to the request, but we want to get all
         // available quotes for all payment types.
-        let mut handles = Vec::new();
-
+        let mut join_set = JoinSet::new();
         for payment_type in payment_types {
-            let mut params = params.clone();
-            params.payment_method_type = Some(payment_type);
+            let params = params.clone();
             let url = url.clone();
             let metrics = metrics.clone();
             let http_client = self.http_client.clone();
-            let api_version = API_VERSION.to_string();
             let api_key = self.api_key.clone();
 
-            let handle = task::spawn(async move {
-                let latency_start = SystemTime::now();
-                let response = http_client
-                    .post(url)
-                    .json(&params)
-                    .header("Meld-Version", api_version)
-                    .header("Authorization", format!("BASIC {}", api_key))
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        error!("Error sending request to Meld get quotes: {:?}", e);
-                        RpcError::OnRampProviderError
-                    })?;
-                metrics.add_latency_and_status_code_for_provider(
-                    ProviderKind::Meld,
-                    response.status().into(),
-                    latency_start,
-                    None,
-                    Some("onramp_multi_quotes".to_string()),
-                );
-
-                if !response.status().is_success() {
-                    // Passing through error description for the error context
-                    // if user parameter is invalid (got 400 status code from the provider)
-                    if matches!(
-                        response.status(),
-                        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
-                    ) {
-                        let response_error = match response.json::<MeldErrorResponse>().await {
-                            Ok(response_error) => response_error,
-                            Err(e) => {
-                                error!(
-                                    "Error parsing Meld HTTP 400 Bad Request error response {:?}",
-                                    e
-                                );
-                                // Respond to the client with a generic error message and HTTP 400 anyway
-                                MeldErrorResponse {
-                                    code: "BAD_REQUEST".to_string(),
-                                    message: "Invalid parameter".to_string(),
-                                }
-                            }
-                        };
-                        return Err(RpcError::ConversionInvalidParameterWithCode(
-                            response_error.code,
-                            response_error.message,
-                        ));
-                    }
-
-                    error!(
-                        "Error on Meld get quotes. Status is not OK: {:?}",
-                        response.status(),
-                    );
-                    return Err(RpcError::OnRampProviderError);
-                }
-
-                let response_quotes = response.json::<MeldQuotesResponse>().await?;
-                Ok(response_quotes.quotes)
+            join_set.spawn(async move {
+                Self::fetch_quotes_for_payment_type(
+                    payment_type,
+                    params,
+                    url,
+                    metrics,
+                    http_client,
+                    api_key,
+                )
+                .await
             });
-
-            handles.push(handle);
         }
 
         let mut quotes = Vec::new();
-        let results = join_all(handles).await;
-
-        for result in results {
+        while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(Ok(quotes_response)) => quotes.extend(quotes_response),
                 Ok(Err(e)) => return Err(e),


### PR DESCRIPTION
# Description

This PR adds support for obtaining Meld quotes for all possible payment types.
By default, the Meld quotes response has quotes only for the bank card payment type if no payment type was provided.
We want to get all available quotes for all available payment types by getting all available payment types for the country, and then querying in parallel the Meld quotes endpoint for each payment method. 
The aggregated response quotes will be returned.

## How Has This Been Tested?

The quotes endpoint integration test was updated to check that the quotes response has multiple payment types.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
