### PR TITLE
fix(terraform): removing duplicated ECS defaults for variables

### DIFF
--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -29,19 +29,16 @@ variable "task_memory" {
 variable "autoscaling_desired_count" {
   description = "Minimum number of instances in the autoscaling group"
   type        = number
-  default     = 2
 }
 
 variable "autoscaling_min_capacity" {
   description = "Minimum number of instances in the autoscaling group"
   type        = number
-  default     = 2
 }
 
 variable "autoscaling_max_capacity" {
   description = "Maximum number of instances in the autoscaling group"
   type        = number
-  default     = 8
 }
 
 variable "cloudwatch_logs_key_arn" {


### PR DESCRIPTION
# Description

This PR removes the duplication of default values for the autoscaling variables for the ECS Terraform module.
We already have defaults set for these variables [in the main variables](https://github.com/reown-com/blockchain-api/blob/72007829e8062e1ed8ca510b9f540c953206bd28/terraform/variables.tf#L35), and they are [passed down to the ECS module](https://github.com/reown-com/blockchain-api/blob/72007829e8062e1ed8ca510b9f540c953206bd28/terraform/res_ecs.tf#L36). So these defaults create confusion and must be removed.

## How Has This Been Tested?

Not tested, but CI/CD plan should pass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
