### PR TITLE
fix(Meld): fixing the `excludeProviders` properties query parameter

### DIFF
--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -149,6 +149,22 @@ describe('OnRamp', () => {
     expect(resp.data.length).toBeGreaterThan(0)
     expect(resp.data[0].countryCode).toBe(defaultCountry)
     expect(resp.data[0].defaultCurrencyCode).toBe('USD')
+
+    // Check for excludeProviders parameter
+    type = 'crypto-currencies'
+    const excludeProviders = 'BINANCECONNECT,COINBASEPAY'
+    resp = await httpClient.get(
+      `${onRampPath}/providers/properties` +
+      `?projectId=${projectId}` +
+      `&type=${type}` +
+      `&excludeProviders=${excludeProviders}`
+    );
+    expect(resp.status).toBe(200)
+    expect(resp.data.length).toBeGreaterThan(0)
+    expect(typeof resp.data[0].currencyCode).toBe('string')
+    expect(typeof resp.data[0].name).toBe('string')
+    expect(typeof resp.data[0].chainCode).toBe('string')
+    expect(typeof resp.data[0].symbolImageUrl).toBe('string') 
   })
 
   it('get multi provider quotes', async () => {

--- a/src/handlers/onramp/properties.rs
+++ b/src/handlers/onramp/properties.rs
@@ -17,8 +17,10 @@ use {
 pub struct QueryParams {
     pub r#type: PropertyType,
     pub project_id: String,
+    /// Comma separated list of countries to filter by
     pub countries: Option<String>,
-    pub exclude_providers: Option<Vec<String>>,
+    /// Comma separated list of provider names to exclude
+    pub exclude_providers: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/src/providers/meld.rs
+++ b/src/providers/meld.rs
@@ -282,11 +282,15 @@ impl OnRampMultiProvider for MeldProvider {
         // and the type is not `countries-defaults`
         if params.r#type != PropertyType::CountriesDefaults {
             let providers_list = if let Some(exclude_providers) = params.exclude_providers {
-                let exclude_set: std::collections::HashSet<&str> =
-                    exclude_providers.iter().map(|s| s.as_str()).collect();
+                // Split by comma and filter out empty strings
+                let exclude_providers_vec = exclude_providers
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<String>>();
                 DEFAULT_PROVIDERS_LIST
                     .iter()
-                    .filter(|p| !exclude_set.contains(*p))
+                    .filter(|p| !exclude_providers_vec.contains(&p.to_string()))
                     .cloned()
                     .collect::<Vec<_>>()
                     .join(",")
@@ -417,7 +421,7 @@ impl OnRampMultiProvider for MeldProvider {
                         project_id: params.project_id.clone(),
                         r#type: PropertyType::PaymentMethods,
                         countries: Some(country.to_string()),
-                        exclude_providers: params.exclude_providers.clone(),
+                        exclude_providers: params.exclude_providers.clone().map(|v| v.join(",")),
                     },
                     metrics.clone(),
                 )


### PR DESCRIPTION
# Description

This PR fixes the `excludeProviders` query parameter for the properties endpoint. The parameter is expected to be a comma-separated value. Since the vector of strings is working when the request type is POST, it's not in GET and throwing an error: `sequence is expected`. This PR changes the type to `String` and handles the extraction of parameters.

## How Has This Been Tested?

The integration test for the `excludeProviders` query parameter was added.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
