### PR TITLE
feat(RPC): increasing Polygon Amoy and Avalanche Fuji providers

### DIFF
--- a/src/env/blast.rs
+++ b/src/env/blast.rs
@@ -53,5 +53,18 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Polygon Mainnet
+        (
+            "eip155:137".into(),
+            (
+                "polygon-mainnet".into(),
+                Weight::new(Priority::Low).unwrap(),
+            ),
+        ),
+        // Polygon Amoy
+        (
+            "eip155:80002".into(),
+            ("polygon-amoy".into(), Weight::new(Priority::Low).unwrap()),
+        ),
     ])
 }

--- a/src/env/drpc.rs
+++ b/src/env/drpc.rs
@@ -179,5 +179,21 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Polygon Amoy
+        (
+            "eip155:80002".into(),
+            (
+                "https://polygon-amoy.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Avalanche Fuji
+        (
+            "eip155:43113".into(),
+            (
+                "https://avalanche-fuji.drpc.org".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }


### PR DESCRIPTION
# Description

This PR increases providers for the Polygon Amoy `eip155:80002` and Avalanche Fuji `eip155:43113` chains due to the limited availability of current providers.

## How Has This Been Tested?

Current integration tests and canary tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
