### PR TITLE
fix(o11y): fixing the no provider for chain alert name.

### DIFF
--- a/terraform/monitoring/panels/proxy/chains_unavailability.libsonnet
+++ b/terraform/monitoring/panels/proxy/chains_unavailability.libsonnet
@@ -9,7 +9,7 @@ local alertCondition  = grafana.alertCondition;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'ChainID Unavailability',
+      title       = 'No provider for chain responses',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)
@@ -17,8 +17,8 @@ local alertCondition  = grafana.alertCondition;
       vars.environment,
       grafana.alert.new(
         namespace     = vars.namespace,
-        name          = "%(env)s - RPC chain unavailability alert"  % { env: grafana.utils.strings.capitalize(vars.environment) },
-        message       = '%(env)s - RPC chain unavailability alert'  % { env: grafana.utils.strings.capitalize(vars.environment) },
+        name          = "%(env)s - RPC no provider for chain alert"  % { env: grafana.utils.strings.capitalize(vars.environment) },
+        message       = '%(env)s - RPC no provider for chain alert'  % { env: grafana.utils.strings.capitalize(vars.environment) },
         notifications = vars.notifications,
         noDataState   = 'no_data',
         period        = '5m',


### PR DESCRIPTION
# Description

This PR changes the chart and alert name for no providers found for the chain from `ChainID Unavailability` to `No provider for chain` to make it clear.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
