### PR TITLE
feat(balance): respond with an empty array if no origin provided

### DIFF
--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -152,6 +152,16 @@ async fn handler_internal(
         }
     }
 
+    // Check if `origin`` is empty and return empty balance response in this case
+    let origin = headers
+        .get("origin")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if origin.is_empty() {
+        debug!("Origin is empty, returning empty balance response");
+        return Ok(Json(BalanceResponseBody { balances: vec![] }));
+    }
+
     state.validate_project_access_and_quota(&project_id).await?;
 
     // if headers not contains `x-sdk-version` and `sv` query parameter then respond

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -152,7 +152,7 @@ async fn handler_internal(
         }
     }
 
-    // Check if `origin`` is empty and return empty balance response in this case
+    // Check if `origin` is empty and return empty balance response in this case
     let origin = headers
         .get("origin")
         .and_then(|v| v.to_str().ok())


### PR DESCRIPTION
# Description

This PR adds a change to the `/v1/account/{address}` balance endpoint to respond with an empty array if no `origin` header was provided.

## How Has This Been Tested?

* Current integration tests were updated,
* A specific test was added to test an empty response without an origin provided.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
