### PR TITLE
fix(Meld): adding proper handling of the no valid quotes error code

### DIFF
--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -454,7 +454,7 @@ impl OnRampMultiProvider for MeldProvider {
                 Ok(Ok(quotes_response)) => quotes.extend(quotes_response),
                 Ok(Err(e)) => {
                     // Check if this is an EMPTY_QUOTES_ERROR_CODE error, if so continue to next payment type
-                    // because the list can be fullfilled with quotes for other payment types.
+                    // because the list can be fulfilled with quotes for other payment types.
                     if let RpcError::ConversionInvalidParameterWithCode(code, _) = &e {
                         if code == EMPTY_QUOTES_ERROR_CODE {
                             error!("No valid quotes for payment type, continuing to next");


### PR DESCRIPTION
# Description

This PR adds proper handling of the `NO_VALID_QUOTES` error code when iterating on payment types. That will fix the iteration break in case one of the payment types doesn't have quotes.

## How Has This Been Tested?

Current staging integration test catching this issue.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
