### PR TITLE
chore: projectId feature validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "cerberus"
 version = "0.2.0"
-source = "git+https://github.com/WalletConnect/cerberus.git?tag=v0.14.0#c0072028c20774acf4e3d4b529557045b63df85a"
+source = "git+https://github.com/WalletConnect/cerberus.git?tag=v0.15.0#273a9361978d1b6cbe1dfdb6f6d88df7c5cb271a"
 dependencies = [
  "async-trait",
  "bitflags 2.9.1",
@@ -2660,6 +2660,7 @@ dependencies = [
  "regex",
  "reqwest 0.11.27",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ] }
 
-cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.14.0" }
+cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.15.0" }
 parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "99a1cc3", default-features = false, features = [
     "flate2",
 ] }

--- a/src/handlers/wallet/exchanges/mod.rs
+++ b/src/handlers/wallet/exchanges/mod.rs
@@ -219,6 +219,6 @@ pub async fn is_feature_enabled_for_project_id(
     }
 
     Err(ExchangeError::FeatureNotEnabled(
-        "Project is not allowed to use this feature".to_string(),
+        "Payments feature is not enabled for this project".to_string(),
     ))
 }

--- a/src/handlers/wallet/exchanges/mod.rs
+++ b/src/handlers/wallet/exchanges/mod.rs
@@ -1,15 +1,9 @@
 use {
     crate::{
         state::AppState,
-        utils::{crypto, crypto::Caip19Asset},
-    },
-    axum::extract::State,
-    serde::{Deserialize, Serialize},
-    std::sync::Arc,
-    strum::IntoEnumIterator,
-    strum_macros::{AsRefStr, EnumIter},
-    thiserror::Error,
-    tracing::debug,
+        utils::crypto::{self, Caip19Asset},
+    }, axum::extract::State, cerberus::project::{Feature, ProjectDataRequest}, serde::{Deserialize, Serialize}, std::sync::Arc, strum::IntoEnumIterator, strum_macros::{AsRefStr, EnumIter}, thiserror::Error, tracing::debug
+   
 };
 
 pub mod binance;
@@ -19,6 +13,8 @@ pub mod test_exchange;
 use binance::BinanceExchange;
 use coinbase::CoinbaseExchange;
 use test_exchange::TestExchange;
