### PR TITLE
fix: reverting #1131 and add only unmarshalling error catching

### DIFF
--- a/src/providers/allnodes.rs
+++ b/src/providers/allnodes.rs
@@ -1,7 +1,7 @@
 use {
     super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory, RpcQueryParams, RpcWsProvider, WS_PROXY_TASK_METRICS,
+        Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams,
+        RpcWsProvider, WS_PROXY_TASK_METRICS,
     },
     crate::{
         env::AllnodesConfig,
@@ -14,7 +14,7 @@ use {
         response::{IntoResponse, Response},
     },
     axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -127,16 +127,11 @@ impl RpcProvider for AllnodesProvider {
         let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if let Some(error) = &response.error {
-                if status.is_success() {
-                    debug!(
-                        "Strange: provider returned JSON RPC error, but status {status} is success: \
-                     Allnodes: {response:?}"
-                    );
-                }
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Allnodes: {response:?}"
+                );
             }
         }
 

--- a/src/providers/arbitrum.rs
+++ b/src/providers/arbitrum.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::ArbitrumConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for ArbitrumProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  Arbitrum: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/aurora.rs
+++ b/src/providers/aurora.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::AuroraConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -73,11 +70,6 @@ impl RpcProvider for AuroraProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      Aurora: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::BaseConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -73,11 +70,6 @@ impl RpcProvider for BaseProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      Base: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::BinanceConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -73,11 +70,6 @@ impl RpcProvider for BinanceProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      Binance: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/blast.rs
+++ b/src/providers/blast.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::BlastConfig,
         error::{RpcError, RpcResult},
@@ -73,11 +70,6 @@ impl RpcProvider for BlastProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                Blast: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/callstatic.rs
+++ b/src/providers/callstatic.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::CallStaticConfig,
         error::{RpcError, RpcResult},
@@ -73,11 +70,6 @@ impl RpcProvider for CallStaticProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  CallStatic: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/drpc.rs
+++ b/src/providers/drpc.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::DrpcConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for DrpcProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  dRPC: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/mantle.rs
+++ b/src/providers/mantle.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::MantleConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for MantleProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      Mantle public RPC: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1219,10 +1219,3 @@ pub trait TokenMetadataCacheProvider: Send + Sync {
         item: &TokenMetadataCacheItem,
     ) -> Result<(), RpcError>;
 }
-
-/// Check if a JSON-RPC error code indicates a server error
-/// according to the JSON-RPC 2.0 specification
-/// https://www.jsonrpc.org/specification#error_object
-pub fn is_internal_error_code(error_code: i32) -> bool {
-    (-32099..=-32000).contains(&error_code)
-}

--- a/src/providers/monad.rs
+++ b/src/providers/monad.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::MonadConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for MonadProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  Monad: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/moonbeam.rs
+++ b/src/providers/moonbeam.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::MoonbeamConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -73,11 +70,6 @@ impl RpcProvider for MoonbeamProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      Moonbeam: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::MorphConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -72,11 +69,6 @@ impl RpcProvider for MorphProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  Morph: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -87,6 +87,13 @@ impl RpcProvider for PoktProvider {
                 if error.code == -32603 {
                     return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
                 }
+                // Check if the error message is a Go node internal unmarshal error
+                if error
+                    .message
+                    .contains("cannot unmarshal array into Go value")
+                {
+                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+                }
             }
         }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::PoktConfig,
         error::{RpcError, RpcResult},
@@ -82,12 +79,12 @@ impl RpcProvider for PoktProvider {
                          success: Pokt: {response:?}"
                     );
                 }
-                // Handling the custom Pokt rate limited error codes
+                // Handling the custom rate limit error
                 // https://github.com/pokt-foundation/portal-api/blob/a53c4952944041ba2749178907397963d7254baa/src/controllers/v1.controller.ts#L348
                 if error.code == -32004 || error.code == -32068 {
                     return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response());
                 }
-                if is_internal_error_code(error.code) {
+                if error.code == -32603 {
                     return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
                 }
             }

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::PublicnodeConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -72,11 +69,6 @@ impl RpcProvider for PublicnodeProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      PublicNode: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::QuicknodeConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -83,11 +80,6 @@ impl RpcProvider for QuicknodeProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      Quicknode: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/therpc.rs
+++ b/src/providers/therpc.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::TheRpcConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -68,18 +65,15 @@ impl RpcProvider for TheRpcProvider {
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if let Some(error) = &response.error {
+                // Handling the custom rate limit error
+                if error.code == -32029 {
+                    return Ok((http::StatusCode::TOO_MANY_REQUESTS, body).into_response());
+                }
                 if status.is_success() {
                     debug!(
                         "Strange: provider returned JSON RPC error, but status {status} is \
                          success: Pokt: {response:?}"
                     );
-                }
-                // Handling the custom rate limited error code
-                if error.code == -32029 {
-                    return Ok((http::StatusCode::TOO_MANY_REQUESTS, body).into_response());
-                }
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
                 }
             }
         }

--- a/src/providers/unichain.rs
+++ b/src/providers/unichain.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::UnichainConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for UnichainProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  Unichain: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/wemix.rs
+++ b/src/providers/wemix.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::WemixConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for WemixProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                  Wemix: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        is_internal_error_code, Provider, ProviderKind, RateLimited, RpcProvider,
-        RpcProviderFactory,
-    },
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::ZKSyncConfig,
         error::{RpcError, RpcResult},
@@ -12,7 +9,7 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::debug,
@@ -70,11 +67,6 @@ impl RpcProvider for ZKSyncProvider {
                     "Strange: provider returned JSON RPC error, but status {status} is success: \
                      zkSync: {response:?}"
                 );
-            }
-            if let Some(error) = &response.error {
-                if is_internal_error_code(error.code) {
-                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-                }
             }
         }
 


### PR DESCRIPTION
# Description

This PR reverts #1131 and adds only catching the unmarshalling Go error message in Pokt as a temporarily solution.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
