### PR TITLE
feat: removing a repository OFAC variable usage in favor of the terraform cloud

### DIFF
--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -39,8 +39,6 @@ jobs:
       task-name: ${{ vars.TASK_NAME }}
       stage: staging
       stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.org/health
-      tf-variables: |
-        ofac_blocked_countries: ${{ vars.OFAC_BLOCKED_ZONES }}
       aws-role-arn: ${{ vars.AWS_ROLE_STAGING }}
 
   validate-staging:
@@ -65,8 +63,6 @@ jobs:
       task-name: ${{ vars.TASK_NAME }}
       stage: prod
       stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.org/health
-      tf-variables: |
-        ofac_blocked_countries: ${{ vars.OFAC_BLOCKED_ZONES }}
       aws-role-arn: ${{ vars.AWS_ROLE_PROD }}
 
   validate-prod:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,7 +48,7 @@ To authenticate, run `terraform login` and follow the instructions.
 | <a name="input_infura_project_id"></a> [infura\_project\_id](#input\_infura\_project\_id) | The project ID for Infura |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Defines logging level for the application |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The notification channels to send alerts to |  <pre lang="json">list(any)</pre> |  <pre lang="json">[]</pre> |  no |
-| <a name="input_ofac_blocked_countries"></a> [ofac\_blocked\_countries](#input\_ofac\_blocked\_countries) | The list of countries to block |  <pre lang="json">string</pre> |  <pre lang="json">""</pre> |  no |
+| <a name="input_ofac_countries"></a> [ofac\_blocked\_countries](#input\_ofac\_blocked\_countries) | The list of countries to block |  <pre lang="json">string</pre> |  <pre lang="json">""</pre> |  no |
 | <a name="input_pokt_project_id"></a> [pokt\_project\_id](#input\_pokt\_project\_id) | The project ID for POKT |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_project_cache_ttl"></a> [project\_cache\_ttl](#input\_project\_cache\_ttl) | The TTL for project data cache |  <pre lang="json">number</pre> |  <pre lang="json">300</pre> |  no |
 | <a name="input_registry_api_auth_token"></a> [registry\_api\_auth\_token](#input\_registry\_api\_auth\_token) | The auth token for the registry API |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |

--- a/terraform/ecs/README.md
+++ b/terraform/ecs/README.md
@@ -51,7 +51,7 @@ This module creates an ECS cluster and an autoscaling group of EC2 instances to 
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | The version of the app image to deploy |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_infura_project_id"></a> [infura\_project\_id](#input\_infura\_project\_id) | The project ID for Infura |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | The log level for the app |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
-| <a name="input_ofac_blocked_countries"></a> [ofac\_blocked\_countries](#input\_ofac\_blocked\_countries) | The list of countries under OFAC sanctions |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
+| <a name="input_ofac_countries"></a> [ofac\_blocked\_countries](#input\_ofac\_blocked\_countries) | The list of countries under OFAC sanctions |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_pokt_project_id"></a> [pokt\_project\_id](#input\_pokt\_project\_id) | The project ID for POKT |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_port"></a> [port](#input\_port) | The port the app listens on |  <pre lang="json">number</pre> |  <pre lang="json">n/a</pre> |  yes |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | The IDs of the private subnets |  <pre lang="json">list(string)</pre> |  <pre lang="json">n/a</pre> |  yes |

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -84,7 +84,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_GEOIP_DB_KEY", value = var.geoip_db_key },
         { name = "RPC_PROXY_TESTING_PROJECT_ID", value = var.testing_project_id },
 
-        { name = "RPC_PROXY_BLOCKED_COUNTRIES", value = var.ofac_blocked_countries },
+        { name = "RPC_PROXY_BLOCKED_COUNTRIES", value = var.ofac_countries },
 
         { name = "RPC_PROXY_PROVIDER_POKT_PROJECT_ID", value = var.pokt_project_id },
         { name = "RPC_PROXY_PROVIDER_QUICKNODE_API_TOKENS", value = var.quicknode_api_tokens },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -151,7 +151,7 @@ variable "provider_cache_endpoint" {
   type        = string
 }
 
-variable "ofac_blocked_countries" {
+variable "ofac_countries" {
   description = "The list of countries under OFAC sanctions"
   type        = string
 }

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -59,7 +59,7 @@ module "ecs" {
   rate_limiting_cache_endpoint_read  = module.redis.endpoint
   rate_limiting_cache_endpoint_write = module.redis.endpoint
   provider_cache_endpoint            = module.redis.endpoint
-  ofac_blocked_countries             = var.ofac_blocked_countries
+  ofac_countries                     = var.ofac_countries
   postgres_url                       = module.postgres.database_url
 
   # Providers

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,7 +50,7 @@ variable "app_autoscaling_max_capacity" {
   default     = 10
 }
 
-variable "ofac_blocked_countries" {
+variable "ofac_countries" {
   description = "The list of countries to block"
   type        = string
   default     = ""


### PR DESCRIPTION
# Description

This PR removes the repository ofac variable usage in favor of using the `ofac_countries` terraform cloud variable.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
