### PR TITLE
fix: fixing clippy errors due to the new Rust version

### DIFF
--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -57,7 +57,7 @@ impl IdentityLookupInfo {
             timestamp: wc::analytics::time::now(),
 
             address_hash: sha256::digest(address.as_ref()),
-            address: format!("{:#x}", address),
+            address: format!("{address:#x}"),
             name_present,
             avatar_present,
             source: source.as_str().to_string(),

--- a/src/database/utils.rs
+++ b/src/database/utils.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 pub fn hashmap_to_hstore(hashmap: &HashMap<String, String>) -> String {
     hashmap
         .iter()
-        .map(|(key, value)| format!("\"{}\" => \"{}\"", key, value))
+        .map(|(key, value)| format!("\"{key}\" => \"{value}\""))
         .collect::<Vec<_>>()
         .join(", ")
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -315,7 +315,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("Crypto utils error: {}", e),
+                    format!("Crypto utils error: {e}"),
                 )),
             )
                 .into_response(),
@@ -363,7 +363,7 @@ impl IntoResponse for RpcError {
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("We failed to reach the identity provider with an error: {}", e),
+                    format!("We failed to reach the identity provider with an error: {e}"),
                 )),
             )
                 .into_response(),
@@ -411,7 +411,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("Invalid parameter: {}", e),
+                    format!("Invalid parameter: {e}"),
                 )),
             )
                 .into_response(),
@@ -421,7 +421,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "name".to_string(),
-                    format!("Invalid name format: {}", e),
+                    format!("Invalid name format: {e}"),
                 )),
             )
                 .into_response(),
@@ -429,7 +429,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "name".to_string(),
-                    format!("Invalid name length: {}", e),
+                    format!("Invalid name length: {e}"),
                 )),
             )
                 .into_response(),
@@ -437,7 +437,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "name".to_string(),
-                    format!("Name is not in the allowed zones: {}", e),
+                    format!("Name is not in the allowed zones: {e}"),
                 )),
             )
                 .into_response(),
@@ -445,7 +445,7 @@ impl IntoResponse for RpcError {
                     StatusCode::BAD_REQUEST,
                     Json(new_error_response(
                         "".to_string(),
-                        format!("Conversion parameter error: {}", e),
+                        format!("Conversion parameter error: {e}"),
                     )),
                 )
                     .into_response(),
@@ -453,7 +453,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response_with_code(
                     code.to_string(),
-                    format!("Conversion parameter error: {}", message),
+                    format!("Conversion parameter error: {message}"),
                 )),
             )
                 .into_response(),
@@ -461,7 +461,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "coin_type".to_string(),
-                    format!("Unsupported coin type: {}", e),
+                    format!("Unsupported coin type: {e}"),
                 )),
             )
                 .into_response(),
@@ -469,7 +469,7 @@ impl IntoResponse for RpcError {
                     StatusCode::BAD_REQUEST,
                     Json(new_error_response(
                         "address".to_string(),
-                        format!("Unsupported namespace: {}", e),
+                        format!("Unsupported namespace: {e}"),
                     )),
                 )
                     .into_response(),
@@ -485,7 +485,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "name".to_string(),
-                    format!("Name is already registered: {}", e),
+                    format!("Name is already registered: {e}"),
                 )),
             )
                 .into_response(),
@@ -493,7 +493,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "name".to_string(),
-                    format!("Name is not registered: {}", e),
+                    format!("Name is not registered: {e}"),
                 )),
             )
                 .into_response(),
@@ -501,7 +501,7 @@ impl IntoResponse for RpcError {
                 StatusCode::NOT_FOUND,
                 Json(new_error_response(
                     "name".to_string(),
-                    format!("Name is not found in the database: {}", e),
+                    format!("Name is not found in the database: {e}"),
                 )),
             )
                 .into_response(),
@@ -517,7 +517,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "timestamp".to_string(),
-                    format!("Signature UNIXTIME timestamp is too old: {}", e),
+                    format!("Signature UNIXTIME timestamp is too old: {e}"),
                 )),
             )
                 .into_response(),
@@ -525,7 +525,7 @@ impl IntoResponse for RpcError {
                 StatusCode::UNAUTHORIZED,
                 Json(new_error_response(
                     "signature".to_string(),
-                    format!("Signature validation error: {}", e),
+                    format!("Signature validation error: {e}"),
                 )),
             )
                 .into_response(),
@@ -541,7 +541,7 @@ impl IntoResponse for RpcError {
                 StatusCode::UNPROCESSABLE_ENTITY,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("Deserialization error: {}", e),
+                    format!("Deserialization error: {e}"),
                 )),
             )
                 .into_response(),
@@ -549,22 +549,20 @@ impl IntoResponse for RpcError {
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(new_error_response(
                     "rate_limit".to_string(),
-                    format!("Rate limited: {}", e),
+                    format!("Rate limited: {e}"),
                 )),
             )
                 .into_response(),
             Self::PermissionNotFound(address, pci) => {
                 // TODO: Remove this debug log
                 print!(
-                    "Permission not found with PCI: {:?} and address: {:?}",
-                    pci,
-                    address
+                    "Permission not found with PCI: {pci:?} and address: {address:?}"
                 );
                 (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "pci".to_string(),
-                    format!("Permission for PCI is not found: {}", pci),
+                    format!("Permission for PCI is not found: {pci}"),
                 )),
             )
                 .into_response()
@@ -573,7 +571,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "pci".to_string(),
-                    format!("Permission is revoked: {}", pci),
+                    format!("Permission is revoked: {pci}"),
                 )),
             )
                 .into_response(),
@@ -581,7 +579,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "pci".to_string(),
-                    format!("Permission is expired: {}", pci),
+                    format!("Permission is expired: {pci}"),
                 )),
             )
                 .into_response(),
@@ -589,7 +587,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("Wrong Base64 format: {}", e),
+                    format!("Wrong Base64 format: {e}"),
                 )),
             )
                 .into_response(),
@@ -597,7 +595,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "key".to_string(),
-                    format!("Invalid key format: {}", e),
+                    format!("Invalid key format: {e}"),
                 )),
             )
                 .into_response(),
@@ -605,7 +603,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "signature".to_string(),
-                    format!("Invalid signature format: {}", e),
+                    format!("Invalid signature format: {e}"),
                 )),
             )
                 .into_response(),
@@ -621,7 +619,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "calldata".to_string(),
-                    format!("ABI signature decoding error: {}", e),
+                    format!("ABI signature decoding error: {e}"),
                 )),
             )
                 .into_response(),
@@ -661,7 +659,7 @@ impl IntoResponse for RpcError {
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("Fungibles price provider is temporarily unavailable: {}", e),
+                    format!("Fungibles price provider is temporarily unavailable: {e}"),
                 )),
             )
                 .into_response(),
@@ -685,7 +683,7 @@ impl IntoResponse for RpcError {
                     StatusCode::UNAUTHORIZED,
                     Json(new_error_response(
                         "".to_string(),
-                        format!("Cosigner permission denied: {}", e),
+                        format!("Cosigner permission denied: {e}"),
                     )),
                 )
                     .into_response(),
@@ -693,7 +691,7 @@ impl IntoResponse for RpcError {
                 StatusCode::UNAUTHORIZED,
                 Json(new_error_response(
                     "".to_string(),
-                    format!("Unsupported permission in CoSigner: {}", e),
+                    format!("Unsupported permission in CoSigner: {e}"),
                 )),
             )
                 .into_response(),
@@ -701,7 +699,7 @@ impl IntoResponse for RpcError {
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "orchestrationId".to_string(),
-                    format!("Orchestration ID is not found: {}", id),
+                    format!("Orchestration ID is not found: {id}"),
                 )),
             )
                 .into_response(),

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -92,7 +92,7 @@ pub struct TokenMetadataCacheItem {
 }
 
 fn address_balance_cache_key(address: &str) -> String {
-    format!("address_balance/{}", address)
+    format!("address_balance/{address}")
 }
 
 pub async fn get_cached_balance(
@@ -119,7 +119,7 @@ pub async fn set_cached_balance(
                 Some(BALANCE_CACHE_TTL),
             )
             .await
-            .unwrap_or_else(|e| error!("Failed to set balance cache: {}", e));
+            .unwrap_or_else(|e| error!("Failed to set balance cache: {e}"));
     }
 }
 
