### PR TITLE
fix(o11y): fixing Prometheus query and label for RPC caching

### DIFF
--- a/terraform/monitoring/panels/proxy/rpc_methods_cache.libsonnet
+++ b/terraform/monitoring/panels/proxy/rpc_methods_cache.libsonnet
@@ -11,10 +11,12 @@ local targets   = grafana.targets;
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries.withUnit('percent'))
+
+    // Specific target for 'eth_chainId'
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = '(sum by(method) (increase(rpc_cached_call_counter_total{}[$__rate_interval])) / sum(increase(rpc_call_counter_total{status_code="200"}[$__rate_interval]))) * 100',
+      expr          = '100 * (sum(increase(rpc_cached_call_counter_total{method="eth_chainId"}[$__rate_interval])) / on() sum(increase(rpc_call_counter_total[$__rate_interval])))',
       exemplar      = false,
-      legendFormat  = '__auto',
+      legendFormat  = 'eth_chainId',
     ))
 }


### PR DESCRIPTION
# Description

This PR fixes the Prometheus query for the RPC cache Grafana panel by adding the `on()` to tell PromQL to join each “method” series against that lone total series (matching on zero labels) and explicitly setting the label to fix the `Value` label instead of the cached method.

## How Has This Been Tested?

Tested manually by putting the updated query into Grafana.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
