### PR TITLE
feat(proxy): adding an error check only when the response is success and debugging message

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -173,32 +173,37 @@ pub async fn rpc_call(
                     }
                 };
 
-                match serde_json::from_slice::<jsonrpc::Response>(&body_bytes) {
-                    Ok(json_response) => {
-                        if let Some(error) = &json_response.error {
-                            // Check for possible internal error codes range -32000..-32099
-                            // if the response is successful
-                            // and bytes contains the "error" field
-                            // https://www.jsonrpc.org/specification#error_object
-                            if is_internal_error_rpc_code(error.code) {
-                                state.metrics.add_internal_error_code_for_provider(
-                                    provider.provider_kind(),
-                                    chain_id.clone(),
-                                    error.code,
-                                );
-                                state
-                                    .metrics
-                                    .add_rpc_call_retries(i as u64, chain_id.clone());
-                                continue;
+                // Check the JSON-RPC response schema and possible internal error codes
+                // if the status is success and error is present
+                if status.is_success() {
+                    match serde_json::from_slice::<jsonrpc::Response>(&body_bytes) {
+                        Ok(json_response) => {
+                            if let Some(error) = &json_response.error {
+                                // Check for possible unhandled internal error codes range -32000..-32099
+                                // https://www.jsonrpc.org/specification#error_object
+                                let error_code = error.code;
+                                let error_message = error.message.clone();
+                                if is_internal_error_rpc_code(error_code) {
+                                    error!("Provider {{provider.provider_kind()}} returned an internal error code: {error_code} and the message: {error_message}");
+                                    state.metrics.add_internal_error_code_for_provider(
+                                        provider.provider_kind(),
+                                        chain_id.clone(),
+                                        error.code,
+                                    );
+                                    state
+                                        .metrics
+                                        .add_rpc_call_retries(i as u64, chain_id.clone());
+                                    continue;
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        error!("Failed to parse JSON-RPC response from provider {{provider.provider_kind()}}: {e}");
-                        state
-                            .metrics
-                            .add_rpc_call_retries(i as u64, chain_id.clone());
-                        continue;
+                        Err(e) => {
+                            error!("Failed to parse JSON-RPC response from provider {{provider.provider_kind()}}: {e}");
+                            state
+                                .metrics
+                                .add_rpc_call_retries(i as u64, chain_id.clone());
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description

This PR adds a response deserialization check only when the response is successful, because there is no reason to check the schema and the error in case of unsuccessful responses. Adding error message logging for unhandled error codes.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
