### PR TITLE
feat(Hiro): adding transfer fee endpoint support

### DIFF
--- a/src/providers/hiro.rs
+++ b/src/providers/hiro.rs
@@ -249,7 +249,8 @@ impl HiroProvider {
             }
         }
 
-        let mut response = (status, body).into_response();
+        let wrapped_body = self.wrap_response_in_result(&body)?;
+        let mut response = (status, wrapped_body).into_response();
         response
             .headers_mut()
             .insert("Content-Type", HeaderValue::from_static("application/json"));

--- a/src/providers/hiro.rs
+++ b/src/providers/hiro.rs
@@ -233,7 +233,6 @@ impl HiroProvider {
         let hyper_request = hyper::http::Request::builder()
             .method(Method::GET)
             .uri(uri)
-            .header("Content-Type", "application/json")
             .body(hyper::body::Body::empty())?;
 
         let response = self.client.request(hyper_request).await?;


### PR DESCRIPTION
# Description

Add `stacks_transfer_fees` rpc method that queries `/v2/fee/transfer` endpoint on Stack's API

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
