### PR TITLE
fix(o11y): tune the 502 alert

### DIFF
--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -13,7 +13,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
   period        = '0m',
   conditions    = [
     grafana.alertCondition.new(
-      evaluatorParams = [ 0 ],
+      evaluatorParams = [ 15 ],
       evaluatorType   = 'gt',
       operatorType    = 'or',
       queryRefId      = 'ELB',

--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -13,6 +13,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
   period        = '0m',
   conditions    = [
     grafana.alertCondition.new(
+      // Threshold set to 15 based on operational experience: alert if average 5xx errors exceed 15 in 15 minutes, which typically indicates a significant issue requiring attention.
       evaluatorParams = [ 15 ],
       evaluatorType   = 'gt',
       operatorType    = 'or',


### PR DESCRIPTION
# Description

This PR changes the alerting threshold for 502s from 0 to 15 for 15 minutes, to avoid being always fired and alerting when we don't have a single occasion.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
