### PR TITLE
feat(RPC): allowing WSS RPC connection to the standard `/v1` RPC endpoint

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -110,6 +110,9 @@ pub enum RpcError {
     #[error(transparent)]
     AxumTungstenite(Box<axum_tungstenite::Error>),
 
+    #[error("Only WebSocket connections are supported for GET method on this endpoint")]
+    WebSocketConnectionExpected,
+
     #[error(transparent)]
     RateLimited(#[from] wc::rate_limit::RateLimitExceeded),
 
@@ -372,6 +375,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response(
                     "scheme".to_string(),
                     "Invalid scheme used. Try http(s):// or ws(s)://".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::WebSocketConnectionExpected => (
+                StatusCode::UPGRADE_REQUIRED,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Only WebSocket connections are supported for GET method on this endpoint".to_string(),
                 )),
             )
                 .into_response(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,10 +240,13 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .propagate_x_request_id();
 
     let app = Router::new()
+        // HTTP RPC proxy (POST method only) with the trailing slash alias
         .route("/v1", post(handlers::proxy::handler))
         .route("/v1/", post(handlers::proxy::handler))
-        .route("/v1/supported-chains", get(handlers::supported_chains::handler))
+        // WebSocket RPC proxy (GET method only) with the /ws alias
+        .route("/v1", get(handlers::ws_proxy::handler))
         .route("/ws", get(handlers::ws_proxy::handler))
+        .route("/v1/supported-chains", get(handlers::supported_chains::handler))
         .route("/v1/identity/:address", get(handlers::identity::handler))
         .route(
             "/v1/account/:address/identity",


### PR DESCRIPTION
# Description

This PR allows WSS RPC connections to the standard HTTP RPC `/v1` endpoint. This is required for some SDKs that don't have the ability to change the endpoint for the WSS connection upgrade, like [solana/web3.js](https://solana-foundation.github.io/solana-web3.js/classes/Connection.html#constructor), and are forced to use the same endpoint for the HTTP RPC and WSS RPC connections.
Since the WSS connections are the `GET` method only and HTTP RPC are the `POST` method only, we can route based on this to the different handlers (http, wss).
This PR also adds an appropriate error message if there is a non-WSS connection to the endpoint with the `GET` method.

* Due to the Rust version update, there are formatting and `format!` clippy errors fixes included in this PR as the last two commits.

## How Has This Been Tested?

Current HTTP and WSS tests shouldn't fail.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
