### PR TITLE
feat(proxy): extending the known list of json-rpc error messages

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -96,6 +96,7 @@ pub fn is_rate_limited_error_rpc_message(error_message: &str) -> bool {
         "your plan",
         "current plan",
         "you reached",
+        "no matched providers found",
     ];
 
     RATE_LIMITED_ERROR_PATTERNS
@@ -125,6 +126,8 @@ pub fn is_known_rpc_error_message(error_message: &str) -> bool {
         "unsupported block number",
         "block not found",
         "invalid opcode",
+        "unknown account",
+        "gapped-nonce tx",
     ];
 
     KNOWN_ERROR_PATTERNS


### PR DESCRIPTION
# Description

This PR extends the known list of JSON-RPC messages based on the metrics and current alerts.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
