### PR TITLE
feat: test exchange

### DIFF
--- a/src/handlers/wallet/exchanges/mod.rs
+++ b/src/handlers/wallet/exchanges/mod.rs
@@ -14,9 +14,11 @@ use {
 
 pub mod binance;
 pub mod coinbase;
+pub mod test_exchange;
 
 use binance::BinanceExchange;
 use coinbase::CoinbaseExchange;
+use test_exchange::TestExchange;
 
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 pub struct Config {
@@ -85,6 +87,7 @@ pub trait ExchangeProvider {
 pub enum ExchangeType {
     Binance,
     Coinbase,
+    ReownTest,
 }
 
 #[derive(Error, Debug)]
@@ -110,6 +113,7 @@ impl ExchangeType {
         match self {
             ExchangeType::Binance => Box::new(BinanceExchange),
             ExchangeType::Coinbase => Box::new(CoinbaseExchange),
+            ExchangeType::ReownTest => Box::new(TestExchange),
         }
     }
 
@@ -129,6 +133,7 @@ impl ExchangeType {
         match self {
             ExchangeType::Binance => BinanceExchange.get_buy_url(state, params).await,
             ExchangeType::Coinbase => CoinbaseExchange.get_buy_url(state, params).await,
+            ExchangeType::ReownTest => TestExchange.get_buy_url(state, params),
         }
     }
 
@@ -140,6 +145,7 @@ impl ExchangeType {
         match self {
             ExchangeType::Binance => BinanceExchange.get_buy_status(state, params).await,
             ExchangeType::Coinbase => CoinbaseExchange.get_buy_status(state, params).await,
+            ExchangeType::ReownTest => TestExchange.get_buy_status(state, params).await,
         }
     }
 

--- a/src/handlers/wallet/exchanges/test_exchange.rs
+++ b/src/handlers/wallet/exchanges/test_exchange.rs
@@ -1,0 +1,95 @@
+use {
+    crate::handlers::wallet::exchanges::{
+        ExchangeProvider, ExchangeError, GetBuyUrlParams, GetBuyStatusParams, GetBuyStatusResponse, BuyTransactionStatus,
+    },
+    crate::utils::crypto::Caip19Asset,
+    once_cell::sync::Lazy,
+    axum::extract::State,
+    std::sync::Arc,
+    crate::state::AppState,
+    serde::{Deserialize, Serialize},
+};
+
+pub struct TestExchange;
+
+const TEST_EXCHANGE_URL: &str = "http://localhost:3000";
+
+static CAIP_19_SUPPORTED_ASSETS: Lazy<Vec<Caip19Asset>> = Lazy::new(|| {
+    vec![
+        Caip19Asset::parse("eip155:11155111/slip44:60").unwrap(),
+        Caip19Asset::parse("eip155:84532/slip44:60").unwrap(),
+    ]
+});
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestExchangeApiResponse {
+    pub status: String,
+    pub txid: Option<String>,
+    pub created_at: Option<String>,
+}
+
+impl ExchangeProvider for TestExchange {
+    fn id(&self) -> &'static str {
+        "reown_test"
+    }
+
+    fn name(&self) -> &'static str {
+        "Reown Test Exchange"
+    }
+
+    fn image_url(&self) -> Option<&'static str> {
+        Some("https://pay-assets.reown.com/binance_128_128.webp")
+    }
+
+    fn is_asset_supported(&self, asset: &Caip19Asset) -> bool {
+        CAIP_19_SUPPORTED_ASSETS.contains(asset)
+    }
+}
+
+impl TestExchange {
+    pub fn get_buy_url(&self, _state: State<Arc<AppState>>, params: GetBuyUrlParams) -> Result<String, ExchangeError> {
+        Ok(format!(
+            "{}/?asset={}&amount={}&recipient={}&sessionId={}&projectId={}", 
+            TEST_EXCHANGE_URL, 
+            params.asset, 
+            params.amount, 
+            params.recipient, 
+            params.session_id, 
+            params.project_id
+        ))
+    }
+
+    pub async fn get_buy_status(&self, state: State<Arc<AppState>>, params: GetBuyStatusParams) -> Result<GetBuyStatusResponse, ExchangeError> {
+        let response = state
+            .http_client
+            .get(format!("{}/status?sessionId={}", TEST_EXCHANGE_URL, params.session_id))
+            .send()
+            .await
+            .map_err(|e| ExchangeError::GetPayUrlError(e.to_string()))?;
+
+        if response.status().is_success() {
+            let api_response: TestExchangeApiResponse = response
+                .json()
+                .await
+                .map_err(|e| ExchangeError::GetPayUrlError(format!("Failed to parse response: {}", e)))?;
+
+            let status = match api_response.status.to_lowercase().as_str() {
+                "success" => BuyTransactionStatus::Success,
+                "pending" | "in_progress" => BuyTransactionStatus::InProgress,
+                "failed" | "error" => BuyTransactionStatus::Failed,
+                _ => BuyTransactionStatus::Unknown,
+            };
+
+            Ok(GetBuyStatusResponse {
+                status,
+                tx_hash: api_response.txid,
+            })
+        } else {
+            Err(ExchangeError::GetPayUrlError(format!(
+                "API returned error status: {}", 
+                response.status()
+            )))
+        }
+    }
+}

--- a/src/handlers/wallet/exchanges/test_exchange.rs
+++ b/src/handlers/wallet/exchanges/test_exchange.rs
@@ -12,7 +12,7 @@ use {
 
 pub struct TestExchange;
 
-const TEST_EXCHANGE_URL: &str = "http://localhost:3000";
+const TEST_EXCHANGE_URL: &str = "https://appkit-pay-test-exchange.reown.com";
 
 static CAIP_19_SUPPORTED_ASSETS: Lazy<Vec<Caip19Asset>> = Lazy::new(|| {
     vec![
@@ -39,7 +39,7 @@ impl ExchangeProvider for TestExchange {
     }
 
     fn image_url(&self) -> Option<&'static str> {
-        Some("https://pay-assets.reown.com/binance_128_128.webp")
+        Some("https://pay-assets.reown.com/reown_test_128_128.webp")
     }
 
     fn is_asset_supported(&self, asset: &Caip19Asset) -> bool {
@@ -63,7 +63,7 @@ impl TestExchange {
     pub async fn get_buy_status(&self, state: State<Arc<AppState>>, params: GetBuyStatusParams) -> Result<GetBuyStatusResponse, ExchangeError> {
         let response = state
             .http_client
-            .get(format!("{}/status?sessionId={}", TEST_EXCHANGE_URL, params.session_id))
+            .get(format!("{}/api/status?sessionId={}", TEST_EXCHANGE_URL, params.session_id))
             .send()
             .await
             .map_err(|e| ExchangeError::GetPayUrlError(e.to_string()))?;


### PR DESCRIPTION
# Description

Add test exchange so that customers can interact with AppKit Pay without the need to use Coinbase or Binance. Its available on Sepolia and Base Sepolia networks when native ETH is provided.

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
