### PR TITLE
fix: disable failing tests

### DIFF
--- a/integration/exchanges.test.ts
+++ b/integration/exchanges.test.ts
@@ -178,7 +178,7 @@ describe('Exchanges', () => {
 
   describe('Get Exchange URL', () => {
     
-    binanceTestFn('should generate pay URL for Binance with USDC on Base', async () => {
+    binanceTestFn.skip('should generate pay URL for Binance with USDC on Base', async () => {
       const payload = {
         jsonrpc: '2.0',
         id: 1,
@@ -555,12 +555,12 @@ describe('Exchanges', () => {
         recipient: ethAddress,
         supportedExchanges: ['binance', 'coinbase']
       },
-      {
-        name: 'USDC on Base',
-        asset: baseUSDC,
-        recipient: baseAddress,
-        supportedExchanges: ['binance', 'coinbase']
-      },
+      // {
+      //   name: 'USDC on Base',
+      //   asset: baseUSDC,
+      //   recipient: baseAddress,
+      //   supportedExchanges: ['binance', 'coinbase']
+      // },
       {
         name: 'USDC on Ethereum',
         asset: ethUSDC,


### PR DESCRIPTION
# Description

Disable failing integration test due to upstream issue

[Slack conversation](https://reown-inc.slack.com/archives/C03SCF66K2T/p1753802464828789?thread_ts=1753794824.274629&cid=C03SCF66K2T)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
