### PR TITLE
feat(Meld): adding default providers and exclude providers parameters

### DIFF
--- a/src/handlers/onramp/properties.rs
+++ b/src/handlers/onramp/properties.rs
@@ -18,6 +18,7 @@ pub struct QueryParams {
     pub r#type: PropertyType,
     pub project_id: String,
     pub countries: Option<String>,
+    pub exclude_providers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -23,6 +23,21 @@ use {
 const API_VERSION: &str = "2023-12-19";
 const DEFAULT_CATEGORY: &str = "CRYPTO_ONRAMP";
 const DEFAULT_SESSION_TYPE: &str = "BUY";
+const DEFAULT_PROVIDERS_LIST: &[&str] = &[
+    "BINANCECONNECT",
+    "BANXA",
+    "BLOCKCHAINDOTCOM",
+    "BTCDIRECT",
+    "COINBASEPAY",
+    "GUARDARIAN",
+    "ONMETA",
+    "ONRAMPMONEY",
+    "PAYBIS",
+    "SHIFT4",
+    "STRIPE",
+    "TRANSAK",
+    "UNLIMIT",
+];
 
 #[derive(Debug)]
 pub struct MeldProvider {
@@ -263,6 +278,19 @@ impl OnRampMultiProvider for MeldProvider {
         url.query_pairs_mut()
             .append_pair("categories", DEFAULT_CATEGORY);
 
+        // Excclude provider from DEFAULT_PROVIDERS_LIST if exclude_providers is provided
+        let providers_list = if let Some(exclude_providers) = params.exclude_providers {
+            let mut providers_list = DEFAULT_PROVIDERS_LIST.to_vec();
+            for provider in exclude_providers {
+                providers_list.retain(|p| p != &provider);
+            }
+            providers_list.join(",")
+        } else {
+            DEFAULT_PROVIDERS_LIST.join(",")
+        };
+        url.query_pairs_mut()
+            .append_pair("serviceProviders", &providers_list);
+
         let latency_start = SystemTime::now();
         let response = self.send_get_request(url).await.map_err(|e| {
             error!("Error sending request to Meld providers properties: {e:?}");
@@ -383,6 +411,7 @@ impl OnRampMultiProvider for MeldProvider {
                         project_id: params.project_id.clone(),
                         r#type: PropertyType::PaymentMethods,
                         countries: Some(country.to_string()),
+                        exclude_providers: params.exclude_providers.clone(),
                     },
                     metrics.clone(),
                 )


### PR DESCRIPTION
# Description

This PR adds a default providers list for the `/v1/onramp/providers/properties` and `excludeProviders` query parameter to provide a providers exclusion list.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
