### PR TITLE
feat(proxy): implementing RPC caching scaffold and adding `chainId` server-side calculation

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -75,7 +75,7 @@ pub async fn rpc_call(
 ) -> Result<Response, RpcError> {
     let chain_id = query_params.chain_id.clone();
 
-    // Deserialization the request body to a JSON-RPC request schema and
+    // Deserializing the request body to a JSON-RPC request schema and
     // check if a cached response can be returned
     // TODO: Optimize this to remove the second deserialization during the provider analytics
     match serde_json::from_slice::<JsonRpcRequest>(&body) {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -75,8 +75,9 @@ pub async fn rpc_call(
 ) -> Result<Response, RpcError> {
     let chain_id = query_params.chain_id.clone();
 
-    // Deserialize the request body to a JSON-RPC request and check if
-    // can cached response be returned
+    // Deserialization the request body to a JSON-RPC request schema and
+    // check if a cached response can be returned
+    // TODO: Optimize this to remove the second deserialization during the provider analytics
     match serde_json::from_slice::<JsonRpcRequest>(&body) {
         Ok(request) => {
             if let Some(response) = is_cached_response(&chain_id, &request, &state.metrics) {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -80,7 +80,9 @@ pub async fn rpc_call(
     // TODO: Optimize this to remove the second deserialization during the provider analytics
     match serde_json::from_slice::<JsonRpcRequest>(&body) {
         Ok(request) => {
-            if let Some(response) = is_cached_response(&chain_id, &request, &state.metrics) {
+            if let Some(response) =
+                is_cached_response(&chain_id, &request, &state.metrics, &state.moka_cache).await
+            {
                 return Ok(
                     (http::StatusCode::OK, serde_json::to_string(&response)?).into_response()
                 );

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,7 @@ use {
         utils::{build::CompileInfo, rate_limit::RateLimit},
     },
     cerberus::project::ProjectDataWithQuota,
+    moka::future::Cache,
     sqlx::PgPool,
     std::sync::Arc,
     tap::TapFallible,
@@ -36,6 +37,8 @@ pub struct AppState {
     // Redis caching
     pub identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     pub balance_cache: Option<Arc<dyn KeyValueStorage<BalanceResponseBody>>>,
+    // Moka local instance in-memory cache
+    pub moka_cache: Cache<String, String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -52,6 +55,7 @@ pub fn new_state(
     identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     balance_cache: Option<Arc<dyn KeyValueStorage<BalanceResponseBody>>>,
 ) -> AppState {
+    let moka_cache = Cache::builder().build();
     AppState {
         config,
         postgres,
@@ -66,6 +70,7 @@ pub fn new_state(
         irn,
         identity_cache,
         balance_cache,
+        moka_cache,
     }
 }
 

--- a/src/utils/json_rpc_cache.rs
+++ b/src/utils/json_rpc_cache.rs
@@ -50,19 +50,19 @@ async fn get_mem_cached_response(
 async fn set_mem_cached_response(
     caip2_chain_id: &str,
     method: &str,
-    chain_id_bytes: &str,
+    value: &str,
     moka_cache: &Cache<String, String>,
 ) {
     moka_cache
         .insert(
             construct_mem_cache_key(method, caip2_chain_id),
-            chain_id_bytes.to_string(),
+            value.to_string(),
         )
         .await;
 }
 
-// Get bytes representation of the chainID
-// by encoded as a hex‑string “quantity"
+// Get bytes representation of the chain ID
+// encoded as a hex‑string “quantity"
 // https://eips.ethereum.org/EIPS/eip-155#chain-id
 fn get_evm_chain_id_bytes(chain_id: &str) -> Option<String> {
     let chain_id_bytes = match chain_id.parse::<u64>() {

--- a/src/utils/json_rpc_cache.rs
+++ b/src/utils/json_rpc_cache.rs
@@ -4,6 +4,7 @@ use {
         metrics::Metrics,
         utils::crypto,
     },
+    moka::future::Cache,
     strum_macros::{Display, EnumString},
     tracing::error,
 };
@@ -14,34 +15,50 @@ pub enum CachedMethods {
     EthChainId,
 }
 
-pub fn is_cached_response(
+/// Check if the response is cached and apply caching
+pub async fn is_cached_response(
     caip2_chain_id: &str,
     request: &JsonRpcRequest,
     metrics: &Metrics,
+    moka_cache: &Cache<String, String>,
 ) -> Option<JsonRpcResponse> {
     if let Ok(method) = request.method.as_ref().parse::<CachedMethods>() {
         match method {
             CachedMethods::EthChainId => {
-                let Ok((_, chain_id)) = crypto::disassemble_caip2(caip2_chain_id) else {
-                    tracing::error!("Failed to disassemble CAIP2 chainId: {caip2_chain_id}");
-                    return None;
-                };
-                let Some(chain_id_bytes) = get_evm_chain_id_bytes(&chain_id) else {
-                    error!("Failed to get chainId bytes for: {chain_id}");
-                    return None;
-                };
-                let response = JsonRpcResponse::Result(JsonRpcResult::new(
-                    request.id.clone(),
-                    chain_id_bytes.into(),
-                ));
-
-                metrics.add_rpc_cached_call(caip2_chain_id.to_string(), method.to_string());
-                Some(response)
+                handle_eth_chain_id(caip2_chain_id, request, moka_cache, metrics).await
             }
         }
     } else {
         None
     }
+}
+
+fn construct_mem_cache_key(method: &str, caip2_chain_id: &str) -> String {
+    format!("rpc_cache:{method}:{caip2_chain_id}")
+}
+
+async fn get_mem_cached_response(
+    caip2_chain_id: &str,
+    method: &str,
+    moka_cache: &Cache<String, String>,
+) -> Option<String> {
+    moka_cache
+        .get(&construct_mem_cache_key(method, caip2_chain_id))
+        .await
+}
+
+async fn set_mem_cached_response(
+    caip2_chain_id: &str,
+    method: &str,
+    chain_id_bytes: &str,
+    moka_cache: &Cache<String, String>,
+) {
+    moka_cache
+        .insert(
+            construct_mem_cache_key(method, caip2_chain_id),
+            chain_id_bytes.to_string(),
+        )
+        .await;
 }
 
 // Get bytes representation of the chainID
@@ -51,11 +68,76 @@ fn get_evm_chain_id_bytes(chain_id: &str) -> Option<String> {
     let chain_id_bytes = match chain_id.parse::<u64>() {
         Ok(bytes) => bytes,
         Err(e) => {
-            tracing::error!("Failed to parse chain_id {chain_id} as u64: {e}");
+            error!("Failed to parse chain_id {chain_id} as u64: {e}");
             return None;
         }
     };
     Some(format!("0x{chain_id_bytes:x}"))
+}
+
+async fn check_cached_chain_id_response(
+    caip2_chain_id: &str,
+    request: &JsonRpcRequest,
+    moka_cache: &Cache<String, String>,
+) -> Option<JsonRpcResponse> {
+    get_mem_cached_response(
+        caip2_chain_id,
+        CachedMethods::EthChainId.to_string().as_str(),
+        moka_cache,
+    )
+    .await
+    .map(|cached_chain_id_bytes| {
+        JsonRpcResponse::Result(JsonRpcResult::new(
+            request.id.clone(),
+            cached_chain_id_bytes.into(),
+        ))
+    })
+}
+
+/// Handle the eth_chainId RPC method caching
+async fn handle_eth_chain_id(
+    caip2_chain_id: &str,
+    request: &JsonRpcRequest,
+    moka_cache: &Cache<String, String>,
+    metrics: &Metrics,
+) -> Option<JsonRpcResponse> {
+    let Ok((_, chain_id)) = crypto::disassemble_caip2(caip2_chain_id) else {
+        error!("Failed to disassemble CAIP2 chainId: {caip2_chain_id}");
+        return None;
+    };
+
+    // Check if the chainId is cached in the moka memory cache and return immediately
+    if let Some(response) =
+        check_cached_chain_id_response(caip2_chain_id, request, moka_cache).await
+    {
+        metrics.add_rpc_cached_call(
+            caip2_chain_id.to_string(),
+            CachedMethods::EthChainId.to_string(),
+        );
+        return Some(response);
+    }
+
+    let Some(chain_id_bytes) = get_evm_chain_id_bytes(&chain_id) else {
+        error!("Failed to get chainId bytes for: {chain_id}");
+        return None;
+    };
+    let response = JsonRpcResponse::Result(JsonRpcResult::new(
+        request.id.clone(),
+        chain_id_bytes.clone().into(),
+    ));
+
+    set_mem_cached_response(
+        caip2_chain_id,
+        CachedMethods::EthChainId.to_string().as_str(),
+        &chain_id_bytes,
+        moka_cache,
+    )
+    .await;
+    metrics.add_rpc_cached_call(
+        caip2_chain_id.to_string(),
+        CachedMethods::EthChainId.to_string(),
+    );
+    Some(response)
 }
 
 #[cfg(test)]

--- a/src/utils/json_rpc_cache.rs
+++ b/src/utils/json_rpc_cache.rs
@@ -1,0 +1,79 @@
+use {
+    crate::{
+        json_rpc::{JsonRpcRequest, JsonRpcResponse, JsonRpcResult},
+        metrics::Metrics,
+        utils::crypto,
+    },
+    strum_macros::{Display, EnumString},
+    tracing::error,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, Display)]
+pub enum CachedMethods {
+    #[strum(serialize = "eth_chainId")]
+    EthChainId,
+}
+
+pub fn is_cached_response(
+    caip2_chain_id: &str,
+    request: &JsonRpcRequest,
+    metrics: &Metrics,
+) -> Option<JsonRpcResponse> {
+    if let Ok(method) = request.method.as_ref().parse::<CachedMethods>() {
+        match method {
+            CachedMethods::EthChainId => {
+                let Ok((_, chain_id)) = crypto::disassemble_caip2(caip2_chain_id) else {
+                    tracing::error!("Failed to disassemble CAIP2 chainId: {caip2_chain_id}");
+                    return None;
+                };
+                let Some(chain_id_bytes) = get_evm_chain_id_bytes(&chain_id) else {
+                    error!("Failed to get chainId bytes for: {chain_id}");
+                    return None;
+                };
+                let response = JsonRpcResponse::Result(JsonRpcResult::new(
+                    request.id.clone(),
+                    chain_id_bytes.into(),
+                ));
+
+                metrics.add_rpc_cached_call(caip2_chain_id.to_string(), method.to_string());
+                Some(response)
+            }
+        }
+    } else {
+        None
+    }
+}
+
+// Get bytes representation of the chainID
+// by encoded as a hex‑string “quantity"
+// https://eips.ethereum.org/EIPS/eip-155#chain-id
+fn get_evm_chain_id_bytes(chain_id: &str) -> Option<String> {
+    let chain_id_bytes = match chain_id.parse::<u64>() {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::error!("Failed to parse chain_id {chain_id} as u64: {e}");
+            return None;
+        }
+    };
+    Some(format!("0x{chain_id_bytes:x}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_evm_chain_id_bytes() {
+        assert_eq!(get_evm_chain_id_bytes("1"), Some("0x1".to_string()));
+        assert_eq!(get_evm_chain_id_bytes("10"), Some("0xa".to_string()));
+        assert_eq!(get_evm_chain_id_bytes("137"), Some("0x89".to_string()));
+        assert_eq!(get_evm_chain_id_bytes("42161"), Some("0xa4b1".to_string()));
+    }
+
+    #[test]
+    fn test_get_evm_chain_id_bytes_invalid() {
+        assert_eq!(get_evm_chain_id_bytes("invalid"), None);
+        assert_eq!(get_evm_chain_id_bytes(""), None);
+        assert_eq!(get_evm_chain_id_bytes("abc"), None);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,7 @@ pub mod build;
 pub mod crypto;
 pub mod erc4337;
 pub mod erc7677;
+pub mod json_rpc_cache;
 pub mod network;
 pub mod permissions;
 pub mod rate_limit;

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -167,6 +167,7 @@ dashboard.new(
     panels.proxy.rpc_server_error_codes(ds, vars)    { gridPos: pos._3 },
     panels.proxy.provider_retries(ds, vars)          { gridPos: pos._3 },
     panels.proxy.http_codes(ds, vars)                { gridPos: pos._3 },
+    panels.proxy.rpc_methods_cache(ds, vars)         { gridPos: pos._3 },
 
   row.new('Non-RPC providers Status Codes'),
     panels.status.provider(ds, vars, 'Zerion')       { gridPos: pos._4 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -36,6 +36,7 @@ local redis  = panels.aws.redis;
     chains_unavailability:  (import 'proxy/chains_unavailability.libsonnet'  ).new,
     websocket_connections:  (import 'proxy/websocket_connections.libsonnet'  ).new,
     rpc_server_error_codes: (import 'proxy/rpc_server_error_codes.libsonnet' ).new,
+    rpc_methods_cache:      (import 'proxy/rpc_methods_cache.libsonnet'      ).new,
   },
 
   projects: {

--- a/terraform/monitoring/panels/proxy/rpc_methods_cache.libsonnet
+++ b/terraform/monitoring/panels/proxy/rpc_methods_cache.libsonnet
@@ -1,0 +1,20 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Cached responses percent by RPC method',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries.withUnit('percent'))
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = '(sum by(method) (increase(rpc_cached_call_counter_total{}[$__rate_interval])) / sum(increase(rpc_call_counter_total{status_code="200"}[$__rate_interval]))) * 100',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    )) 
+}

--- a/terraform/monitoring/panels/proxy/rpc_methods_cache.libsonnet
+++ b/terraform/monitoring/panels/proxy/rpc_methods_cache.libsonnet
@@ -16,5 +16,5 @@ local targets   = grafana.targets;
       expr          = '(sum by(method) (increase(rpc_cached_call_counter_total{}[$__rate_interval])) / sum(increase(rpc_call_counter_total{status_code="200"}[$__rate_interval]))) * 100',
       exemplar      = false,
       legendFormat  = '__auto',
-    )) 
+    ))
 }


### PR DESCRIPTION
# Description

This PR adds an RPC responses caching scaffold based on the chainId and methods.

The `eth_chainId` RPC method request now returns the value based on the local calculation instead of the RPC call to providers to save on latency and quota, since we can calculate bytes on our side for this type of request. 

The `chainId` bytes local calculation is cached in a local instance in-memory Moka cache to avoid recalculations on every request.

The new metrics for cached RPC responses per chain and method were added, and a new Grafana panel for the cached responses percentage per method was also implemented.

## How Has This Been Tested?

Tested manually, and current integration tests must pass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
