### PR TITLE
feat(RPC): extending the Quicknode provider to Solana WSS support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,9 @@ use {
         BinanceProvider, BlastProvider, CallStaticProvider, DrpcProvider, DuneProvider,
         HiroProvider, MantleProvider, MonadProvider, MoonbeamProvider, MorphProvider, NearProvider,
         OdysseyProvider, PoktProvider, ProviderRepository, PublicnodeProvider, QuicknodeProvider,
-        RootstockProvider, SolScanProvider, SuiProvider, SyndicaProvider, SyndicaWsProvider,
-        TheRpcProvider, UnichainProvider, WemixProvider, ZKSyncProvider, ZerionProvider,
-        ZoraProvider, ZoraWsProvider,
+        QuicknodeWsProvider, RootstockProvider, SolScanProvider, SuiProvider, SyndicaProvider,
+        SyndicaWsProvider, TheRpcProvider, UnichainProvider, WemixProvider, ZKSyncProvider,
+        ZerionProvider, ZoraProvider, ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -552,12 +552,16 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     ));
     providers.add_rpc_provider::<MoonbeamProvider, MoonbeamConfig>(MoonbeamConfig::default());
     providers.add_rpc_provider::<TheRpcProvider, TheRpcConfig>(TheRpcConfig::default());
+
     providers.add_ws_provider::<AllnodesWsProvider, AllnodesConfig>(AllnodesConfig::new(
         config.allnodes_api_key.clone(),
     ));
     providers.add_ws_provider::<ZoraWsProvider, ZoraConfig>(ZoraConfig::default());
     providers.add_ws_provider::<SyndicaWsProvider, SyndicaConfig>(SyndicaConfig::new(
         config.syndica_api_key.clone(),
+    ));
+    providers.add_ws_provider::<QuicknodeWsProvider, QuicknodeConfig>(QuicknodeConfig::new(
+        config.quicknode_api_tokens.clone(),
     ));
 
     providers.add_balance_provider::<ZerionProvider, ZerionConfig>(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -156,7 +156,7 @@ pub use {
     pimlico::PimlicoProvider,
     pokt::PoktProvider,
     publicnode::PublicnodeProvider,
-    quicknode::QuicknodeProvider,
+    quicknode::{QuicknodeProvider, QuicknodeWsProvider},
     rootstock::RootstockProvider,
     solscan::SolScanProvider,
     sui::SuiProvider,

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -45,10 +45,7 @@ impl Provider for QuicknodeProvider {
 
 #[async_trait]
 impl RateLimited for QuicknodeProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool
-    where
-        Self: Sized,
-    {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
         response.status() == http::StatusCode::TOO_MANY_REQUESTS
     }
 }
@@ -179,10 +176,7 @@ impl RpcWsProvider for QuicknodeWsProvider {
 
 #[async_trait]
 impl RateLimited for QuicknodeWsProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool
-    where
-        Self: Sized,
-    {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
         response.status() == http::StatusCode::TOO_MANY_REQUESTS
     }
 }


### PR DESCRIPTION
# Description

This PR extends the Quicknode provider to support Solana WebSocket on Mainnet, Devnet, and Testnet.

## How Has This Been Tested?

Manually tested and integration tests should pass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
