### PR TITLE
fix(Pokt): handling node internal Go error

### DIFF
--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -87,6 +87,13 @@ impl RpcProvider for PoktProvider {
                 if error.code == -32603 {
                     return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
                 }
+                // Check if the error message is a Go node internal unmarshal error
+                if error
+                    .message
+                    .contains("cannot unmarshal array into Go value")
+                {
+                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+                }
             }
         }
 


### PR DESCRIPTION
# Description

This PR fixes the handling of the Pokt node internal Go error, considering it as an `HTTP 500 error response` and failing over to other providers instead of forwarding it to the client.

## How Has This Been Tested?

Manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
