### PR TITLE
fix(RPC): fixing the check for server error codes

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -10,7 +10,7 @@ use {
     axum::{
         body::Bytes,
         extract::{ConnectInfo, Query, State},
-        response::Response,
+        response::{IntoResponse, Response},
     },
     hyper::{http, HeaderMap},
     std::{
@@ -161,30 +161,46 @@ pub async fn rpc_call(
 
         match response {
             Ok(response) if !response.status().is_server_error() => {
-                // Check for internal error codes range
-                // -32000 to -32099 in response and write to metrics
+                let status = response.status();
+                let body_bytes = match hyper::body::to_bytes(response.into_body()).await {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!("Failed to read response body: {e}");
+                        continue;
+                    }
+                };
+
+                // Check for possible internal error codes range -32000..-32099
+                // if the response is successful
+                // and bytes contains the "error" field
                 // https://www.jsonrpc.org/specification#error_object
-                if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-                    if let Some(error) = &response.error {
-                        if is_internal_error_rpc_code(error.code) {
-                            state.metrics.add_internal_error_code_for_provider(
-                                provider.provider_kind(),
-                                chain_id.clone(),
-                                error.code,
-                            );
+                if status.is_success() && crypto::contains_bytes(&body_bytes, b"\"error\"") {
+                    if let Ok(json_response) =
+                        serde_json::from_slice::<jsonrpc::Response>(&body_bytes)
+                    {
+                        if let Some(error) = &json_response.error {
+                            if is_internal_error_rpc_code(error.code) {
+                                state.metrics.add_internal_error_code_for_provider(
+                                    provider.provider_kind(),
+                                    chain_id.clone(),
+                                    error.code,
+                                );
+                            }
                         }
                     }
                 }
                 state
                     .metrics
                     .add_found_provider_for_chain(chain_id.clone(), &provider.provider_kind());
+
                 // Record successful chain latency for the provider that succeeded
                 state.metrics.add_chain_latency(
                     &provider.provider_kind(),
                     chain_request_start,
                     chain_id.clone(),
                 );
-                return Ok(response);
+
+                return Ok((status, body_bytes).into_response());
             }
             e => {
                 state

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -165,32 +165,43 @@ pub async fn rpc_call(
                 let body_bytes = match hyper::body::to_bytes(response.into_body()).await {
                     Ok(bytes) => bytes,
                     Err(e) => {
-                        error!("Failed to read response body: {e}");
+                        error!("Failed to read JSON-RPC response body from provider {{provider.provider_kind()}}: {e}");
+                        state
+                            .metrics
+                            .add_rpc_call_retries(i as u64, chain_id.clone());
                         continue;
                     }
                 };
 
-                // Check for possible internal error codes range -32000..-32099
-                // if the response is successful
-                // and bytes contains the "error" field
-                // https://www.jsonrpc.org/specification#error_object
-                if (status.is_success() || status == http::StatusCode::BAD_REQUEST)
-                    && crypto::contains_bytes(&body_bytes, b"\"error\"")
-                {
-                    if let Ok(json_response) =
-                        serde_json::from_slice::<jsonrpc::Response>(&body_bytes)
-                    {
+                match serde_json::from_slice::<jsonrpc::Response>(&body_bytes) {
+                    Ok(json_response) => {
                         if let Some(error) = &json_response.error {
+                            // Check for possible internal error codes range -32000..-32099
+                            // if the response is successful
+                            // and bytes contains the "error" field
+                            // https://www.jsonrpc.org/specification#error_object
                             if is_internal_error_rpc_code(error.code) {
                                 state.metrics.add_internal_error_code_for_provider(
                                     provider.provider_kind(),
                                     chain_id.clone(),
                                     error.code,
                                 );
+                                state
+                                    .metrics
+                                    .add_rpc_call_retries(i as u64, chain_id.clone());
+                                continue;
                             }
                         }
                     }
+                    Err(e) => {
+                        error!("Failed to parse JSON-RPC response from provider {{provider.provider_kind()}}: {e}");
+                        state
+                            .metrics
+                            .add_rpc_call_retries(i as u64, chain_id.clone());
+                        continue;
+                    }
                 }
+
                 state
                     .metrics
                     .add_found_provider_for_chain(chain_id.clone(), &provider.provider_kind());

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -174,7 +174,9 @@ pub async fn rpc_call(
                 // if the response is successful
                 // and bytes contains the "error" field
                 // https://www.jsonrpc.org/specification#error_object
-                if status.is_success() && crypto::contains_bytes(&body_bytes, b"\"error\"") {
+                if (status.is_success() || status == http::StatusCode::BAD_REQUEST)
+                    && crypto::contains_bytes(&body_bytes, b"\"error\"")
+                {
                     if let Ok(json_response) =
                         serde_json::from_slice::<jsonrpc::Response>(&body_bytes)
                     {

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -1143,6 +1143,11 @@ pub fn convert_alloy_address_to_h160(addr: Address) -> H160 {
     H160::from_slice(bytes)
 }
 
+/// Check if the body contains the pattern using the quick bytes window scroll
+pub fn contains_bytes(body: &[u8], pattern: &[u8]) -> bool {
+    body.windows(pattern.len()).any(|window| window == pattern)
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -1593,5 +1598,12 @@ mod tests {
         // Invalid reference (special characters)
         let invalid_reference = "eip155:1/2";
         assert!(Caip2ChainId::parse(invalid_reference).is_err());
+    }
+
+    #[test]
+    fn test_contains_bytes() {
+        let body = b"say hello world";
+        let pattern = b"hello";
+        assert!(contains_bytes(body, pattern));
     }
 }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -1143,11 +1143,6 @@ pub fn convert_alloy_address_to_h160(addr: Address) -> H160 {
     H160::from_slice(bytes)
 }
 
-/// Check if the body contains the pattern using the quick bytes window scroll
-pub fn contains_bytes(body: &[u8], pattern: &[u8]) -> bool {
-    body.windows(pattern.len()).any(|window| window == pattern)
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -1598,12 +1593,5 @@ mod tests {
         // Invalid reference (special characters)
         let invalid_reference = "eip155:1/2";
         assert!(Caip2ChainId::parse(invalid_reference).is_err());
-    }
-
-    #[test]
-    fn test_contains_bytes() {
-        let body = b"say hello world";
-        let pattern = b"hello";
-        assert!(contains_bytes(body, pattern));
     }
 }


### PR DESCRIPTION
# Description

This PR fixes the check for the presence of server error codes in the JSON-RPC provider response. The current implementation has a bug that uses the `body` variable for the deserialization and a search, which is actually a request body. That results in no data for the metrics, since the pattern never matches.
Additional optimization was added due to the required deserialization for each response. We should make a deserialization only when there is an `"error"` inside the body of the bytes to avoid deserializing every response. 
The `contains_bytes` util function was created to quickly search the pattern through the bytes by using a window scrolling (the fastest way to search).

## How Has This Been Tested?

Unit test was added.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
