### PR TITLE
fix(o11y): including 503 errors in the availability chart

### DIFF
--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -48,7 +48,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-24-9]"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
+      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
       refId       = "availability",
       exemplar    = false,
     ))


### PR DESCRIPTION
# Description

This PR makes a change to the SLA Availability chart to include `HTTP 503` errors (include all 5xx errors).

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
