### PR TITLE
feat: better rate-limited error message

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -559,8 +559,8 @@ impl IntoResponse for RpcError {
             Self::RateLimited(e) => (
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(new_error_response(
-                    "rate_limit".to_string(),
-                    format!("Rate limited: {e}"),
+                    "rate_limited".to_string(),
+                    format!("Requests per second limit exceeded: {e}"),
                 )),
             )
                 .into_response(),


### PR DESCRIPTION
# Description

This PR changes the error message when requests per second limit exceeded from `Rate limited` to `Requests per second limit exceeded` for clarity between the quota and RPS limit error messages.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
