### PR TITLE
feat(ecs): increasing the minimal cluster count

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,13 +35,13 @@ variable "log_level" {
 variable "app_autoscaling_desired_count" {
   description = "The desired number of tasks to run"
   type        = number
-  default     = 2
+  default     = 3
 }
 
 variable "app_autoscaling_min_capacity" {
   description = "The minimum number of tasks to run when autoscaling"
   type        = number
-  default     = 2
+  default     = 3
 }
 
 variable "app_autoscaling_max_capacity" {


### PR DESCRIPTION
# Description

This PR increases the minimal ECS cluster count from 2 to 3 to handle sudden request spikes (x2, x3) without errors until the cluster scales. The current two instances are not enough to handle sudden request spikes, and we have `HTTP 5xx` responses during the x2 x3 spikes until the cluster scales.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
