### PR TITLE
fix(proxy): extending known RPC errors list, debug only on unexpected JSON-RPC schema

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -229,11 +229,7 @@ pub async fn rpc_call(
                     }
                 }
                 Err(e) => {
-                    error!("Failed to parse JSON-RPC response from provider {{provider.provider_kind()}}: {e}");
-                    state
-                        .metrics
-                        .add_rpc_call_retries(i as u64, chain_id.clone());
-                    continue;
+                    error!("Failed to parse JSON-RPC response from provider {provider_kind}: {e}. Message: {}", String::from_utf8_lossy(&body_bytes));
                 }
             }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -95,15 +95,23 @@ pub fn is_rate_limited_error_rpc_message(error_message: &str) -> bool {
 /// that should be returned to the client.
 pub fn is_known_rpc_error_message(error_message: &str) -> bool {
     error_message.contains("execution reverted")
-        || error_message.contains("EVM error:")
+        || error_message.contains("EVM error")
+        || error_message.contains("Transaction simulation failed")
         || error_message.contains("insufficient funds for ")
+        || error_message.contains("gas ")
         || error_message.contains("already known")
         || error_message.contains("filter not found")
+        || error_message.contains("execution aborted")
         || error_message.contains("transaction")
-        || error_message.contains("nonce too")
+        || error_message.contains("nonce too ")
         || error_message.contains("stack underflow")
         || error_message.contains("mined")
         || error_message.contains("missing")
+        || error_message.contains("batch ")
+        || error_message.contains("state available for block")
+        || error_message.contains("unsupported block number")
+        || error_message.contains("block not found")
+        || error_message.contains("invalid opcode")
 }
 
 /// Checks if a JSON-RPC error code indicates a server error specific codes.


### PR DESCRIPTION
# Description

This PR extends the known RPC errors after checking the logs and metrics to catch as many as possible. Debug only when the schema don't match since we have a lot of such retries on the self-hosted node, reflects that our schema expectation can be missed some cases. Debug logging can help to check this.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