+
+const PAYMENTS_FEATURE_ID: &str = "payments";
 
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 pub struct Config {
@@ -172,7 +168,15 @@ pub fn get_exchange_by_id(id: &str) -> Option<Exchange> {
     ExchangeType::from_id(id).map(|e| e.to_exchange())
 }
 
-pub fn is_feature_enabled_for_project_id(
+async fn get_enabled_features( state: State<Arc<AppState>>, project_id: &String) -> Result<Vec<Feature>, ExchangeError> {
+    let request = ProjectDataRequest::new(project_id.as_str()).include_features().include_limits();
+    let project_data = state.registry.project_data_request(request).await.map_err(|e| ExchangeError::InternalError(e.to_string()))?;
+    debug!("project_data: {:?}", project_data);
+    let features = project_data.features.unwrap_or_default();
+    Ok(features)
+}
+
+pub async fn is_feature_enabled_for_project_id(
     state: State<Arc<AppState>>,
     project_id: &String,
 ) -> Result<(), ExchangeError> {
@@ -182,20 +186,20 @@ pub fn is_feature_enabled_for_project_id(
         }
     }
 
-    let allowed_project_ids = state
-        .config
-        .exchanges
-        .allowed_project_ids
-        .as_ref()
-        .ok_or_else(|| ExchangeError::FeatureNotEnabled("Feature is not enabled".to_string()))?;
-
-    debug!("allowed_project_ids: {:?}", allowed_project_ids);
-
-    if !allowed_project_ids.contains(project_id) {
-        return Err(ExchangeError::FeatureNotEnabled(
-            "Project is not allowed to use this feature".to_string(),
-        ));
+    if let Some(allowed_project_ids) = state.config.exchanges.allowed_project_ids.as_ref() {
+        debug!("allowed_project_ids: {:?}", allowed_project_ids);
+        if allowed_project_ids.contains(project_id) {
+            return Ok(());
+        }
     }
 
-    Ok(())
+    let features = get_enabled_features(state, project_id).await?;
+    debug!("features: {:?}", features);
+    if features.iter().any(|f| f.id == PAYMENTS_FEATURE_ID && f.is_enabled) {
+        return Ok(());
+    }
+
+    return Err(ExchangeError::FeatureNotEnabled(
+        "Project is not allowed to use this feature".to_string(),
+    ));
 }

--- a/src/handlers/wallet/get_exchange_buy_status.rs
+++ b/src/handlers/wallet/get_exchange_buy_status.rs
@@ -72,6 +72,7 @@ pub async fn handler(
     Json(request): Json<GetExchangeBuyStatusRequest>,
 ) -> Result<GetExchangeBuyStatusResponse, GetExchangeBuyStatusError> {
     is_feature_enabled_for_project_id(state.clone(), &project_id)
+        .await
         .map_err(|e| GetExchangeBuyStatusError::ValidationError(e.to_string()))?;
     handler_internal(state, connect_info, headers, query, request)
         .with_metrics(HANDLER_TASK_METRICS.with_name("pay_get_exchange_buy_status"))

--- a/src/handlers/wallet/get_exchange_url.rs
+++ b/src/handlers/wallet/get_exchange_url.rs
@@ -70,6 +70,7 @@ pub async fn handler(
     Json(request): Json<GeneratePayUrlRequest>,
 ) -> Result<GeneratePayUrlResponse, GetExchangeUrlError> {
     is_feature_enabled_for_project_id(state.clone(), &project_id)
+        .await
         .map_err(|e| GetExchangeUrlError::ValidationError(e.to_string()))?;
     handler_internal(state, project_id, connect_info, headers, query, request)
         .with_metrics(HANDLER_TASK_METRICS.with_name("pay_get_exchange_url"))

--- a/src/handlers/wallet/get_exchanges.rs
+++ b/src/handlers/wallet/get_exchanges.rs
@@ -76,6 +76,7 @@ pub async fn handler(
     Json(request): Json<GetExchangesRequest>,
 ) -> Result<GetExchangesResponse, GetExchangesError> {
     is_feature_enabled_for_project_id(state.clone(), &project_id)
+        .await
         .map_err(|e| GetExchangesError::ValidationError(e.to_string()))?;
     handler_internal(state, connect_info, headers, query, request)
         .with_metrics(HANDLER_TASK_METRICS.with_name("pay_get_exchanges"))

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -8,7 +8,10 @@ use {
         storage::{error::StorageError, redis},
     },
     cerberus::{
-        project::{PlanLimits, ProjectData, ProjectDataRequest, ProjectDataResponse, ProjectDataWithLimits, ProjectKey},
+        project::{
+            PlanLimits, ProjectData, ProjectDataRequest, ProjectDataResponse,
+            ProjectDataWithLimits, ProjectKey,
+        },
         registry::{RegistryClient, RegistryError, RegistryHttpClient, RegistryResult},
     },
     std::{sync::Arc, time::Instant},
@@ -99,7 +102,10 @@ impl Registry {
         })
     }
 
-    pub async fn project_data_request(&self, request: ProjectDataRequest<'_>) -> RpcResult<ProjectDataResponse> {
+    pub async fn project_data_request(
+        &self,
+        request: ProjectDataRequest<'_>,
+    ) -> RpcResult<ProjectDataResponse> {
         let time = Instant::now();
         let (source, data) = self.project_data_internal(request).await?;
         self.metrics.request(time.elapsed(), source, &data);
@@ -112,7 +118,7 @@ impl Registry {
     ) -> RpcResult<(ResponseSource, ProjectDataResult)> {
         if let Some(cache) = &self.cache {
             let time = Instant::now();
-            let data = cache.fetch(&request.id).await?;
+            let data = cache.fetch(request.id).await?;
             self.metrics.fetch_cache_time(time.elapsed());
 
             if let Some(data) = data {
@@ -122,7 +128,7 @@ impl Registry {
 
         let id = request.id;
         let data = self.fetch_registry(request).await;
-        
+
         // Cache all responses that we get, even errors.
         let data = match data {
             Ok(Some(data)) => Ok(data),
@@ -140,7 +146,10 @@ impl Registry {
         Ok((ResponseSource::Registry, data))
     }
 
-    async fn fetch_registry(&self, request: ProjectDataRequest<'_>) -> RegistryResult<Option<ProjectDataResponse>> {
+    async fn fetch_registry(
+        &self,
+        request: ProjectDataRequest<'_>,
+    ) -> RegistryResult<Option<ProjectDataResponse>> {
         let time = Instant::now();
 
         let data = if let Some(client) = &self.client {

--- a/src/project/storage/mod.rs
+++ b/src/project/storage/mod.rs
@@ -4,7 +4,7 @@ use {
         project::{error::ProjectDataError, metrics::ProjectDataMetrics},
         storage::{error::StorageError, KeyValueStorage, StorageResult},
     },
-    cerberus::project::ProjectDataWithLimits,
+    cerberus::project::ProjectDataResponse,
     std::{
         sync::Arc,
         time::{Duration, Instant},
@@ -15,7 +15,7 @@ use {
 
 mod config;
 
-pub type ProjectDataResult = Result<ProjectDataWithLimits, ProjectDataError>;
+pub type ProjectDataResult = Result<ProjectDataResponse, ProjectDataError>;
 
 #[derive(Clone, Debug)]
 pub struct ProjectStorage {
@@ -85,5 +85,5 @@ impl ProjectStorage {
 
 #[inline]
 fn build_cache_key(id: &str) -> String {
-    format!("project-data-v2/{id}")
+    format!("project-data-v3/{id}")
 }


### PR DESCRIPTION
# Description

Upgrade cerberus to v0.15.0 and add dynamic feature checking for exchanges

Changes:

- Bumped cerberus from v0.14.0 to v0.15.0
- Feature checking logic in exchange allowlist now checks static allowlist first, then falls back to payments feature flag from project registry
- `is_feature_enabled_for_project_id` is now async, updated all callers with .await
-  Switched to ProjectDataRequest builder pattern from cerberus in `project/mod.rs`
- Changed cache key to v3 due to data structure changes

What this does:
- Projects can get exchange access through the payments feature without being in the static config
- Still supports existing allowlist-based projects


Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
