### PR TITLE
fix(Meld): return quotes even if there is a bad request error

### DIFF
--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -23,7 +23,6 @@ use {
 const API_VERSION: &str = "2023-12-19";
 const DEFAULT_CATEGORY: &str = "CRYPTO_ONRAMP";
 const DEFAULT_SESSION_TYPE: &str = "BUY";
-const EMPTY_QUOTES_ERROR_CODE: &str = "NO_VALID_QUOTES";
 
 #[derive(Debug)]
 pub struct MeldProvider {
@@ -449,25 +448,26 @@ impl OnRampMultiProvider for MeldProvider {
         }
 
         let mut quotes = Vec::new();
+        let mut first_error: Option<RpcError> = None;
+
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(Ok(quotes_response)) => quotes.extend(quotes_response),
                 Ok(Err(e)) => {
-                    // Check if this is an EMPTY_QUOTES_ERROR_CODE error, if so continue to next payment type
-                    // because the list can be fulfilled with quotes for other payment types.
-                    if let RpcError::ConversionInvalidParameterWithCode(code, _) = &e {
-                        if code == EMPTY_QUOTES_ERROR_CODE {
-                            error!("No valid quotes for payment type, continuing to next");
-                            continue;
-                        }
+                    if first_error.is_none() {
+                        first_error = Some(e);
                     }
-                    return Err(e);
                 }
                 Err(e) => {
                     error!("Error on getting Meld quotes in parallel: {:?}", e);
                     return Err(RpcError::OnRampProviderError);
                 }
             }
+        }
+
+        // If we have no quotes and there were errors, return the first error
+        if quotes.is_empty() && first_error.is_some() {
+            return Err(first_error.unwrap());
         }
 
         Ok(quotes)


### PR DESCRIPTION
# Description

This PR changes how to handle the error response when iterating on payment types.
We should proceed with quotes responses even if we have `HTTP 400 Bad request` response when we have quotes, because there are conditions where the Meld respond with `HTTP 400 Bad request` with the error message of the low amount, but there can be some quotes with this amount for different payment type. 

To return as many quotes as possible for different amounts (for small as well), we should return an error only if there are no quotes returned for all payment methods. In this case, the client should modify the request to get quotes, and we return the first error. 

We can't return multiple errors because of the API schema, so we will stick with the first error.
In case of multiple errors, the user still needs to resolve them all, but one by one in this case.

## How Has This Been Tested?

Current tests and manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
