### PR TITLE
fix: reverting of adding axum custom listener with the backlog size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8356,7 +8356,6 @@ dependencies = [
  "serde_json",
  "serde_piecewise_default",
  "sha256",
- "socket2 0.5.10",
  "sqlx",
  "strum 0.26.3",
  "strum_macros 0.26.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tower-http = { version = "0.4", features = [
     "request-id",
     "util",
 ] }
-socket2 = "0.5.5"
 jsonrpc = "0.18.0"
 async-tungstenite = { version = "0.20.0", features = [
     "tokio",


### PR DESCRIPTION
# Description

This PR reverts the custom listener with the backlog from #1179 due to the degraded performance in production.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
