### PR TITLE
fix: preserving JSON-RPC `id` type

### DIFF
--- a/src/json_rpc/mod.rs
+++ b/src/json_rpc/mod.rs
@@ -4,9 +4,8 @@
 //! clients.
 
 use {
-    derive_more::{Display, From, Into},
+    derive_more::From,
     serde::{Deserialize, Serialize},
-    serde_aux::prelude::deserialize_string_from_number,
     std::sync::Arc,
 };
 
@@ -17,11 +16,6 @@ pub const JSON_RPC_VERSION_STR: &str = "2.0";
 
 pub static JSON_RPC_VERSION: once_cell::sync::Lazy<Arc<str>> =
     once_cell::sync::Lazy::new(|| Arc::from(JSON_RPC_VERSION_STR));
-
-/// Represents the message ID type.
-#[derive(Debug, Hash, Clone, PartialEq, Eq, Serialize, Deserialize, From, Into, Display)]
-#[serde(transparent)]
-pub struct MessageId(#[serde(deserialize_with = "deserialize_string_from_number")] String);
 
 /// Enum representing a JSON RPC Payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -37,7 +31,7 @@ pub enum JsonRpcPayload {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct JsonRpcRequest<T = serde_json::Value> {
     /// ID this message corresponds to.
-    pub id: MessageId,
+    pub id: serde_json::Value,
     /// The JSON RPC version.
     pub jsonrpc: Arc<str>,
     /// The RPC method.
@@ -48,7 +42,7 @@ pub struct JsonRpcRequest<T = serde_json::Value> {
 
 impl JsonRpcRequest {
     /// Create a new instance.
-    pub fn new(id: MessageId, method: Arc<str>) -> Self {
+    pub fn new(id: serde_json::Value, method: Arc<str>) -> Self {
         Self {
             id,
             jsonrpc: JSON_RPC_VERSION.clone(),
@@ -59,7 +53,7 @@ impl JsonRpcRequest {
 }
 
 impl<T> JsonRpcRequest<T> {
-    pub fn new_with_params(id: MessageId, method: Arc<str>, params: T) -> Self {
+    pub fn new_with_params(id: serde_json::Value, method: Arc<str>, params: T) -> Self {
         Self {
             id,
             jsonrpc: JSON_RPC_VERSION.clone(),
@@ -83,7 +77,7 @@ pub enum JsonRpcResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonRpcResult<T = serde_json::Value> {
     /// ID this message corresponds to.
-    pub id: MessageId,
+    pub id: serde_json::Value,
     /// RPC version.
     pub jsonrpc: Arc<str>,
     /// The result for the message.
@@ -91,7 +85,7 @@ pub struct JsonRpcResult<T = serde_json::Value> {
 }
 
 impl JsonRpcResult {
-    pub fn new(id: MessageId, result: serde_json::Value) -> Self {
+    pub fn new(id: serde_json::Value, result: serde_json::Value) -> Self {
         Self {
             id,
             jsonrpc: JSON_RPC_VERSION.clone(),
@@ -104,7 +98,7 @@ impl JsonRpcResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonRpcError<T: Serialize = Option<Arc<str>>> {
     /// ID this message corresponds to.
-    pub id: MessageId,
+    pub id: serde_json::Value,
     /// RPC version.
     pub jsonrpc: Arc<str>,
     /// The ErrorResponse corresponding to this message.
@@ -112,7 +106,7 @@ pub struct JsonRpcError<T: Serialize = Option<Arc<str>>> {
 }
 
 impl<T: Serialize> JsonRpcError<T> {
-    pub fn new(id: MessageId, error: ErrorResponse<T>) -> Self {
+    pub fn new(id: serde_json::Value, error: ErrorResponse<T>) -> Self {
         Self {
             id,
             jsonrpc: JSON_RPC_VERSION.clone(),

--- a/src/json_rpc/tests.rs
+++ b/src/json_rpc/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 fn test_request_serialized() {
     assert_eq!(
         &serde_json::to_string(&JsonRpcPayload::Request(JsonRpcRequest::new(
-            MessageId("1".into()),
+            "1".into(),
             "eth_chainId".into()
         )))
         .unwrap(),
@@ -19,14 +19,14 @@ fn test_request_deserialized() {
             "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":null}"
         )
         .unwrap(),
-        &JsonRpcRequest::new(MessageId("1".into()), "eth_chainId".into(),),
+        &JsonRpcRequest::new(1.into(), "eth_chainId".into(),),
     );
     assert_eq!(
         &serde_json::from_str::<JsonRpcRequest>(
             "{\"id\":\"abc\",\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":null}"
         )
         .unwrap(),
-        &JsonRpcRequest::new(MessageId("abc".into()), "eth_chainId".into(),),
+        &JsonRpcRequest::new("abc".into(), "eth_chainId".into(),),
     );
 }
 
@@ -34,7 +34,7 @@ fn test_request_deserialized() {
 fn test_response_result() {
     let payload: JsonRpcPayload =
         JsonRpcPayload::Response(JsonRpcResponse::Result(JsonRpcResult {
-            id: MessageId("1".into()),
+            id: "1".into(),
             jsonrpc: JSON_RPC_VERSION.clone(),
             result: "some result".into(),
         }));
@@ -54,7 +54,7 @@ fn test_response_result() {
 #[test]
 fn test_response_error() {
     let payload: JsonRpcPayload = JsonRpcPayload::Response(JsonRpcResponse::Error(JsonRpcError {
-        id: MessageId(1.to_string()),
+        id: 1.into(),
         jsonrpc: JSON_RPC_VERSION.clone(),
         error: ErrorResponse {
             code: 32,
@@ -67,7 +67,7 @@ fn test_response_error() {
 
     assert_eq!(
         &serialized,
-        "{\"id\":\"1\",\"jsonrpc\":\"2.0\",\"error\":{\"code\":32,\"message\":\"some message\",\"data\":null}}"
+        "{\"id\":1,\"jsonrpc\":\"2.0\",\"error\":{\"code\":32,\"message\":\"some message\",\"data\":null}}"
     );
 
     let deserialized: JsonRpcPayload = serde_json::from_str(&serialized).unwrap();

--- a/src/utils/json_rpc_cache.rs
+++ b/src/utils/json_rpc_cache.rs
@@ -22,7 +22,7 @@ pub async fn is_cached_response(
     metrics: &Metrics,
     moka_cache: &Cache<String, String>,
 ) -> Option<JsonRpcResponse> {
-    if let Ok(method) = request.method.as_ref().parse::<CachedMethods>() {
+    if let Ok(method) = (*request.method).parse::<CachedMethods>() {
         match method {
             CachedMethods::EthChainId => {
                 handle_eth_chain_id(caip2_chain_id, request, moka_cache, metrics).await
@@ -129,7 +129,7 @@ async fn handle_eth_chain_id(
     set_mem_cached_response(
         caip2_chain_id,
         CachedMethods::EthChainId.to_string().as_str(),
-        &chain_id_bytes,
+        chain_id_bytes.as_str(),
         moka_cache,
     )
     .await;

--- a/src/utils/json_rpc_cache.rs
+++ b/src/utils/json_rpc_cache.rs
@@ -22,7 +22,7 @@ pub async fn is_cached_response(
     metrics: &Metrics,
     moka_cache: &Cache<String, String>,
 ) -> Option<JsonRpcResponse> {
-    if let Ok(method) = (*request.method).parse::<CachedMethods>() {
+    if let Ok(method) = request.method.as_ref().parse::<CachedMethods>() {
         match method {
             CachedMethods::EthChainId => {
                 handle_eth_chain_id(caip2_chain_id, request, moka_cache, metrics).await


### PR DESCRIPTION
# Description

This PR fixes the bug in the `json_rpc` request and response by preserving the type of the `id`. 
We are converting any `id` types (number, string) to the string instead of preserving the exact `id` type and responding with the same type.
According to the [JSON-RPC specification](https://www.jsonrpc.org/specification) `id` can contain any of the string, number, or null types. Force conversion to the string type leads to client deserialization errors where it uses a number in the request and expects the number in the response. 
This PR changes to use a `serde_json::Value`, same as in the [jsonrpc crate](https://docs.rs/jsonrpc/0.18.0/src/jsonrpc/lib.rs.html#75) to preserve the type for the response.

## How Has This Been Tested?

Unit tests were updated and tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
