### PR TITLE
fix(o11y): fixing swap endpoints availability chart

### DIFF
--- a/terraform/monitoring/panels/swaps/availability.libsonnet
+++ b/terraform/monitoring/panels/swaps/availability.libsonnet
@@ -43,13 +43,14 @@ local error_alert(vars) = alert.new(
           axisSoftMin = 98,
           axisSoftMax = 100,
         )
+        .withSpanNulls(true)
     )
     .setAlert(vars.environment, error_alert(vars))
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/tokens"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/tokens"}[$__rate_interval]))))*100',
-      refId         = 'swaps_availability',
+      refId         = 'swaps_tokens_availability',
       exemplar      = false,
       legendFormat  = 'Tokens list',
     ))
@@ -57,7 +58,7 @@ local error_alert(vars) = alert.new(
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/quotes"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/quotes"}[$__rate_interval]))))*100',
-      refId         = 'swaps_availability',
+      refId         = 'swaps_quotes_availability',
       exemplar      = false,
       legendFormat  = 'Quotes',
     ))
@@ -65,7 +66,7 @@ local error_alert(vars) = alert.new(
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/build-approve"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-approve"}[$__rate_interval]))))*100',
-      refId         = 'swaps_availability',
+      refId         = 'swaps_build_approve_availability',
       exemplar      = false,
       legendFormat  = 'Build approve',
     ))
@@ -73,7 +74,7 @@ local error_alert(vars) = alert.new(
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/build-transaction"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-transaction"}[$__rate_interval]))))*100',
-      refId         = 'swaps_availability',
+      refId         = 'swaps_build_transaction_availability',
       exemplar      = false,
       legendFormat  = 'Build transaction',
     ))
@@ -81,7 +82,7 @@ local error_alert(vars) = alert.new(
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/gas-price"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-transaction"}[$__rate_interval]))))*100',
-      refId         = 'swaps_availability',
+      refId         = 'swaps_gas_price_availability',
       exemplar      = false,
       legendFormat  = 'Gas price',
     ))
@@ -89,8 +90,18 @@ local error_alert(vars) = alert.new(
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/allowance"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/allowance"}[$__rate_interval]))))*100',
-      refId         = 'swaps_availability',
+      refId         = 'swaps_allowance_availability',
       exemplar      = false,
       legendFormat  = 'Allowance check',
+    ))
+
+    // Hidden target for overall swaps availability alert
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route=~"/v1/convert/(tokens|quotes|build-approve|build-transaction|gas-price|allowance)"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route=~"/v1/convert/(tokens|quotes|build-approve|build-transaction|gas-price|allowance)"}[$__rate_interval]))))*100',
+      refId         = 'swaps_availability',
+      exemplar      = false,
+      legendFormat  = 'Overall availability',
+      hide          = true,
     ))
 }

--- a/terraform/monitoring/panels/swaps/availability.libsonnet
+++ b/terraform/monitoring/panels/swaps/availability.libsonnet
@@ -81,7 +81,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/gas-price"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/build-transaction"}[$__rate_interval]))))*100',
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/convert/gas-price"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/convert/gas-price"}[$__rate_interval]))))*100',
       refId         = 'swaps_gas_price_availability',
       exemplar      = false,
       legendFormat  = 'Gas price',


### PR DESCRIPTION
# Description

This PR fixes the Swap endpoints availability chart and alert by adding proper `refId`s. 
The same `refId` was reused, which caused calculation issues. Also, there was no summary availability query.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