@@ -173,8 +173,7 @@ async fn handler_internal(
         for &v in &EMPTY_BALANCE_RESPONSE_SDK_VERSIONS {
             if version == v || version.ends_with(v) {
                 debug!(
-                    "Responding with an empty balance array for sdk version: {}",
-                    version
+                    "Responding with an empty balance array for sdk version: {version}"
                 );
                 return Ok(Json(BalanceResponseBody { balances: vec![] }));
             }
@@ -226,8 +225,7 @@ async fn handler_internal(
             Err(e) => {
                 retry_count = i;
                 error!(
-                    "Error on balance provider response, trying the next provider: {:?}",
-                    e
+                    "Error on balance provider response, trying the next provider: {e:?}"
                 );
             }
         };
@@ -300,8 +298,7 @@ async fn handler_internal(
         let force_update: Vec<&str> = force_update.split(',').collect();
         for caip_contract_address in force_update {
             debug!(
-                "Forcing balance update for the contract address: {}",
-                caip_contract_address
+                "Forcing balance update for the contract address: {caip_contract_address}"
             );
             let (namespace, chain_id, contract_address) =
                 crypto::disassemble_caip10(caip_contract_address)
@@ -309,7 +306,7 @@ async fn handler_internal(
             let contract_address = contract_address
                 .parse::<Address>()
                 .map_err(|_| RpcError::InvalidAddress)?;
-            let caip2_chain_id = format!("{}:{}", namespace, chain_id);
+            let caip2_chain_id = format!("{namespace}:{chain_id}");
             let parsed_address = address
                 .parse::<Address>()
                 .map_err(|_| RpcError::InvalidAddress)?;
@@ -369,19 +366,18 @@ async fn handler_internal(
             let get_price_info = get_price_info_provider
                 .get_price(
                     &chain_id.clone(),
-                    format!("{:#x}", contract_address).as_str(),
+                    format!("{contract_address:#x}").as_str(),
                     &query.currency,
                     &state.providers.token_metadata_cache,
                     state.metrics.clone(),
                 )
                 .await
                 .tap_err(|e| {
-                    error!("Failed to call fungible get_price with {}", e);
+                    error!("Failed to call fungible get_price with {e}");
                 })?;
             let token_info = get_price_info.fungibles.first().ok_or_else(|| {
                 error!(
-                    "Empty tokens list result from get_price for address: {:#x}",
-                    contract_address
+                    "Empty tokens list result from get_price for address: {contract_address:#x}"
                 );
                 RpcError::BalanceProviderError
             })?;
@@ -432,7 +428,7 @@ impl TokenMetadataCache {
         Self { cache_pool }
     }
     fn token_metadata_cache_key(&self, caip10_token_address: &str) -> String {
-        format!("token_metadata/{}", caip10_token_address)
+        format!("token_metadata/{caip10_token_address}")
     }
 
     #[allow(dependency_on_unit_never_type_fallback)]

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -172,9 +172,7 @@ async fn handler_internal(
     if let Some(version) = sdk_version {
         for &v in &EMPTY_BALANCE_RESPONSE_SDK_VERSIONS {
             if version == v || version.ends_with(v) {
-                debug!(
-                    "Responding with an empty balance array for sdk version: {version}"
-                );
+                debug!("Responding with an empty balance array for sdk version: {version}");
                 return Ok(Json(BalanceResponseBody { balances: vec![] }));
             }
         }
@@ -224,9 +222,7 @@ async fn handler_internal(
             }
             Err(e) => {
                 retry_count = i;
-                error!(
-                    "Error on balance provider response, trying the next provider: {e:?}"
-                );
+                error!("Error on balance provider response, trying the next provider: {e:?}");
             }
         };
     }
@@ -297,9 +293,7 @@ async fn handler_internal(
             })?;
         let force_update: Vec<&str> = force_update.split(',').collect();
         for caip_contract_address in force_update {
-            debug!(
-                "Forcing balance update for the contract address: {caip_contract_address}"
-            );
+            debug!("Forcing balance update for the contract address: {caip_contract_address}");
             let (namespace, chain_id, contract_address) =
                 crypto::disassemble_caip10(caip_contract_address)
                     .map_err(|_| RpcError::InvalidAddress)?;

--- a/src/handlers/bundler.rs
+++ b/src/handlers/bundler.rs
@@ -105,8 +105,7 @@ async fn handler_internal(
                     || domain.ends_with("local.")
                 {
                     return Err(RpcError::UnsupportedBundlerName(format!(
-                        "domain is not supported, got {}",
-                        domain
+                        "domain is not supported, got {domain}"
                     )));
                 }
             } else {

--- a/src/handlers/chain_agnostic/mod.rs
+++ b/src/handlers/chain_agnostic/mod.rs
@@ -144,8 +144,7 @@ pub async fn get_balances_of_all_source_tokens(
                             .map_err(|e| {
                                 RpcError::CryptoUitlsError(
                                     crate::utils::crypto::CryptoUitlsError::ProviderError(format!(
-                                        "Failed to get solana token account balance: {}",
-                                        e
+                                        "Failed to get solana token account balance: {e}"
                                     )),
                                 )
                             })?
@@ -154,8 +153,7 @@ pub async fn get_balances_of_all_source_tokens(
                             .map_err(|e| {
                                 RpcError::CryptoUitlsError(
                                     crate::utils::crypto::CryptoUitlsError::ProviderError(format!(
-                                        "Failed to parse solana token account balance: {}",
-                                        e
+                                        "Failed to parse solana token account balance: {e}"
                                     )),
                                 )
                             })?,
@@ -362,8 +360,7 @@ pub async fn get_assets_changes_from_simulation(
                 .get(&chain_id)
                 .ok_or_else(|| {
                     RpcError::InvalidConfiguration(format!(
-                        "Contract balance storage slot for simulation is not present for {} on {}",
-                        asset_name, chain_id
+                        "Contract balance storage slot for simulation is not present for {asset_name} on {chain_id}"
                     ))
                 })?;
             account_state.insert(

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -1270,9 +1270,7 @@ fn construct_metrics_bridging_route(
     to_chain_id: String,
     to_contract: String,
 ) -> String {
-    format!(
-        "{from_chain_id}:{from_contract}->{to_chain_id}:{to_contract}"
-    )
+    format!("{from_chain_id}:{from_contract}->{to_chain_id}:{to_contract}")
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/handlers/chain_agnostic/route.rs
+++ b/src/handlers/chain_agnostic/route.rs
@@ -278,8 +278,7 @@ async fn handler_internal(
                 return Ok(Json(PrepareResponse::Error(PrepareResponseError {
                     error: BridgingError::TransactionSimulationFailed,
                     reason: format!(
-                        "The initial transaction (native token transfer) simulation failed due to an error: {}",
-                        e
+                        "The initial transaction (native token transfer) simulation failed due to an error: {e}"
                     ),
                 })));
             }
@@ -361,8 +360,7 @@ async fn handler_internal(
                                     return Ok(Json(PrepareResponse::Error(PrepareResponseError {
                                         error: BridgingError::TransactionSimulationFailed,
                                         reason: format!(
-                                            "The initial transaction simulation failed due to an error: {}",
-                                            e
+                                            "The initial transaction simulation failed due to an error: {e}"
                                         ),
                                     })));
                                 }
@@ -422,8 +420,7 @@ async fn handler_internal(
                             return Ok(Json(PrepareResponse::Error(PrepareResponseError {
                                 error: BridgingError::TransactionSimulationFailed,
                                 reason: format!(
-                                    "The initial transaction simulation failed due to an error: {}",
-                                    e
+                                    "The initial transaction simulation failed due to an error: {e}"
                                 ),
                             })));
                         }
@@ -1274,8 +1271,7 @@ fn construct_metrics_bridging_route(
     to_contract: String,
 ) -> String {
     format!(
-        "{}:{}->{}:{}",
-        from_chain_id, from_contract, to_chain_id, to_contract
+        "{from_chain_id}:{from_contract}->{to_chain_id}:{to_contract}"
     )
 }
 

--- a/src/handlers/convert/allowance.rs
+++ b/src/handlers/convert/allowance.rs
@@ -51,7 +51,7 @@ async fn handler_internal(
         .get_allowance(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call get allownce with {}", e);
+            error!("Failed to call get allownce with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/convert/approve.rs
+++ b/src/handlers/convert/approve.rs
@@ -66,7 +66,7 @@ async fn handler_internal(
         .build_approve_tx(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call build approve tx for conversion with {}", e);
+            error!("Failed to call build approve tx for conversion with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/convert/gas_price.rs
+++ b/src/handlers/convert/gas_price.rs
@@ -52,7 +52,7 @@ async fn handler_internal(
         .get_gas_price(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call get gas price with {}", e);
+            error!("Failed to call get gas price with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/convert/quotes.rs
+++ b/src/handlers/convert/quotes.rs
@@ -63,7 +63,7 @@ async fn handler_internal(
         .get_convert_quote(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call get conversion quotes with {}", e);
+            error!("Failed to call get conversion quotes with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/convert/tokens.rs
+++ b/src/handlers/convert/tokens.rs
@@ -63,7 +63,7 @@ async fn handler_internal(
         .get_tokens_list(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call get tokens list for conversion with {}", e);
+            error!("Failed to call get tokens list for conversion with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/convert/transaction.rs
+++ b/src/handlers/convert/transaction.rs
@@ -79,7 +79,7 @@ async fn handler_internal(
         .build_convert_tx(request_payload, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call build conversion transaction with {}", e);
+            error!("Failed to call build conversion transaction with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -89,7 +89,7 @@ async fn handler_internal(
         )
         .await
         .tap_err(|e| {
-            error!("Failed to call fungible price with {}", e);
+            error!("Failed to call fungible price with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/generators/onrampurl.rs
+++ b/src/handlers/generators/onrampurl.rs
@@ -110,7 +110,7 @@ async fn handler_internal(
     let mut parameters = match serde_json::from_slice::<OnRampURLRequest>(&body) {
         Ok(parameters) => parameters,
         Err(e) => {
-            debug!("Error deserializing request body: {}", e);
+            debug!("Error deserializing request body: {e}");
             return Ok((
                 StatusCode::BAD_REQUEST,
                 "Error deserializing request body: {}",
@@ -123,7 +123,7 @@ async fn handler_internal(
     let on_ramp_url = match generate_on_ramp_url(CB_PAY_HOST, CB_PAY_PATH, parameters) {
         Ok(on_ramp_url) => on_ramp_url,
         Err(e) => {
-            error!("Error generating on-ramp URL: {}", e);
+            error!("Error generating on-ramp URL: {e}");
             return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
         }
     };
@@ -216,7 +216,7 @@ fn ensure_generate_on_ramp_url() {
             .find(|(key, _)| key == "destinationWallets")
             .unwrap()
             .1,
-        format!("[{{\"address\":\"{}\"}}]", address)
+        format!("[{{\"address\":\"{address}\"}}]")
     );
     assert_eq!(
         url.query_pairs()

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -176,7 +176,7 @@ async fn handler_internal(
                 )
                 .await
                 .tap_err(|e| {
-                    error!("Failed to call coinbase transactions history with {}", e);
+                    error!("Failed to call coinbase transactions history with {e}");
                 })?
         } else {
             return Err(RpcError::UnsupportedProvider(onramp));
@@ -198,7 +198,7 @@ async fn handler_internal(
             )
             .await
             .tap_err(|e| {
-                error!("Failed to call transactions history with {}", e);
+                error!("Failed to call transactions history with {e}");
             })?
     };
 

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -202,7 +202,7 @@ async fn lookup_identity(
     headers: HeaderMap,
 ) -> Result<(IdentityLookupSource, IdentityResponse), RpcError> {
     let address_with_checksum = to_checksum(&address, None);
-    let cache_record_key = format!("{}-v1", address_with_checksum);
+    let cache_record_key = format!("{address_with_checksum}-v1");
 
     // Check if we should enable cache control for allow listed Project ID
     // The cache is enabled by default
@@ -395,7 +395,7 @@ pub fn handle_rpc_error(error: ProviderError) -> Result<(), RpcError> {
             // Check the list of error codes that reflects an execution reverted
             // and should proceed with Ok()
             for &code in &JSON_RPC_OK_ERROR_CODES {
-                if error_detail.contains(&format!("code: {},", code)) {
+                if error_detail.contains(&format!("code: {code},")) {
                     debug!(
                         "JsonRpcError code {} while looking up identity: {:?}",
                         code, error_detail
@@ -505,7 +505,7 @@ impl ethers::providers::RpcError for SelfProviderError {
 
 impl From<SelfProviderError> for ProviderError {
     fn from(value: SelfProviderError) -> Self {
-        ProviderError::CustomError(format!("{}{}", SELF_PROVIDER_ERROR_PREFIX, value))
+        ProviderError::CustomError(format!("{SELF_PROVIDER_ERROR_PREFIX}{value}"))
     }
 }
 
@@ -573,8 +573,7 @@ impl JsonRpcClient for SelfProvider {
         };
         let result = serde_json::from_value(result).map_err(|e| {
             SelfProviderError::GenericParameterError(format!(
-                "Caller should always provide generic parameter R=Bytes: {}",
-                e
+                "Caller should always provide generic parameter R=Bytes: {e}"
             ))
         })?;
         Ok(result)

--- a/src/handlers/onramp/multi_quotes.rs
+++ b/src/handlers/onramp/multi_quotes.rs
@@ -73,7 +73,7 @@ async fn handler_internal(
         .get_quotes(request_payload, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call onramp multi providers quotes with {}", e);
+            error!("Failed to call onramp multi providers quotes with {e}");
         })?;
 
     Ok(Json(quotes).into_response())

--- a/src/handlers/onramp/options.rs
+++ b/src/handlers/onramp/options.rs
@@ -92,7 +92,7 @@ async fn handler_internal(
         .get_buy_options(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call coinbase buy options with {}", e);
+            error!("Failed to call coinbase buy options with {e}");
         })?;
 
     Ok(Json(buy_options).into_response())

--- a/src/handlers/onramp/properties.rs
+++ b/src/handlers/onramp/properties.rs
@@ -55,7 +55,7 @@ async fn handler_internal(
         .get_providers_properties(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call onramp providers properties with {}", e);
+            error!("Failed to call onramp providers properties with {e}");
         })?;
 
     Ok(Json(providers_properties).into_response())

--- a/src/handlers/onramp/providers.rs
+++ b/src/handlers/onramp/providers.rs
@@ -63,7 +63,7 @@ async fn handler_internal(
         .get_providers(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call onramp providers with {}", e);
+            error!("Failed to call onramp providers with {e}");
         })?;
 
     Ok(Json(providers_response).into_response())

--- a/src/handlers/onramp/quotes.rs
+++ b/src/handlers/onramp/quotes.rs
@@ -88,7 +88,7 @@ async fn handler_internal(
         .get_buy_quotes(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call coinbase buy quotes with {}", e);
+            error!("Failed to call coinbase buy quotes with {e}");
         })?;
 
     Ok(Json(buy_quotes).into_response())

--- a/src/handlers/onramp/widget.rs
+++ b/src/handlers/onramp/widget.rs
@@ -76,7 +76,7 @@ async fn handler_internal(
         .get_widget(request_payload, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call onramp widget with {}", e);
+            error!("Failed to call onramp widget with {e}");
         })?;
 
     Ok(Json(widget_response).into_response())

--- a/src/handlers/portfolio.rs
+++ b/src/handlers/portfolio.rs
@@ -72,7 +72,7 @@ async fn handler_internal(
         .get_portfolio(address, query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
-            error!("Failed to call portfolio with {}", e);
+            error!("Failed to call portfolio with {e}");
         })?;
 
     Ok(Json(response).into_response())

--- a/src/handlers/profile/address.rs
+++ b/src/handlers/profile/address.rs
@@ -77,7 +77,7 @@ pub async fn handler_internal(
             Err(e) => match e {
                 SqlxError::RowNotFound => return Err(RpcError::NameNotRegistered(name)),
                 _ => {
-                    error!("Failed to lookup name in the database: {}", e);
+                    error!("Failed to lookup name in the database: {e}");
                     return Ok((
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Name lookup database error",
@@ -166,7 +166,7 @@ pub async fn handler_internal(
     {
         Ok(response) => Ok(Json(response).into_response()),
         Err(e) => {
-            error!("Failed to update address: {}", e);
+            error!("Failed to update address: {e}");
             Ok((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to update address",

--- a/src/handlers/profile/attributes.rs
+++ b/src/handlers/profile/attributes.rs
@@ -144,10 +144,10 @@ pub async fn handler_internal(
 
     match update_name_attributes(name.clone(), payload.attributes, &state.postgres).await {
         Err(e) => {
-            error!("Failed to update attributes: {}", e);
+            error!("Failed to update attributes: {e}");
             Ok((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to update attributes: {}", e),
+                format!("Failed to update attributes: {e}"),
             )
                 .into_response())
         }

--- a/src/handlers/profile/lookup.rs
+++ b/src/handlers/profile/lookup.rs
@@ -68,7 +68,7 @@ async fn handler_internal(
             }
             _ => {
                 // Handle other types of errors
-                error!("Failed to lookup name: {}", e);
+                error!("Failed to lookup name: {e}");
                 return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
             }
         },

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -185,7 +185,7 @@ pub async fn handler_internal(
     )
     .await;
     if let Err(e) = insert_result {
-        error!("Failed to insert new name: {}", e);
+        error!("Failed to insert new name: {e}");
         return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
     }
 
@@ -225,7 +225,7 @@ pub async fn handler_internal(
             )),
             _ => {
                 // Handle other types of errors
-                error!("Failed to lookup name: {}", e);
+                error!("Failed to lookup name: {e}");
                 return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
             }
         },

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -55,9 +55,7 @@ async fn handler_internal(
             Ok(response) => result.push(response),
             Err(e) => {
                 // Unexpected behavior when looking up a name for an address
-                error!(
-                    "Unexpected behavior when looking up a name for an address: {e}"
-                );
+                error!("Unexpected behavior when looking up a name for an address: {e}");
                 return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
             }
         }

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -35,7 +35,7 @@ async fn handler_internal(
     let names = match get_names_by_address(address, &state.postgres).await {
         Ok(names) => names,
         Err(e) => {
-            error!("Error on get names by address: {}", e);
+            error!("Error on get names by address: {e}");
             return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
         }
     };
@@ -56,8 +56,7 @@ async fn handler_internal(
             Err(e) => {
                 // Unexpected behavior when looking up a name for an address
                 error!(
-                    "Unexpected behavior when looking up a name for an address: {}",
-                    e
+                    "Unexpected behavior when looking up a name for an address: {e}"
                 );
                 return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
             }

--- a/src/handlers/profile/suggestions.rs
+++ b/src/handlers/profile/suggestions.rs
@@ -69,7 +69,7 @@ async fn handler_internal(
 
     // Adding the exact match for the main zone to check if it is
     // registered
-    let exact_name_with_zone = format!("{}.{}", name, zone);
+    let exact_name_with_zone = format!("{name}.{zone}");
     suggestions.push(NameSuggestion {
         name: exact_name_with_zone.clone(),
         registered: is_name_registered(exact_name_with_zone, &state.postgres).await,
@@ -78,7 +78,7 @@ async fn handler_internal(
     // Iterate found dictionary candidates and check if they are registered
     for suggested_name in candidates {
         // Get name suggestion for the main zone if the name is free
-        let name_with_zone = format!("{}.{}", suggested_name, zone);
+        let name_with_zone = format!("{suggested_name}.{zone}");
         let is_registered = is_name_registered(name_with_zone.clone(), &state.postgres).await;
 
         if !is_registered {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -172,7 +172,7 @@ pub async fn rpc_call(
     }
 
     state.metrics.add_no_providers_for_chain(chain_id.clone());
-    debug!("All providers failed for chain_id: {}", chain_id);
+    debug!("All providers failed for chain_id: {chain_id}");
     Err(RpcError::ChainTemporarilyUnavailable(chain_id))
 }
 

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -106,7 +106,7 @@ async fn handler_internal(
         return Err(RpcError::UnsupportedChain(chain_id.clone()));
     }
 
-    let chain_id_caip2 = format!("{}:{}", namespace, chain_id);
+    let chain_id_caip2 = format!("{namespace}:{chain_id}");
     let mut user_op = request_payload.user_op.clone();
 
     // Project ID for internal json-rpc calls

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -131,9 +131,7 @@ async fn handler_internal(
     };
 
     // TODO: remove this debuging log
-    print!(
-        "New permission created with PCI: {pci:?} for address: {address:?}"
-    );
+    print!("New permission created with PCI: {pci:?} for address: {address:?}");
 
     Ok(Json(response).into_response())
 }

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -132,8 +132,7 @@ async fn handler_internal(
 
     // TODO: remove this debuging log
     print!(
-        "New permission created with PCI: {:?} for address: {:?}",
-        pci, address
+        "New permission created with PCI: {pci:?} for address: {address:?}"
     );
 
     Ok(Json(response).into_response())

--- a/src/handlers/wallet/exchanges/binance.rs
+++ b/src/handlers/wallet/exchanges/binance.rs
@@ -309,13 +309,12 @@ impl BinanceExchange {
         };
         debug!("Data to sign: {}", data_to_sign);
 
-        let mut signer = Signer::new(MessageDigest::sha256(), &pkey).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to create signer: {e}"))
-        })?;
+        let mut signer = Signer::new(MessageDigest::sha256(), &pkey)
+            .map_err(|e| ExchangeError::GetPayUrlError(format!("Failed to create signer: {e}")))?;
 
-        signer.update(data_to_sign.as_bytes()).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to update signer: {e}"))
-        })?;
+        signer
+            .update(data_to_sign.as_bytes())
+            .map_err(|e| ExchangeError::GetPayUrlError(format!("Failed to update signer: {e}")))?;
         let signature = signer
             .sign_to_vec()
             .map_err(|e| ExchangeError::GetPayUrlError(format!("Failed to sign data: {e}")))?;
@@ -365,9 +364,8 @@ impl BinanceExchange {
         let status = response.status();
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
-            let message = format!(
-                "Binance API request failed with status: {status}, body: {error_body}"
-            );
+            let message =
+                format!("Binance API request failed with status: {status}, body: {error_body}");
             debug!("Binance API request failed: {}", message);
             return Err(ExchangeError::InternalError(message));
         }

--- a/src/handlers/wallet/exchanges/binance.rs
+++ b/src/handlers/wallet/exchanges/binance.rs
@@ -295,30 +295,30 @@ impl BinanceExchange {
         private_key: &str,
     ) -> Result<String, ExchangeError> {
         let key_bytes = STANDARD.decode(private_key).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to decode private key: {}", e))
+            ExchangeError::GetPayUrlError(format!("Failed to decode private key: {e}"))
         })?;
 
         let pkey = PKey::private_key_from_pkcs8(&key_bytes).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to parse private key: {}", e))
+            ExchangeError::GetPayUrlError(format!("Failed to parse private key: {e}"))
         })?;
 
         let data_to_sign = if body.is_empty() || body == "{}" {
             timestamp.to_string()
         } else {
-            format!("{}{}", body, timestamp)
+            format!("{body}{timestamp}")
         };
         debug!("Data to sign: {}", data_to_sign);
 
         let mut signer = Signer::new(MessageDigest::sha256(), &pkey).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to create signer: {}", e))
+            ExchangeError::GetPayUrlError(format!("Failed to create signer: {e}"))
         })?;
 
         signer.update(data_to_sign.as_bytes()).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to update signer: {}", e))
+            ExchangeError::GetPayUrlError(format!("Failed to update signer: {e}"))
         })?;
         let signature = signer
             .sign_to_vec()
-            .map_err(|e| ExchangeError::GetPayUrlError(format!("Failed to sign data: {}", e)))?;
+            .map_err(|e| ExchangeError::GetPayUrlError(format!("Failed to sign data: {e}")))?;
 
         Ok(STANDARD.encode(&signature))
     }
@@ -341,12 +341,12 @@ impl BinanceExchange {
             .as_millis() as u64;
 
         let body = serde_json::to_string(payload).map_err(|e| {
-            ExchangeError::GetPayUrlError(format!("Failed to serialize request body: {}", e))
+            ExchangeError::GetPayUrlError(format!("Failed to serialize request body: {e}"))
         })?;
 
         let signature = self.generate_signature(&body, timestamp, &private_key)?;
 
-        let url = format!("{}{}", host, path);
+        let url = format!("{host}{path}");
 
         let response = state
             .http_client
@@ -366,8 +366,7 @@ impl BinanceExchange {
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
             let message = format!(
-                "Binance API request failed with status: {}, body: {}",
-                status, error_body
+                "Binance API request failed with status: {status}, body: {error_body}"
             );
             debug!("Binance API request failed: {}", message);
             return Err(ExchangeError::InternalError(message));
@@ -375,7 +374,7 @@ impl BinanceExchange {
 
         let parsed_response: BinanceResponse<R> = response.json().await.map_err(|e| {
             debug!("Unable to parse Binance response: {}", e);
-            ExchangeError::InternalError(format!("Failed to parse Binance response: {}", e))
+            ExchangeError::InternalError(format!("Failed to parse Binance response: {e}"))
         })?;
         debug!("Parsed response: {:?}", parsed_response);
         if let Some(success) = parsed_response.success {
@@ -403,14 +402,14 @@ impl BinanceExchange {
         let crypto = CAIP19_TO_BINANCE_CRYPTO
             .get(full_caip19.as_str())
             .ok_or_else(|| {
-                ExchangeError::ValidationError(format!("Unsupported asset: {}", full_caip19))
+                ExchangeError::ValidationError(format!("Unsupported asset: {full_caip19}"))
             })?
             .to_string();
 
         let network = CHAIN_ID_TO_BINANCE_NETWORK
             .get(chain_id.as_str())
             .ok_or_else(|| {
-                ExchangeError::ValidationError(format!("Unsupported chain ID: {}", chain_id))
+                ExchangeError::ValidationError(format!("Unsupported chain ID: {chain_id}"))
             })?
             .to_string();
 
@@ -432,7 +431,7 @@ impl BinanceExchange {
             .await
             .map_err(|e| {
                 debug!("Failed to get project data: {}", e);
-                ExchangeError::InternalError(format!("Failed to get project data: {}", e))
+                ExchangeError::InternalError(format!("Failed to get project data: {e}"))
             })?;
         let project_name = if project.project_data.name.is_empty() {
             debug!("Project name is empty, using fallback name");

--- a/src/handlers/wallet/exchanges/coinbase.rs
+++ b/src/handlers/wallet/exchanges/coinbase.rs
@@ -304,9 +304,7 @@ impl CoinbaseExchange {
             params.recipient.clone(),
             vec![network.clone()],
         )]))
-        .map_err(|e| {
-            ExchangeError::InternalError(format!("Failed to serialize addresses: {e}"))
-        })?;
+        .map_err(|e| ExchangeError::InternalError(format!("Failed to serialize addresses: {e}")))?;
 
         let assets = serde_json::to_string(&vec![crypto.clone()]).map_err(|e| {
             ExchangeError::InternalError(format!("Failed to serialize assets: {e}"))

--- a/src/handlers/wallet/exchanges/coinbase.rs
+++ b/src/handlers/wallet/exchanges/coinbase.rs
@@ -226,7 +226,7 @@ impl CoinbaseExchange {
         let jwt_key =
             generate_coinbase_jwt_key(&pub_key, &priv_key, "GET", COINBASE_API_HOST, path)?;
 
-        let url = format!("https://{}{}", COINBASE_API_HOST, path);
+        let url = format!("https://{COINBASE_API_HOST}{path}");
 
         let res = state
             .http_client
@@ -250,14 +250,14 @@ impl CoinbaseExchange {
         let crypto = CAIP19_TO_COINBASE_CRYPTO
             .get(full_caip19.as_str())
             .ok_or_else(|| {
-                ExchangeError::ValidationError(format!("Unsupported asset: {}", full_caip19))
+                ExchangeError::ValidationError(format!("Unsupported asset: {full_caip19}"))
             })?
             .to_string();
 
         let network = CHAIN_ID_TO_COINBASE_NETWORK
             .get(chain_id.as_str())
             .ok_or_else(|| {
-                ExchangeError::ValidationError(format!("Unsupported chain ID: {}", chain_id))
+                ExchangeError::ValidationError(format!("Unsupported chain ID: {chain_id}"))
             })?
             .to_string();
 
@@ -272,7 +272,7 @@ impl CoinbaseExchange {
         let res = self
             .send_get_request(
                 state,
-                &format!("/onramp/v1/buy/user/{}/transactions", transaction_id),
+                &format!("/onramp/v1/buy/user/{transaction_id}/transactions"),
             )
             .await?;
 
@@ -305,15 +305,15 @@ impl CoinbaseExchange {
             vec![network.clone()],
         )]))
         .map_err(|e| {
-            ExchangeError::InternalError(format!("Failed to serialize addresses: {}", e))
+            ExchangeError::InternalError(format!("Failed to serialize addresses: {e}"))
         })?;
 
         let assets = serde_json::to_string(&vec![crypto.clone()]).map_err(|e| {
-            ExchangeError::InternalError(format!("Failed to serialize assets: {}", e))
+            ExchangeError::InternalError(format!("Failed to serialize assets: {e}"))
         })?;
 
         let mut url = Url::parse(COINBASE_ONE_CLICK_BUY_URL)
-            .map_err(|e| ExchangeError::InternalError(format!("Failed to parse URL: {}", e)))?;
+            .map_err(|e| ExchangeError::InternalError(format!("Failed to parse URL: {e}")))?;
 
         url.query_pairs_mut()
             .append_pair("appId", project_id)
@@ -387,7 +387,7 @@ fn generate_coinbase_jwt_key(
         .duration_since(UNIX_EPOCH)
         .map_err(|_| ExchangeError::InternalError("Failed to get current time".to_string()))?
         .as_secs() as usize;
-    let uri = format!("{} {}{}", request_method, request_host, request_path);
+    let uri = format!("{request_method} {request_host}{request_path}");
     let claims = Claims {
         iss: "cdp".to_string(),
         nbf: now,
@@ -407,12 +407,12 @@ fn generate_coinbase_jwt_key(
         "typ": "JWT"
     });
     let header = serde_json::to_vec(&header)
-        .map_err(|e| ExchangeError::InternalError(format!("Failed to serialize header: {}", e)))?;
+        .map_err(|e| ExchangeError::InternalError(format!("Failed to serialize header: {e}")))?;
     let header_b64 = BASE64_URL_SAFE_NO_PAD.encode(&header);
     let claims = serde_json::to_vec(&claims)
-        .map_err(|e| ExchangeError::InternalError(format!("Failed to serialize claims: {}", e)))?;
+        .map_err(|e| ExchangeError::InternalError(format!("Failed to serialize claims: {e}")))?;
     let claims_b64 = BASE64_URL_SAFE_NO_PAD.encode(&claims);
-    let message = format!("{}.{}", header_b64, claims_b64);
+    let message = format!("{header_b64}.{claims_b64}");
 
     let secret_bytes = STANDARD
         .decode(key_secret.trim())
@@ -426,5 +426,5 @@ fn generate_coinbase_jwt_key(
     let signature = signing_key.sign(message.as_bytes());
     let signature_b64 = BASE64_URL_SAFE_NO_PAD.encode(signature.to_bytes());
 
-    Ok(format!("{}.{}.{}", header_b64, claims_b64, signature_b64))
+    Ok(format!("{header_b64}.{claims_b64}.{signature_b64}"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
 
     let profiler = async move {
         if let Err(e) = tokio::spawn(profiler::run()).await {
-            warn!("Memory debug stats collection failed with: {:?}", e);
+            warn!("Memory debug stats collection failed with: {e:?}");
         }
         Ok(())
     };
@@ -472,7 +472,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ];
 
     if let Err(e) = futures_util::future::select_all(services).await.0 {
-        warn!("Server error: {:?}", e);
+        warn!("Server error: {e:?}");
     };
 
     Ok(())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -490,7 +490,7 @@ impl Metrics {
     ) {
         let mut attributes = vec![
             otel::KeyValue::new("provider", provider_kind.to_string()),
-            otel::KeyValue::new("status_code", format!("{}", status)),
+            otel::KeyValue::new("status_code", format!("{status}")),
         ];
         if let Some(chain_id) = chain_id {
             attributes.push(otel::KeyValue::new("chain_id", chain_id));

--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -98,7 +98,7 @@ impl DuneProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url.clone()).await.map_err(|e| {
-            error!("Error sending request to Dune EVM balance API: {:?}", e);
+            error!("Error sending request to Dune EVM balance API: {e:?}");
             RpcError::BalanceProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -132,7 +132,7 @@ impl DuneProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url.clone()).await.map_err(|e| {
-            error!("Error sending request to Dune svm balance API: {:?}", e);
+            error!("Error sending request to Dune svm balance API: {e:?}");
             RpcError::BalanceProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -195,12 +195,12 @@ impl BalanceProvider for DuneProvider {
 
             // Build a CAIP-2 chain ID
             let caip2_chain_id = match f.chain_id {
-                Some(cid) => format!("{}:{}", namespace, cid),
+                Some(cid) => format!("{namespace}:{cid}"),
                 None => match namespace {
                     // Use default Mainnet chain IDs if not provided
-                    crypto::CaipNamespaces::Eip155 => format!("{}:1", namespace),
+                    crypto::CaipNamespaces::Eip155 => format!("{namespace}:1"),
                     crypto::CaipNamespaces::Solana => {
-                        format!("{}:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", namespace)
+                        format!("{namespace}:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
                     }
                 },
             };
@@ -209,7 +209,7 @@ impl BalanceProvider for DuneProvider {
             let caip10_token_address_strict = if f.address == "native" {
                 match namespace {
                     crypto::CaipNamespaces::Eip155 => {
-                        format!("{}:{}", caip2_chain_id, H160_EMPTY_ADDRESS)
+                        format!("{caip2_chain_id}:{H160_EMPTY_ADDRESS}")
                     }
                     crypto::CaipNamespaces::Solana => {
                         format!("{}:{}", caip2_chain_id, crypto::SOLANA_NATIVE_TOKEN_ADDRESS)
@@ -278,14 +278,14 @@ impl BalanceProvider for DuneProvider {
                                 .set_metadata(&address_key, &new_item_to_store)
                                 .await
                             {
-                                error!("Failed to update token metadata cache: {:?}", e);
+                                error!("Failed to update token metadata cache: {e:?}");
                             }
                         });
                     }
                     new_item
                 }
                 Err(e) => {
-                    error!("Error getting token metadata: {:?}", e);
+                    error!("Error getting token metadata: {e:?}");
                     continue;
                 }
             };

--- a/src/providers/hiro.rs
+++ b/src/providers/hiro.rs
@@ -77,7 +77,7 @@ impl HiroProvider {
 
         let stacks_transactions_request = serde_json::to_string(&TransactionsRequest { tx })
             .map_err(|e| {
-                RpcError::InvalidParameter(format!("Failed to serialize transaction: {}", e))
+                RpcError::InvalidParameter(format!("Failed to serialize transaction: {e}"))
             })?;
 
         let hyper_request = hyper::http::Request::builder()
@@ -162,7 +162,7 @@ impl HiroProvider {
             transaction_payload,
         })
         .map_err(|e| {
-            RpcError::InvalidParameter(format!("Failed to serialize fees transaction: {}", e))
+            RpcError::InvalidParameter(format!("Failed to serialize fees transaction: {e}"))
         })?;
 
         let hyper_request = hyper::http::Request::builder()
@@ -245,7 +245,7 @@ impl RpcProvider for HiroProvider {
         let method: SupportedMethods = serde_json::from_value(serde_json::Value::String(
             (*json_rpc_request.method).to_string(),
         ))
-        .map_err(|e| RpcError::InvalidParameter(format!("Invalid method provided: {:?}", e)))?;
+        .map_err(|e| RpcError::InvalidParameter(format!("Invalid method provided: {e:?}")))?;
 
         match method {
             SupportedMethods::StacksTransactions => {

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -109,9 +109,7 @@ impl MeldProvider {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error,
                     Err(e) => {
-                        error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing Meld HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         MeldErrorResponse {
                             code: "UNKNOWN".to_string(),
@@ -203,9 +201,7 @@ impl OnRampMultiProvider for MeldProvider {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
-                        error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing Meld HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -269,9 +265,7 @@ impl OnRampMultiProvider for MeldProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_get_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to Meld providers properties: {e:?}"
-            );
+            error!("Error sending request to Meld providers properties: {e:?}");
             RpcError::OnRampProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -292,9 +286,7 @@ impl OnRampMultiProvider for MeldProvider {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
-                        error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing Meld HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -352,9 +344,7 @@ impl OnRampMultiProvider for MeldProvider {
                 let response_error = match response.json::<MeldErrorResponse>().await {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
-                        error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing Meld HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -84,11 +84,11 @@ impl MeldProvider {
             .post(url)
             .json(&params)
             .header("Meld-Version", API_VERSION)
-            .header("Authorization", format!("BASIC {}", api_key))
+            .header("Authorization", format!("BASIC {api_key}"))
             .send()
             .await
             .map_err(|e| {
-                error!("Error sending request to Meld get quotes: {:?}", e);
+                error!("Error sending request to Meld get quotes: {e:?}");
                 RpcError::OnRampProviderError
             })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -110,8 +110,7 @@ impl MeldProvider {
                     Ok(response_error) => response_error,
                     Err(e) => {
                         error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         MeldErrorResponse {
@@ -205,8 +204,7 @@ impl OnRampMultiProvider for MeldProvider {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
                         error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -272,8 +270,7 @@ impl OnRampMultiProvider for MeldProvider {
         let latency_start = SystemTime::now();
         let response = self.send_get_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to Meld providers properties: {:?}",
-                e
+                "Error sending request to Meld providers properties: {e:?}"
             );
             RpcError::OnRampProviderError
         })?;
@@ -296,8 +293,7 @@ impl OnRampMultiProvider for MeldProvider {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
                         error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -335,7 +331,7 @@ impl OnRampMultiProvider for MeldProvider {
             )
             .await
             .map_err(|e| {
-                error!("Error sending request to Meld get widget: {:?}", e);
+                error!("Error sending request to Meld get widget: {e:?}");
                 RpcError::OnRampProviderError
             })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -357,8 +353,7 @@ impl OnRampMultiProvider for MeldProvider {
                     Ok(response_error) => response_error.message,
                     Err(e) => {
                         error!(
-                            "Error parsing Meld HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing Meld HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -457,7 +452,7 @@ impl OnRampMultiProvider for MeldProvider {
                     first_error.get_or_insert(e);
                 }
                 Err(e) => {
-                    error!("Error on getting Meld quotes in parallel: {:?}", e);
+                    error!("Error on getting Meld quotes in parallel: {e:?}");
                     return Err(RpcError::OnRampProviderError);
                 }
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -391,7 +391,9 @@ impl ProviderRepository {
             return Err(RpcError::UnsupportedChain(chain_id.to_string()));
         }
 
-        let weights: Vec<_> = providers.values().map(|weight| weight.value())
+        let weights: Vec<_> = providers
+            .values()
+            .map(|weight| weight.value())
             .map(|w| w.max(1))
             .collect();
         let non_zero_weight_providers = weights.iter().filter(|&x| *x > 0).count();

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -391,9 +391,7 @@ impl ProviderRepository {
             return Err(RpcError::UnsupportedChain(chain_id.to_string()));
         }
 
-        let weights: Vec<_> = providers
-            .iter()
-            .map(|(_, weight)| weight.value())
+        let weights: Vec<_> = providers.values().map(|weight| weight.value())
             .map(|w| w.max(1))
             .collect();
         let non_zero_weight_providers = weights.iter().filter(|&x| *x > 0).count();
@@ -407,8 +405,7 @@ impl ProviderRepository {
                         let dist_key = dist.sample(&mut OsRng);
                         let provider = keys.get(dist_key).ok_or_else(|| {
                             RpcError::WeightedProvidersIndex(format!(
-                                "Failed to get random provider for chain_id: {}",
-                                chain_id
+                                "Failed to get random provider for chain_id: {chain_id}"
                             ))
                         })?;
 
@@ -418,16 +415,14 @@ impl ProviderRepository {
                         if i < providers_to_iterate - 1 {
                             if let Err(e) = dist.update_weights(&[(dist_key, &0)]) {
                                 return Err(RpcError::WeightedProvidersIndex(format!(
-                                    "Failed to update weight in sampling iteration: {}",
-                                    e
+                                    "Failed to update weight in sampling iteration: {e}"
                                 )));
                             }
                         };
 
                         self.rpc_providers.get(provider).cloned().ok_or_else(|| {
                             RpcError::WeightedProvidersIndex(format!(
-                                "Provider not found during the weighted index check: {}",
-                                provider
+                                "Provider not found during the weighted index check: {provider}"
                             ))
                         })
                     })
@@ -437,7 +432,7 @@ impl ProviderRepository {
             Err(e) => {
                 // Respond with temporarily unavailable when all weights are 0 for
                 // a chain providers
-                warn!("Failed to create weighted index: {}", e);
+                warn!("Failed to create weighted index: {e}");
                 Err(RpcError::ChainTemporarilyUnavailable(chain_id.to_string()))
             }
         }
@@ -508,8 +503,7 @@ impl ProviderRepository {
                         let dist_key = dist.sample(&mut OsRng);
                         let provider = keys.get(dist_key).ok_or_else(|| {
                             RpcError::WeightedProvidersIndex(format!(
-                                "Failed to get random balance provider for namespace: {}",
-                                namespace
+                                "Failed to get random balance provider for namespace: {namespace}"
                             ))
                         })?;
 
@@ -519,8 +513,7 @@ impl ProviderRepository {
                         if i < providers_to_iterate - 1 {
                             if let Err(e) = dist.update_weights(&[(dist_key, &0)]) {
                                 return Err(RpcError::WeightedProvidersIndex(format!(
-                                    "Failed to update weight in sampling iteration: {}",
-                                    e
+                                    "Failed to update weight in sampling iteration: {e}"
                                 )));
                             }
                         };
@@ -530,8 +523,7 @@ impl ProviderRepository {
                             .cloned()
                             .ok_or_else(|| {
                                 RpcError::WeightedProvidersIndex(format!(
-                                "Balance provider not found during the weighted index check: {}",
-                                provider
+                                "Balance provider not found during the weighted index check: {provider}"
                             ))
                             })
                     })
@@ -550,7 +542,7 @@ impl ProviderRepository {
             Err(e) => {
                 // Respond with temporarily unavailable when all weights are 0 for
                 // a chain providers
-                warn!("Failed to create weighted index: {}", e);
+                warn!("Failed to create weighted index: {e}");
                 Err(RpcError::ChainTemporarilyUnavailable(namespace.to_string()))
             }
         }
@@ -563,7 +555,7 @@ impl ProviderRepository {
             return None;
         }
 
-        let weights: Vec<_> = providers.iter().map(|(_, weight)| weight.value()).collect();
+        let weights: Vec<_> = providers.values().map(|weight| weight.value()).collect();
         let keys = providers.keys().cloned().collect::<Vec<_>>();
         match WeightedIndex::new(weights) {
             Ok(dist) => {
@@ -575,7 +567,7 @@ impl ProviderRepository {
                 self.ws_providers.get(provider).cloned()
             }
             Err(e) => {
-                warn!("Failed to create weighted index: {}", e);
+                warn!("Failed to create weighted index: {e}");
                 None
             }
         }
@@ -691,7 +683,7 @@ impl ProviderRepository {
                 weights::record_values(&self.rpc_weight_resolver, metrics);
             }
             Err(e) => {
-                warn!("Failed to update weights from prometheus: {}", e);
+                warn!("Failed to update weights from prometheus: {e}");
             }
         }
     }

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -51,7 +51,7 @@ impl RpcProvider for MorphProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let uri = format!("https://{}.morphl2.io", chain);
+        let uri = format!("https://{chain}.morphl2.io");
 
         let hyper_request = hyper::http::Request::builder()
             .method(Method::POST)

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -84,8 +84,7 @@ impl OneInchProvider {
         let latency_start = SystemTime::now();
         let price_response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for fungible price: {:?}",
-                e
+                "Error sending request to 1inch provider for fungible price: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -105,8 +104,7 @@ impl OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -153,8 +151,7 @@ impl OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for token info: {:?}",
-                e
+                "Error sending request to 1inch provider for token info: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -174,8 +171,7 @@ impl OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -301,8 +297,7 @@ impl ConversionProvider for OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for token list: {:?}",
-                e
+                "Error sending request to 1inch provider for token list: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -322,8 +317,7 @@ impl ConversionProvider for OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -422,8 +416,7 @@ impl ConversionProvider for OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for convertion quote: {:?}",
-                e
+                "Error sending request to 1inch provider for convertion quote: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -444,8 +437,7 @@ impl ConversionProvider for OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -456,8 +448,7 @@ impl ConversionProvider for OneInchProvider {
 
             error!(
                 "Error on getting quotes for conversion from 1inch provider. Status is not OK: \
-                 {:?}",
-                response_status,
+                 {response_status:?}",
             );
             return Err(RpcError::ConversionProviderError);
         }
@@ -508,8 +499,7 @@ impl ConversionProvider for OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for building approval tx: {:?}",
-                e
+                "Error sending request to 1inch provider for building approval tx: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -529,8 +519,7 @@ impl ConversionProvider for OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -616,8 +605,7 @@ impl ConversionProvider for OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for building convertion tx: {:?}",
-                e
+                "Error sending request to 1inch provider for building convertion tx: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -637,8 +625,7 @@ impl ConversionProvider for OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -697,8 +684,7 @@ impl ConversionProvider for OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for gas price: {:?}",
-                e
+                "Error sending request to 1inch provider for gas price: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -718,8 +704,7 @@ impl ConversionProvider for OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
@@ -773,8 +758,7 @@ impl ConversionProvider for OneInchProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error sending request to 1inch provider for allowance: {:?}",
-                e
+                "Error sending request to 1inch provider for allowance: {e:?}"
             );
             RpcError::ConversionProviderError
         })?;
@@ -794,8 +778,7 @@ impl ConversionProvider for OneInchProvider {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
                         error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {:?}",
-                            e
+                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
                         );
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -83,9 +83,7 @@ impl OneInchProvider {
 
         let latency_start = SystemTime::now();
         let price_response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for fungible price: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for fungible price: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -103,9 +101,7 @@ impl OneInchProvider {
                 let response_error = match price_response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -150,9 +146,7 @@ impl OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for token info: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for token info: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -170,9 +164,7 @@ impl OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -296,9 +288,7 @@ impl ConversionProvider for OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for token list: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for token list: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -316,9 +306,7 @@ impl ConversionProvider for OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -415,9 +403,7 @@ impl ConversionProvider for OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for convertion quote: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for convertion quote: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -436,9 +422,7 @@ impl ConversionProvider for OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -498,9 +482,7 @@ impl ConversionProvider for OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for building approval tx: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for building approval tx: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -518,9 +500,7 @@ impl ConversionProvider for OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -604,9 +584,7 @@ impl ConversionProvider for OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for building convertion tx: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for building convertion tx: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -624,9 +602,7 @@ impl ConversionProvider for OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -683,9 +659,7 @@ impl ConversionProvider for OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for gas price: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for gas price: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -703,9 +677,7 @@ impl ConversionProvider for OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }
@@ -757,9 +729,7 @@ impl ConversionProvider for OneInchProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error sending request to 1inch provider for allowance: {e:?}"
-            );
+            error!("Error sending request to 1inch provider for allowance: {e:?}");
             RpcError::ConversionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -777,9 +747,7 @@ impl ConversionProvider for OneInchProvider {
                 let response_error = match response.json::<OneInchErrorResponse>().await {
                     Ok(response_error) => response_error.description,
                     Err(e) => {
-                        error!(
-                            "Error parsing OneInch HTTP 400 Bad Request error response {e:?}"
-                        );
+                        error!("Error parsing OneInch HTTP 400 Bad Request error response {e:?}");
                         // Respond to the client with a generic error message and HTTP 400 anyway
                         "Invalid parameter".to_string()
                     }

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -51,7 +51,7 @@ impl RpcProvider for PublicnodeProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let uri = format!("https://{}.publicnode.com", chain);
+        let uri = format!("https://{chain}.publicnode.com");
 
         let hyper_request = hyper::http::Request::builder()
             .method(Method::POST)

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -60,10 +60,9 @@ impl RpcProvider for QuicknodeProvider {
             self.chain_subdomains
                 .get(chain_id)
                 .ok_or(RpcError::InvalidConfiguration(format!(
-                    "Quicknode subdomain not found for chainId: {}",
-                    chain_id
+                    "Quicknode subdomain not found for chainId: {chain_id}"
                 )))?;
-        let uri = format!("https://{}.quiknode.pro/{}", chain_subdomain, token);
+        let uri = format!("https://{chain_subdomain}.quiknode.pro/{token}");
 
         let hyper_request = hyper::http::Request::builder()
             .method(Method::POST)

--- a/src/providers/solscan.rs
+++ b/src/providers/solscan.rs
@@ -105,7 +105,7 @@ impl SolScanProvider {
 
     /// Construct the cache key for the pricing
     fn format_cache_pricing_key(&self, address: &str) -> String {
-        format!("solscan/pricing/{}", address)
+        format!("solscan/pricing/{address}")
     }
 
     #[allow(dependency_on_unit_never_type_fallback)]
@@ -270,7 +270,7 @@ impl SolScanProvider {
             });
         }
 
-        let caip10_address = format!("{}:{}", SOLANA_MAINNET_CHAIN_ID, address);
+        let caip10_address = format!("{SOLANA_MAINNET_CHAIN_ID}:{address}");
         match metadata_cache.get_metadata(&caip10_address).await {
             Ok(Some(metadata)) => {
                 return Ok(TokenMetaData {

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -114,9 +114,8 @@ impl TenderlyProvider {
         project_slug: String,
         redis_caching_pool: Option<Arc<Pool>>,
     ) -> Self {
-        let base_api_url = format!(
-            "https://api.tenderly.co/api/v1/account/{account_slug}/project/{project_slug}"
-        );
+        let base_api_url =
+            format!("https://api.tenderly.co/api/v1/account/{account_slug}/project/{project_slug}");
         let http_client = reqwest::Client::new();
         Self {
             provider_kind: ProviderKind::Tenderly,
@@ -151,9 +150,7 @@ impl TenderlyProvider {
         function_type: Option<Erc20FunctionType>,
     ) -> String {
         if let Some(function_type) = function_type {
-            return format!(
-                "tenderly/gas/{chain_id}/{contract_address}/{function_type:?}"
-            );
+            return format!("tenderly/gas/{chain_id}/{contract_address}/{function_type:?}");
         };
         format!("tenderly/gas/{chain_id}/{contract_address}")
     }

--- a/src/providers/tenderly.rs
+++ b/src/providers/tenderly.rs
@@ -115,8 +115,7 @@ impl TenderlyProvider {
         redis_caching_pool: Option<Arc<Pool>>,
     ) -> Self {
         let base_api_url = format!(
-            "https://api.tenderly.co/api/v1/account/{}/project/{}",
-            account_slug, project_slug
+            "https://api.tenderly.co/api/v1/account/{account_slug}/project/{project_slug}"
         );
         let http_client = reqwest::Client::new();
         Self {
@@ -153,11 +152,10 @@ impl TenderlyProvider {
     ) -> String {
         if let Some(function_type) = function_type {
             return format!(
-                "tenderly/gas/{}/{}/{:?}",
-                chain_id, contract_address, function_type
+                "tenderly/gas/{chain_id}/{contract_address}/{function_type:?}"
             );
         };
-        format!("tenderly/gas/{}/{}", chain_id, contract_address)
+        format!("tenderly/gas/{chain_id}/{contract_address}")
     }
 
     #[allow(dependency_on_unit_never_type_fallback)]

--- a/src/providers/therpc.rs
+++ b/src/providers/therpc.rs
@@ -51,7 +51,7 @@ impl RpcProvider for TheRpcProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let uri = format!("https://rpc.therpc.io/{}", chain);
+        let uri = format!("https://rpc.therpc.io/{chain}");
 
         let hyper_request = hyper::http::Request::builder()
             .method(Method::POST)

--- a/src/providers/weights.rs
+++ b/src/providers/weights.rs
@@ -24,24 +24,24 @@ pub fn parse_weights(prometheus_data: PromqlResult) -> ParsedWeights {
             let chain_id = if let Some(chain_id) = metric.remove("chain_id") {
                 ChainId(chain_id)
             } else {
-                warn!("No chain_id found in metric: {:?}", metric);
+                warn!("No chain_id found in metric: {metric:?}");
                 continue;
             };
 
             let Some(status_code) = metric.remove("status_code") else {
-                warn!("No status_code found in metric: {:?}", metric);
+                warn!("No status_code found in metric: {metric:?}");
                 continue;
             };
 
             let Some(provider) = metric.remove("provider") else {
-                warn!("No provider found in metric: {:?}", metric);
+                warn!("No provider found in metric: {metric:?}");
                 continue;
             };
 
             let provider_kind = match ProviderKind::from_str(&provider) {
                 Some(provider_kind) => provider_kind,
                 None => {
-                    warn!("Failed to parse provider kind in metric: {}", provider);
+                    warn!("Failed to parse provider kind in metric: {provider}");
                     continue;
                 }
             };
@@ -131,8 +131,7 @@ pub fn update_values(weight_resolver: &ChainsWeightResolver, parsed_weights: Par
 
             let Some(provider_chain_weight) = weight_resolver.get(&chain_id) else {
                 warn!(
-                    "Chain {} not found in weight resolver: {:?}",
-                    chain_id, weight_resolver
+                    "Chain {chain_id} not found in weight resolver: {weight_resolver:?}"
                 );
                 continue;
             };

--- a/src/providers/weights.rs
+++ b/src/providers/weights.rs
@@ -130,9 +130,7 @@ pub fn update_values(weight_resolver: &ChainsWeightResolver, parsed_weights: Par
             let chain_weight = calculate_chain_weight(chain_availability, provider_availability);
 
             let Some(provider_chain_weight) = weight_resolver.get(&chain_id) else {
-                warn!(
-                    "Chain {chain_id} not found in weight resolver: {weight_resolver:?}"
-                );
+                warn!("Chain {chain_id} not found in weight resolver: {weight_resolver:?}");
                 continue;
             };
 

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -251,7 +251,7 @@ impl HistoryProvider for ZerionProvider {
             &address
         );
         let mut url = Url::parse(&base).map_err(|e| {
-            error!("Error on parsing zerion history url with {}", e);
+            error!("Error on parsing zerion history url with {e}");
             RpcError::HistoryParseCursorError
         })?;
         url.query_pairs_mut()
@@ -268,7 +268,7 @@ impl HistoryProvider for ZerionProvider {
                 crypto::ChainId::from_caip2(&chain_id)
                     .ok_or(RpcError::InvalidParameter(chain_id))?
             } else {
-                crypto::ChainId::from_caip2(&format!("eip155:{}", chain_id))
+                crypto::ChainId::from_caip2(&format!("eip155:{chain_id}"))
                     .ok_or(RpcError::InvalidParameter(chain_id))?
             };
             url.query_pairs_mut()
@@ -278,8 +278,7 @@ impl HistoryProvider for ZerionProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
             error!(
-                "Error on request to zerion transactions history endpoint with {}",
-                e
+                "Error on request to zerion transactions history endpoint with {e}"
             );
             RpcError::TransactionProviderError
         })?;
@@ -302,13 +301,13 @@ impl HistoryProvider for ZerionProvider {
             .json::<ZerionResponseBody<Vec<ZerionTransactionsReponseBody>>>()
             .await
             .tap_err(|e| {
-                error!("Error on parsing zerion history body with {}", e);
+                error!("Error on parsing zerion history body with {e}");
             })?;
 
         let next: Option<String> = match body.links.next {
             Some(url) => {
                 let url = Url::parse(&url).map_err(|e| {
-                    error!("Error on parsing zerion history next url with {}", e);
+                    error!("Error on parsing zerion history next url with {e}");
                     RpcError::HistoryParseCursorError
                 })?;
                 // Get the "after" query parameter
@@ -419,7 +418,7 @@ impl PortfolioProvider for ZerionProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!("Error on request to zerion portfolio endpoint with {}", e);
+            error!("Error on request to zerion portfolio endpoint with {e}");
             RpcError::PortfolioProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -484,7 +483,7 @@ impl BalanceProvider for ZerionProvider {
                 crypto::ChainId::from_caip2(&chain_id)
                     .ok_or(RpcError::InvalidParameter(chain_id))?
             } else {
-                crypto::ChainId::from_caip2(&format!("eip155:{}", chain_id))
+                crypto::ChainId::from_caip2(&format!("eip155:{chain_id}"))
                     .ok_or(RpcError::InvalidParameter(chain_id))?
             };
             url.query_pairs_mut()
@@ -494,8 +493,7 @@ impl BalanceProvider for ZerionProvider {
         let latency_start = SystemTime::now();
         let response = self.send_request(url.clone()).await.map_err(|e| {
             error!(
-                "Error on request to zerion transactions history endpoint with {}",
-                e
+                "Error on request to zerion transactions history endpoint with {e}"
             );
             RpcError::BalanceProviderError
         })?;
@@ -553,7 +551,7 @@ impl BalanceProvider for ZerionProvider {
 
             // Update the token metadata from the cache or update the cache if it's not present
             if let Some(chain_id) = chain_id.clone() {
-                let caip10_token_address = format!("{}:{}", chain_id, token_address_strict);
+                let caip10_token_address = format!("{chain_id}:{token_address_strict}");
                 match metadata_cache.get_metadata(&caip10_token_address).await {
                     Ok(Some(cached_metadata)) => token_metadata = cached_metadata,
                     Ok(None) => {
@@ -565,13 +563,12 @@ impl BalanceProvider for ZerionProvider {
                                 .await
                             {
                                 error!(
-                                    "Error setting metadata in cache for {}: {}",
-                                    caip10_token_address, e
+                                    "Error setting metadata in cache for {caip10_token_address}: {e}"
                                 );
                             }
                         });
                     }
-                    Err(e) => error!("Error getting metadata from cache: {}", e),
+                    Err(e) => error!("Error getting metadata from cache: {e}"),
                 }
             }
 
@@ -587,7 +584,7 @@ impl BalanceProvider for ZerionProvider {
                         } else {
                             chain_id
                                 .as_ref()
-                                .map(|chain_id| format!("{}:{}", chain_id, addr))
+                                .map(|chain_id| format!("{chain_id}:{addr}"))
                         }
                     } else {
                         None

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -277,9 +277,7 @@ impl HistoryProvider for ZerionProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url).await.map_err(|e| {
-            error!(
-                "Error on request to zerion transactions history endpoint with {e}"
-            );
+            error!("Error on request to zerion transactions history endpoint with {e}");
             RpcError::TransactionProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(
@@ -492,9 +490,7 @@ impl BalanceProvider for ZerionProvider {
 
         let latency_start = SystemTime::now();
         let response = self.send_request(url.clone()).await.map_err(|e| {
-            error!(
-                "Error on request to zerion transactions history endpoint with {e}"
-            );
+            error!("Error on request to zerion transactions history endpoint with {e}");
             RpcError::BalanceProviderError
         })?;
         metrics.add_latency_and_status_code_for_provider(

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -297,9 +297,7 @@ pub fn decode_erc20_transfer_data(data: &[u8]) -> Result<(Address, AlloyU256), C
         ));
     }
     let transfer_params = transferCall::abi_decode(data, false).map_err(|err| {
-        CryptoUitlsError::Erc20DecodeError(format!(
-            "Failed to decode ERC20 transfer params: {err}"
-        ))
+        CryptoUitlsError::Erc20DecodeError(format!("Failed to decode ERC20 transfer params: {err}"))
     })?;
     Ok((transfer_params.to, transfer_params.value))
 }
@@ -372,9 +370,8 @@ fn get_rpc_url(
     source: MessageSource,
     session_id: Option<String>,
 ) -> Result<Url, CryptoUitlsError> {
-    let mut provider = Url::parse("https://rpc.walletconnect.org/v1").map_err(|e| {
-        CryptoUitlsError::RpcUrlParseError(format!("Failed to parse RPC url: {e}"))
-    })?;
+    let mut provider = Url::parse("https://rpc.walletconnect.org/v1")
+        .map_err(|e| CryptoUitlsError::RpcUrlParseError(format!("Failed to parse RPC url: {e}")))?;
     provider.query_pairs_mut().append_pair("chainId", chain_id);
     provider
         .query_pairs_mut()

--- a/src/utils/permissions.rs
+++ b/src/utils/permissions.rs
@@ -51,7 +51,7 @@ pub fn contract_call_permission_check(
         if address != call_address {
             error!("Execution address does not match the contract address in the permission data. Execution Address: {:?}, Contract Address: {:?}", address, call_address);
             return Err(RpcError::CosignerPermissionDenied(format!(
-              "Execution address does not match the contract address in the permission data. Execution Address: {:?}, Contract Address: {:?}", address, call_address
+              "Execution address does not match the contract address in the permission data. Execution Address: {address:?}, Contract Address: {call_address:?}"
           )));
         }
     }
@@ -71,8 +71,7 @@ pub fn native_token_transfer_permission_check(
             sum, allowance
         );
         return Err(RpcError::CosignerPermissionDenied(format!(
-            "Execution value is greater than the allowance. Execution Value: {:?}, Allowance: {:?}",
-            sum, allowance
+            "Execution value is greater than the allowance. Execution Value: {sum:?}, Allowance: {allowance:?}"
         )));
     }
 

--- a/src/utils/rate_limit.rs
+++ b/src/utils/rate_limit.rs
@@ -76,7 +76,7 @@ impl RateLimit {
     }
 
     fn format_key(&self, endpoint: &str, ip: &str) -> String {
-        format!("rate_limit:{}:{}", endpoint, ip)
+        format!("rate_limit:{endpoint}:{ip}")
     }
 
     /// Checks if the given endpoint, ip and project ID is rate limited

--- a/src/utils/sessions.rs
+++ b/src/utils/sessions.rs
@@ -26,9 +26,8 @@ pub fn extract_execution_batch_components(
     call_data_bytes: &[u8],
 ) -> Result<Vec<ExecutionTransaction>, RpcError> {
     // Decode the calldata into Safe7579::executeCall
-    let execute_call = Safe7579::executeCall::abi_decode(call_data_bytes, true).map_err(|e| {
-        RpcError::AbiDecodingError(format!("Failed to decode executeCall: {e:?}"))
-    })?;
+    let execute_call = Safe7579::executeCall::abi_decode(call_data_bytes, true)
+        .map_err(|e| RpcError::AbiDecodingError(format!("Failed to decode executeCall: {e:?}")))?;
 
     // Access the mode bytes directly
     let mode_bytes = &execute_call.mode;

--- a/src/utils/sessions.rs
+++ b/src/utils/sessions.rs
@@ -27,7 +27,7 @@ pub fn extract_execution_batch_components(
 ) -> Result<Vec<ExecutionTransaction>, RpcError> {
     // Decode the calldata into Safe7579::executeCall
     let execute_call = Safe7579::executeCall::abi_decode(call_data_bytes, true).map_err(|e| {
-        RpcError::AbiDecodingError(format!("Failed to decode executeCall: {:?}", e))
+        RpcError::AbiDecodingError(format!("Failed to decode executeCall: {e:?}"))
     })?;
 
     // Access the mode bytes directly
@@ -43,8 +43,7 @@ pub fn extract_execution_batch_components(
         let batch_transactions: Vec<(Address, U256, Bytes)> =
             BatchTransactionType::abi_decode(execution_calldata_bytes, true).map_err(|e| {
                 RpcError::AbiDecodingError(format!(
-                    "Failed to decode batch transactions ABI type: {:?}",
-                    e
+                    "Failed to decode batch transactions ABI type: {e:?}"
                 ))
             })?;
 

--- a/src/utils/simple_request_json.rs
+++ b/src/utils/simple_request_json.rs
@@ -167,8 +167,8 @@ mod tests {
         let mut json = serde_json::Map::new();
         for i in 0..1000 {
             json.insert(
-                format!("field{}", i),
-                serde_json::Value::String(format!("value{}", i)),
+                format!("field{i}"),
+                serde_json::Value::String(format!("value{i}")),
             );
         }
         let json = serde_json::Value::Object(json);

--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -56,7 +56,7 @@ async fn insert_and_get_name_by_name() {
     )
     .await;
     if let Err(ref e) = insert_result {
-        println!("Error: {:?}", e);
+        println!("Error: {e:?}");
     }
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
 
@@ -305,7 +305,7 @@ async fn insert_delete_two_addresses() {
     let delete_address_result = delete_address(
         name.clone(),
         types::SupportedNamespaces::Eip155,
-        format!("{}", chain_id),
+        format!("{chain_id}"),
         address.clone(),
         &pg_pool,
     )
@@ -319,7 +319,7 @@ async fn insert_delete_two_addresses() {
     let insert_address_result = insert_or_update_address(
         name.clone(),
         types::SupportedNamespaces::Eip155,
-        format!("{}", chain_id),
+        format!("{chain_id}"),
         new_address.clone(),
         &pg_pool,
     )
@@ -336,7 +336,7 @@ async fn insert_delete_two_addresses() {
     let delete_address_result = delete_address(
         name.clone(),
         types::SupportedNamespaces::Eip155,
-        format!("{}", chain_id),
+        format!("{chain_id}"),
         address,
         &pg_pool,
     )

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -57,7 +57,7 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
             // Check chainId
             assert_eq!(rpc_response.result::<String>().unwrap(), expected_id)
         }
-        _ => panic!("Unexpected status code: {}", status),
+        _ => panic!("Unexpected status code: {status}"),
     };
 }
 
@@ -96,7 +96,7 @@ async fn check_if_rpc_is_responding_correctly_for_near_protocol(
                 "mainnet"
             )
         }
-        _ => panic!("Unexpected status code: {}", status),
+        _ => panic!("Unexpected status code: {status}"),
     };
 }
 
@@ -119,7 +119,7 @@ async fn check_if_rpc_is_responding_correctly_for_solana(
     };
 
     let (status, rpc_response) =
-        send_jsonrpc_request(client, addr, &format!("solana:{}", chain_id), request).await;
+        send_jsonrpc_request(client, addr, &format!("solana:{chain_id}"), request).await;
 
     // Verify that HTTP communication was successful
     assert_eq!(status, StatusCode::OK);
@@ -151,7 +151,7 @@ async fn check_if_rpc_is_responding_correctly_for_sui(
     };
 
     let (status, rpc_response) =
-        send_jsonrpc_request(client, addr, &format!("sui:{}", chain_id), request).await;
+        send_jsonrpc_request(client, addr, &format!("sui:{chain_id}"), request).await;
 
     // Verify that HTTP communication was successful
     assert_eq!(status, StatusCode::OK);
@@ -182,7 +182,7 @@ async fn check_if_rpc_is_responding_correctly_for_bitcoin(
     };
 
     let (status, rpc_response) =
-        send_jsonrpc_request(client, addr, &format!("bip122:{}", chain_id), request).await;
+        send_jsonrpc_request(client, addr, &format!("bip122:{chain_id}"), request).await;
 
     // Verify that HTTP communication was successful
     assert_eq!(status, StatusCode::OK);


### PR DESCRIPTION
# Description

This PR fixes `cargo clippy` errors due to the Rust version upgrade.
These changes are related to the `format!` macro that throws a warning if variables are used outside.

## How Has This Been Tested?

* Local `cargo clippy` should pass after the Rust version update to the latest,
* CI clippy check should pass.
## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
