### PR TITLE
feat(Pokt): making an exclusion for the weight recalculation and update the alert

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -175,6 +175,11 @@ static WS_PROXY_TASK_METRICS: TaskMetrics = TaskMetrics::new("ws_proxy_task");
 pub type ChainsWeightResolver = HashMap<String, HashMap<ProviderKind, Weight>>;
 pub type NamespacesWeightResolver = HashMap<CaipNamespaces, HashMap<ProviderKind, Weight>>;
 
+/// Providers that are excluded from weight recalculation due to temporary issues
+/// or special handling requirements. These providers will maintain their current
+/// weights regardless of failure metrics from Prometheus.
+pub const WEIGHT_RECALCULATION_EXCLUDED_PROVIDERS: &[ProviderKind] = &[ProviderKind::Pokt];
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
 pub struct ProvidersConfig {
     pub prometheus_query_url: Option<String>,

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -38,6 +38,7 @@ local pos_short       = grafana.layout.pos(6);
 
 // RPC provider specific alert period and availability depend on the provider tier
 local availability_top_tier = 90; // Expecting minimal 90% success responses
+local availability_mid_tier = 75; // 75% success responses
 local availability_free_tier = 25; // Expecting minimal 25% success rate
 // alert period for the success rate from above
 local alert_period_top_tier = '5m';
@@ -76,7 +77,7 @@ dashboard.new(
 
   row.new('RPC Proxy Chain Usage'),
     // Top-tier providers
-    panels.usage.provider(ds, vars, 'Pokt', alert_period_top_tier, availability_top_tier)        { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Pokt', alert_period_top_tier, availability_mid_tier)        { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Quicknode', alert_period_top_tier, availability_top_tier)   { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Allnodes', alert_period_top_tier, availability_top_tier)    { gridPos: pos._4 },
     // Free providers


### PR DESCRIPTION
# Description

This PR implements the provider's exclusion list for cases where we want the provider to keep its routing weight even with some part of the errors. The Pokt provider was added for the exclusion.
The alert for the Pokt availability is decreased from 90% to 75%.

## How Has This Been Tested?

Manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
