### PR TITLE
Adding DeInfra Network support

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -15,6 +15,7 @@ Chain name with associated `chainId` query param to use.
 | Binance Smart Chain                                      | eip155:56            |
 | Binance Smart Chain Testnet <sup>[1](#footnote1)</sup>   | eip155:97            |
 | Gnosis Chain                                             | eip155:100           |
+| DeInfra Mainnet <sup>[1](#footnote1)</sup>               | eip155:100501        |
 | Unichain Mainnet <sup>[1](#footnote1)</sup>              | eip155:130           |
 | Polygon                                                  | eip155:137           |
 | Sonic                                                    | eip155:146           |
@@ -56,6 +57,7 @@ Chain name with associated `chainId` query param to use.
 | Zora Sepolia <sup>[1](#footnote1)</sup>                  | eip155:999999999     |
 | Aurora <sup>[1](#footnote1)</sup>                        | eip155:1313161554    |
 | Aurora Testnet <sup>[1](#footnote1)</sup>                | eip155:1313161555    |
+| DeInfra Devnet3 <sup>[1](#footnote1)</sup>               | eip155:1000000003    |
 | Near Mainnet                                             | near:mainnet         |
 
 ### Solana

--- a/src/env/deinfra.rs
+++ b/src/env/deinfra.rs
@@ -1,0 +1,55 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct DeInfraConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for DeInfraConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for DeInfraConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::DeInfra
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // DeInfra Mainnet
+        (
+            "eip155:100501".into(),
+            (
+                "https://c100501n3.deinfra.net:443/jsonrpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // DeInfra Devnet3
+        (
+            "eip155:1000000003".into(),
+            (
+                "https://c3n1.thepower.io/jsonrpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/env/deinfra.rs
+++ b/src/env/deinfra.rs
@@ -39,7 +39,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:100501".into(),
             (
-                "https://c100501n3.deinfra.net:443/jsonrpc".into(),
+                "https://c100501n3.deinfra.net/jsonrpc".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -16,9 +16,9 @@ use {
     std::{collections::HashMap, fmt::Display},
 };
 pub use {
-    allnodes::*, arbitrum::*, aurora::*, base::*, binance::*, blast::*, callstatic::*, drpc::*,
-    dune::*, hiro::*, mantle::*, monad::*, moonbeam::*, morph::*, near::*, odyssey::*, pokt::*,
-    publicnode::*, quicknode::*, rootstock::*, server::*, solscan::*, sui::*, syndica::*,
+    allnodes::*, arbitrum::*, aurora::*, base::*, binance::*, blast::*, callstatic::*, deinfra::*,
+    drpc::*, dune::*, hiro::*, mantle::*, monad::*, moonbeam::*, morph::*, near::*, odyssey::*,
+    pokt::*, publicnode::*, quicknode::*, rootstock::*, server::*, solscan::*, sui::*, syndica::*,
     therpc::*, unichain::*, wemix::*, zerion::*, zksync::*, zora::*,
 };
 mod allnodes;
@@ -28,6 +28,7 @@ mod base;
 mod binance;
 mod blast;
 mod callstatic;
+mod deinfra;
 mod drpc;
 mod dune;
 mod hiro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,22 +21,24 @@ use {
     },
     env::{
         AllnodesConfig, ArbitrumConfig, AuroraConfig, BaseConfig, BinanceConfig, BlastConfig,
-        CallStaticConfig, DrpcConfig, DuneConfig, HiroConfig, MantleConfig, MonadConfig,
-        MoonbeamConfig, MorphConfig, NearConfig, OdysseyConfig, PoktConfig, PublicnodeConfig,
-        QuicknodeConfig, RootstockConfig, SolScanConfig, SuiConfig, SyndicaConfig, TheRpcConfig,
-        UnichainConfig, WemixConfig, ZKSyncConfig, ZerionConfig, ZoraConfig,
+        CallStaticConfig, DeInfraConfig, DrpcConfig, DuneConfig, HiroConfig, MantleConfig,
+        MonadConfig, MoonbeamConfig, MorphConfig, NearConfig, OdysseyConfig, PoktConfig,
+        PublicnodeConfig, QuicknodeConfig, RootstockConfig, SolScanConfig, SuiConfig,
+        SyndicaConfig, TheRpcConfig, UnichainConfig, WemixConfig, ZKSyncConfig, ZerionConfig,
+        ZoraConfig,
     },
     error::RpcResult,
     http::Request,
     hyper::{header::HeaderName, http, server::conn::AddrIncoming, Body, Server},
     providers::{
         AllnodesProvider, AllnodesWsProvider, ArbitrumProvider, AuroraProvider, BaseProvider,
-        BinanceProvider, BlastProvider, CallStaticProvider, DrpcProvider, DuneProvider,
-        HiroProvider, MantleProvider, MonadProvider, MoonbeamProvider, MorphProvider, NearProvider,
-        OdysseyProvider, PoktProvider, ProviderRepository, PublicnodeProvider, QuicknodeProvider,
-        QuicknodeWsProvider, RootstockProvider, SolScanProvider, SuiProvider, SyndicaProvider,
-        SyndicaWsProvider, TheRpcProvider, UnichainProvider, WemixProvider, ZKSyncProvider,
-        ZerionProvider, ZoraProvider, ZoraWsProvider,
+        BinanceProvider, BlastProvider, CallStaticProvider, DeInfraProvider, DrpcProvider,
+        DuneProvider, HiroProvider, MantleProvider, MonadProvider, MoonbeamProvider,
+        MorphProvider, NearProvider, OdysseyProvider, PoktProvider, ProviderRepository,
+        PublicnodeProvider, QuicknodeProvider, QuicknodeWsProvider, RootstockProvider,
+        SolScanProvider, SuiProvider, SyndicaProvider, SyndicaWsProvider, TheRpcProvider,
+        UnichainProvider, WemixProvider, ZKSyncProvider, ZerionProvider, ZoraProvider,
+        ZoraWsProvider,
     },
     sqlx::postgres::PgPoolOptions,
     std::{
@@ -547,6 +549,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     providers.add_rpc_provider::<CallStaticProvider, CallStaticConfig>(CallStaticConfig::new(
         config.callstatic_api_key.clone(),
     ));
+    providers.add_rpc_provider::<DeInfraProvider, DeInfraConfig>(DeInfraConfig::default());
     providers.add_rpc_provider::<BlastProvider, BlastConfig>(BlastConfig::new(
         config.blast_api_key.clone(),
     ));

--- a/src/providers/deinfra.rs
+++ b/src/providers/deinfra.rs
@@ -1,0 +1,87 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{env::DeInfraConfig, error::RpcResult},
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::debug,
+};
+
+#[derive(Debug)]
+pub struct DeInfraProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for DeInfraProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::DeInfra
+    }
+}
+
+#[async_trait]
+impl RateLimited for DeInfraProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for DeInfraProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let rpc_endpoint = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or_else(|| crate::error::RpcError::ChainNotFound)?;
+
+        let uri = rpc_endpoint.clone();
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        debug!("Proxying request to DeInfra for chain {}", chain_id);
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<DeInfraConfig> for DeInfraProvider {
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &DeInfraConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        DeInfraProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -146,6 +146,7 @@ mod blast;
 mod bungee;
 mod callstatic;
 mod coinbase;
+mod deinfra;
 mod drpc;
 mod dune;
 mod hiro;
@@ -184,6 +185,7 @@ pub use {
     blast::BlastProvider,
     bungee::BungeeProvider,
     callstatic::CallStaticProvider,
+    deinfra::DeInfraProvider,
     drpc::DrpcProvider,
     dune::DuneProvider,
     hiro::HiroProvider,
@@ -824,6 +826,7 @@ pub enum ProviderKind {
     Moonbeam,
     Blast,
     Rootstock,
+    DeInfra,
 }
 
 impl Display for ProviderKind {
@@ -866,6 +869,7 @@ impl Display for ProviderKind {
                 ProviderKind::Moonbeam => "Moonbeam",
                 ProviderKind::Blast => "Blast",
                 ProviderKind::Rootstock => "Rootstock",
+                ProviderKind::DeInfra => "DeInfra",
             }
         )
     }
@@ -909,6 +913,7 @@ impl ProviderKind {
             "Moonbeam" => Some(Self::Moonbeam),
             "Blast" => Some(Self::Blast),
             "Rootstock" => Some(Self::Rootstock),
+            "DeInfra" => Some(Self::DeInfra),
             _ => None,
         }
     }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -714,6 +714,7 @@ pub enum ChainId {
     Blast = 81032,
     Celo = 42220,
     Degen = 666666666,
+    DeInfra = 100501,
     #[strum(serialize = "ethereum", serialize = "mainnet")]
     Ethereum = 1,
     Fantom = 250,

--- a/tests/functional/http/deinfra.rs
+++ b/tests/functional/http/deinfra.rs
@@ -1,0 +1,29 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain, crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind, test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn deinfra_provider(ctx: &mut ServerContext) {
+    let provider_kind = ProviderKind::DeInfra;
+
+    // DeInfra Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider_kind,
+        "eip155:100501",
+        "0x188f5",
+    )
+    .await;
+
+    // DeInfra Devnet3
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider_kind,
+        "eip155:1000000003",
+        "0x3b9acae3",
+    )
+    .await;
+}

--- a/tests/functional/http/deinfra.rs
+++ b/tests/functional/http/deinfra.rs
@@ -14,7 +14,7 @@ async fn deinfra_provider(ctx: &mut ServerContext) {
         ctx,
         &provider_kind,
         "eip155:100501",
-        "0x188f5",
+        "0x18895",
     )
     .await;
 
@@ -23,7 +23,7 @@ async fn deinfra_provider(ctx: &mut ServerContext) {
         ctx,
         &provider_kind,
         "eip155:1000000003",
-        "0x3b9acae3",
+        "0x3b9aca03",
     )
     .await;
 }

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod arbitrum;
 pub(crate) mod aurora;
 pub(crate) mod base;
 pub(crate) mod binance;
+pub(crate) mod deinfra;
 pub(crate) mod drpc;
 pub(crate) mod mantle;
 pub(crate) mod monad;


### PR DESCRIPTION
# Description

This PR adds the DeInfra [native RPC provider](https://doc.deinfra.net/docs/about) to the provider's list and adds support for the DeInfra Mainnet eip155:100501 and DeInfra Devnet3 eip155:1000000003 chain for RPC calls.

## How Has This Been Tested?

A new test for the provider was created.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
