### PR TITLE
feat(redis): updating the Redis cache engine version to 7 on staging environment

### DIFF
--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_cluster" "cache" {
   engine               = "redis"
   node_type            = var.node_type
   num_cache_nodes      = var.num_cache_nodes
-  parameter_group_name = "default.redis6.x"
+  parameter_group_name = "default.redis7"
   engine_version       = var.node_engine_version
   port                 = 6379
   subnet_group_name    = aws_elasticache_subnet_group.private_subnets.name

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -3,12 +3,14 @@ data "aws_vpc" "vpc" {
 }
 
 resource "aws_elasticache_cluster" "cache" {
-  cluster_id           = module.this.id
-  engine               = "redis"
-  node_type            = var.node_type
-  num_cache_nodes      = var.num_cache_nodes
-  parameter_group_name = "default.redis7"
-  engine_version       = var.node_engine_version
+  cluster_id      = module.this.id
+  engine          = "redis"
+  node_type       = var.node_type
+  num_cache_nodes = var.num_cache_nodes
+
+  # TODO: remove this once we have migrated to Redis 7 in the prod environment as well
+  parameter_group_name = module.this.stage == "prod" ? "default.redis6.x" : "default.redis7"
+  engine_version       = module.this.stage == "prod" ? "6.x" : var.node_engine_version
   port                 = 6379
   subnet_group_name    = aws_elasticache_subnet_group.private_subnets.name
   security_group_ids = [

--- a/terraform/redis/variables.tf
+++ b/terraform/redis/variables.tf
@@ -16,7 +16,7 @@ variable "num_cache_nodes" {
 variable "node_engine_version" {
   description = "The version of Redis to use"
   type        = string
-  default     = "6.x"
+  default     = "7.1"
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This PR updates the Elasticache Redis engine version from 6 to 7 on the staging environment and keep the current version for the prod.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
