### PR TITLE
fix: removing setting of the network syn in the terraform

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -172,21 +172,6 @@ resource "aws_ecs_task_definition" "app_task" {
         }
       ],
 
-      systemControls : [
-        {
-          namespace = "net.core.somaxconn",
-          value     = "8192"
-        },
-        {
-          namespace = "net.ipv4.tcp_max_syn_backlog",
-          value     = "4096"
-        },
-        {
-          namespace = "net.core.netdev_max_backlog",
-          value     = "5000"
-        }
-      ],
-
       logConfiguration : {
         logDriver = "awslogs",
         options = {


### PR DESCRIPTION
# Description

This PR removes setting the network backlog size from the Terraform due to the Fargate container can't start.

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
