### PR TITLE
feat(proxy): implementing skip the quota chains list

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -291,6 +291,7 @@ mod test {
                     geoip_db_key: Some("GEOIP_DB_KEY".to_owned()),
                     testing_project_id: Some("TESTING_PROJECT_ID".to_owned()),
                     validate_project_id: true,
+                    skip_quota_chains: vec![],
                 },
                 registry: project::Config {
                     api_url: Some("API_URL".to_owned()),

--- a/src/env/server.rs
+++ b/src/env/server.rs
@@ -18,6 +18,7 @@ pub struct ServerConfig {
     pub geoip_db_key: Option<String>,
     pub testing_project_id: Option<String>,
     pub validate_project_id: bool,
+    /// Contains CAIP-2 chain identifiers that should bypass quota validation.
     pub skip_quota_chains: Vec<String>,
 }
 

--- a/src/env/server.rs
+++ b/src/env/server.rs
@@ -18,6 +18,7 @@ pub struct ServerConfig {
     pub geoip_db_key: Option<String>,
     pub testing_project_id: Option<String>,
     pub validate_project_id: bool,
+    pub skip_quota_chains: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -34,6 +35,7 @@ impl Default for ServerConfig {
             geoip_db_key: None,
             testing_project_id: None,
             validate_project_id: true,
+            skip_quota_chains: Vec::new(),
         }
     }
 }

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -59,9 +59,23 @@ async fn handler_internal(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, RpcError> {
-    state
-        .validate_project_access_and_quota(&query_params.project_id.clone())
-        .await?;
+    // Don't validate the quota and validate project access only
+    // if the chainId is in the skip_quota_chains list
+    if state
+        .config
+        .server
+        .skip_quota_chains
+        .contains(&query_params.chain_id)
+    {
+        state
+            .validate_project_access(&query_params.project_id.clone())
+            .await?;
+    } else {
+        state
+            .validate_project_access_and_quota(&query_params.project_id.clone())
+            .await?;
+    };
+
     rpc_call(state, addr, query_params, headers, body).await
 }
 

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -107,6 +107,8 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_CALLSTATIC_API_KEY", value = var.callstatic_api_key },
         { name = "RPC_PROXY_PROVIDER_BLAST_API_KEY", value = var.blast_api_key },
 
+        { name = "RPC_PROXY_SKIP_QUOTA_CHAINS", value = var.proxy_skip_quota_chains },
+
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_ENDPOINT", value = var.prometheus_endpoint },
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_WORKSPACE_ID", value = var.prometheus_workspace_id },
 

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -291,6 +291,14 @@ variable "testing_project_id" {
 }
 
 #-------------------------------------------------------------------------------
+# RPC Proxy configuration
+variable "proxy_skip_quota_chains" {
+  description = "Comma separated list of CAIP-2 chains to skip quota check"
+  type        = string
+  default     = ""
+}
+
+#-------------------------------------------------------------------------------
 # Project Registry
 
 variable "registry_api_endpoint" {

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -84,6 +84,9 @@ module "ecs" {
   callstatic_api_key   = var.callstatic_api_key
   blast_api_key        = var.blast_api_key
 
+  # RPC Proxy configuration
+  proxy_skip_quota_chains = var.proxy_skip_quota_chains
+
   # Project Registry
   registry_api_endpoint   = var.registry_api_endpoint
   registry_api_auth_token = var.registry_api_auth_token

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -76,7 +76,6 @@ variable "project_cache_ttl" {
   default     = 300
 }
 
-
 #-------------------------------------------------------------------------------
 # Providers
 
@@ -204,6 +203,15 @@ variable "blast_api_key" {
   description = "Blast API key"
   type        = string
   sensitive   = true
+}
+
+#-------------------------------------------------------------------------------
+# RPC Proxy configuration
+
+variable "proxy_skip_quota_chains" {
+  description = "Comma separated list of CAIP-2 chains to skip quota check"
+  type        = string
+  default     = ""
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This PR implements skipping the RPC quota chains list by using the terraform `proxy_skip_quota_chains` variable contains the comma-separated CAIP-2 chains to skip. 
Only projectId validation is applied, and no quota check for chains in the whitelist.

## How Has This Been Tested?

Manual testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
