### PR TITLE
fix(exchanges): passing an error into the internal server error message

### DIFF
--- a/src/handlers/wallet/get_exchange_buy_status.rs
+++ b/src/handlers/wallet/get_exchange_buy_status.rs
@@ -123,9 +123,9 @@ async fn handler_internal(
                     exchange_id = %request.exchange_id,
                     "Internal error, unable to get exchange buy status"
                 );
-                Err(GetExchangeBuyStatusError::InternalError(
-                    "Unable to get exchange buy status".to_string(),
-                ))
+                Err(GetExchangeBuyStatusError::InternalError(format!(
+                    "Unable to get exchange buy status: {e:?}"
+                )))
             }
         },
     }

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -154,9 +154,9 @@ async fn handler_internal(
                     error = %e,
                     "Internal error, unable to get exchange URL"
                 );
-                Err(GetExchangeUrlError::InternalError(
-                    "Unable to get exchange URL".to_string(),
-                ))
+                Err(GetExchangeUrlError::InternalError(format!(
+                    "Unable to get exchange URL: {e:?}"
+                )))
             }
         },
     }


### PR DESCRIPTION
# Description

This PR changes to pass an error into the internal error message for logging at the production and for better debugging, since it's not logging at the production at the current state.

## How Has This Been Tested?

Tested locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
