### PR TITLE
fix: fixing the ulimit to the Fargate maximum

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -14,8 +14,8 @@ locals {
   prometheus_proxy_cpu    = module.this.stage == "prod" ? 128 : 64
   prometheus_proxy_memory = module.this.stage == "prod" ? 128 : 64
 
-  file_descriptor_soft_limit = pow(2, 19)
-  file_descriptor_hard_limit = local.file_descriptor_soft_limit * 2
+  file_descriptor_soft_limit = pow(2, 20) # 1024 x 1024 = 1,048,576 is the Fargate maximum
+  file_descriptor_hard_limit = pow(2, 20)
 }
 
 module "ecs_cpu_mem" {


### PR DESCRIPTION
# Description

This PR fixes the `ulimit` size for the ECS instances to the `1,048,576` max, since the maximum value for the Fargate is `1024 x 1024 = 1,048,576` and we shouldn't exceed this.
Also, setting the soft value the same as hard because we don't need warnings since we are already using a maximum value.

## How Has This Been Tested?

Tested manually on staging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
