### PR TITLE
feat(OnRamp): adding an `excludeProviders` filter for quotes

### DIFF
--- a/src/handlers/onramp/multi_quotes.rs
+++ b/src/handlers/onramp/multi_quotes.rs
@@ -81,11 +81,12 @@ async fn handler_internal(
     // If exclude_providers is provided, remove the providers from the quotes
     // since there is no way to exclude providers in the multi provider API
     if let Some(exclude_providers) = exclude_providers {
+        let exclude_set: std::collections::HashSet<_> = exclude_providers.into_iter().collect();
         quotes.retain(|quote| {
             !quote
                 .service_provider
                 .as_ref()
-                .is_some_and(|provider| exclude_providers.contains(provider))
+                .is_some_and(|provider| exclude_set.contains(provider))
         });
     }
 

--- a/src/handlers/onramp/multi_quotes.rs
+++ b/src/handlers/onramp/multi_quotes.rs
@@ -25,6 +25,7 @@ pub struct QueryParams {
     pub source_amount: f64,
     pub source_currency_code: String,
     pub wallet_address: Option<String>,
+    pub exclude_providers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -67,7 +68,8 @@ async fn handler_internal(
         .validate_project_access_and_quota(&request_payload.project_id)
         .await?;
 
-    let quotes = state
+    let exclude_providers = request_payload.exclude_providers.clone();
+    let mut quotes = state
         .providers
         .onramp_multi_provider
         .get_quotes(request_payload, state.metrics.clone())
@@ -75,6 +77,17 @@ async fn handler_internal(
         .tap_err(|e| {
             error!("Failed to call onramp multi providers quotes with {e}");
         })?;
+
+    // If exclude_providers is provided, remove the providers from the quotes
+    // since there is no way to exclude providers in the multi provider API
+    if let Some(exclude_providers) = exclude_providers {
+        quotes.retain(|quote| {
+            !quote
+                .service_provider
+                .as_ref()
+                .is_some_and(|provider| exclude_providers.contains(provider))
+        });
+    }
 
     Ok(Json(quotes).into_response())
 }


### PR DESCRIPTION
# Description

This PR adds a new `excludeProviders` optional query parameter for quotes to exclude providers from the quotes list, since the Meld API doesn't have this type of filtering.

## How Has This Been Tested?

Manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
