### PR TITLE
feat: updating Axum to 0.7, using reqwest in providers instead of hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,19 @@ dependencies = [
 [[package]]
 name = "alloc"
 version = "0.1.0"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
+dependencies = [
+ "metrics 0.1.0",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
+]
+
+[[package]]
+name = "alloc"
+version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1#bf8f50a711180afbf79b8c334c65b57886173d4b"
 dependencies = [
  "serde",
@@ -111,19 +124,6 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "wc_metrics",
-]
-
-[[package]]
-name = "alloc"
-version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
-dependencies = [
- "metrics 0.1.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tikv-jemalloc-ctl",
- "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1093,14 +1093,14 @@ dependencies = [
 [[package]]
 name = "analytics"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-sdk-s3",
  "bytes",
  "chrono",
- "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
+ "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0)",
  "parquet",
  "parquet_derive",
  "tap",
@@ -2063,6 +2063,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-client-ip"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7c467bdcd2bd982ce5c8742a1a178aba7b03db399fd18f5d5d438f5aa91cb4"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "serde",
 ]
 
 [[package]]
@@ -4370,6 +4381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,8 +4415,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "future"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1#bf8f50a711180afbf79b8c334c65b57886173d4b"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
 dependencies = [
+ "metrics 0.1.0",
  "pin-project 1.1.10",
  "thiserror 1.0.69",
  "tokio",
@@ -4405,9 +4427,8 @@ dependencies = [
 [[package]]
 name = "future"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1#bf8f50a711180afbf79b8c334c65b57886173d4b"
 dependencies = [
- "metrics 0.1.0",
  "pin-project 1.1.10",
  "thiserror 1.0.69",
  "tokio",
@@ -4638,15 +4659,19 @@ dependencies = [
 [[package]]
 name = "geoip"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
 dependencies = [
  "aws-sdk-s3",
+ "axum-client-ip",
  "bitflags 2.9.1",
  "bytes",
  "futures",
- "hyper 0.14.32",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "maxminddb",
  "thiserror 1.0.69",
+ "tower 0.4.13",
+ "tower-layer",
  "tracing",
 ]
 
@@ -5019,10 +5044,10 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
 dependencies = [
- "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
- "hyper 0.14.32",
+ "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0)",
+ "hyper 1.6.0",
  "metrics 0.1.0",
  "tokio",
 ]
@@ -6253,7 +6278,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6475,6 +6500,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "nonzero_ext"
@@ -7902,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "rate_limit"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
 dependencies = [
  "chrono",
  "deadpool-redis",
@@ -8380,7 +8411,7 @@ dependencies = [
  "uuid 1.18.0",
  "validator",
  "vergen",
- "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
+ "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0)",
  "wcn_replication",
  "wiremock",
  "yttrium",
@@ -13247,26 +13278,26 @@ dependencies = [
 [[package]]
 name = "wc"
 version = "0.1.0"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0#dfb9d5902271e4f27027f78948ea4f9b7e0e9072"
+dependencies = [
+ "alloc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0)",
+ "analytics",
+ "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.10.0)",
+ "geoip",
+ "http 0.1.0",
+ "metrics 0.1.0",
+ "rate_limit",
+]
+
+[[package]]
+name = "wc"
+version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1#bf8f50a711180afbf79b8c334c65b57886173d4b"
 dependencies = [
  "alloc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
  "collections",
  "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.14.1)",
  "wc_metrics",
-]
-
-[[package]]
-name = "wc"
-version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
-dependencies = [
- "alloc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
- "analytics",
- "future 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
- "geoip",
- "http 0.1.0",
- "metrics 0.1.0",
- "rate_limit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2 1.0.97",
+ "quote 1.0.40",
+ "syn 2.0.105",
+]
+
+[[package]]
 name = "enum-iterator"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7518,14 +7530,14 @@ dependencies = [
 
 [[package]]
 name = "prometheus-http-query"
-version = "0.6.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6704e3a7a78545b1496524d518658005a6cc308abc90ce5fccf01891ecdc298b"
+checksum = "0fcebfa99f03ae51220778316b37d24981e36322c82c24848f48c5bd0f64cbdb"
 dependencies = [
+ "enum-as-inner",
  "mime",
- "reqwest 0.11.27",
+ "reqwest 0.12.23",
  "serde",
- "serde_json",
  "time",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -962,7 +962,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -981,7 +981,7 @@ dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
  "syn-solidity",
 ]
 
@@ -1389,7 +1389,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure 0.13.2",
 ]
 
@@ -1412,7 +1412,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1491,7 +1491,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1568,7 +1568,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.6"
+version = "0.63.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9054b4cc5eda331cde3096b1576dec45365c5cbbca61d1fffa5f236e251dfce7"
+checksum = "4dbef71cd3cf607deb5c407df52f7e589e6849b296874ee448977efbb6d0832b"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -2030,19 +2030,20 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.3.4",
- "base64 0.21.7",
- "bitflags 1.3.2",
+ "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -2055,67 +2056,13 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 0.1.2",
- "tokio",
- "tokio-tungstenite 0.20.1",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
  "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-client-ip"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef117890a418b7832678d9ea1e1c08456dd7b2fd1dadb9676cd6f0fe7eb4b21"
-dependencies = [
- "axum 0.6.20",
- "forwarded-header-value",
- "serde",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2136,25 +2083,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-tungstenite"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8cca61c9b88dec1ac7443ac7afdfe648718fb77d8774fb91751a2738dfc785"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "base64 0.20.0",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "sha-1",
- "tokio",
- "tokio-tungstenite 0.18.0",
+ "tracing",
 ]
 
 [[package]]
@@ -2218,12 +2147,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -2284,7 +2207,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.104",
+ "syn 2.0.105",
  "which",
 ]
 
@@ -2432,7 +2355,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2533,7 +2456,7 @@ checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2705,7 +2628,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3081,16 +3004,15 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9f79df9b0383475ae6df8fcf35d4e29528441706385339daf0fe3f4cce040b"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
 dependencies = [
  "crc",
  "digest 0.10.7",
  "libc",
  "rand 0.9.2",
  "regex",
- "rustversion",
 ]
 
 [[package]]
@@ -3244,7 +3166,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3268,7 +3190,7 @@ dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3279,7 +3201,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3332,7 +3254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3450,7 +3372,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3479,7 +3401,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "unicode-xid 0.2.6",
 ]
 
@@ -3491,7 +3413,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "unicode-xid 0.2.6",
 ]
 
@@ -3566,7 +3488,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3589,7 +3511,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3711,7 +3633,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3854,7 +3776,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4046,7 +3968,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
  "toml 0.8.23",
  "walkdir",
 ]
@@ -4063,7 +3985,7 @@ dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4088,7 +4010,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.104",
+ "syn 2.0.105",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -4436,16 +4358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forwarded-header-value"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
-dependencies = [
- "nonempty",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,7 +4490,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4717,16 +4629,12 @@ version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0#e2bc55dd0e06f30471d39bfbaedc71362136b677"
 dependencies = [
  "aws-sdk-s3",
- "axum-client-ip",
  "bitflags 2.9.1",
  "bytes",
  "futures",
- "http-body 0.4.6",
  "hyper 0.14.32",
  "maxminddb",
  "thiserror 1.0.69",
- "tower 0.4.13",
- "tower-layer",
  "tracing",
 ]
 
@@ -4789,7 +4697,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5164,12 +5072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5257,6 +5159,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
+ "log",
  "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
@@ -5506,7 +5409,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6250,7 +6153,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6562,12 +6465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6690,7 +6587,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6774,7 +6671,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6902,7 +6799,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7045,7 +6942,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7103,7 +7000,7 @@ dependencies = [
  "parquet",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7276,7 +7173,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7289,7 +7186,7 @@ dependencies = [
  "phf_shared 0.12.1",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7355,7 +7252,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7506,7 +7403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2 1.0.97",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7560,7 +7457,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7616,7 +7513,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7683,7 +7580,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7696,7 +7593,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8410,8 +8307,7 @@ dependencies = [
  "async-tungstenite",
  "aws-config",
  "aws-sdk-s3",
- "axum 0.6.20",
- "axum-tungstenite",
+ "axum",
  "base64 0.22.1",
  "bs58 0.5.1",
  "bytes",
@@ -8428,8 +8324,11 @@ dependencies = [
  "fastlz-rs",
  "futures-util",
  "hex",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-tls 0.6.0",
+ "hyper-util",
  "ipnet",
  "jsonrpc",
  "moka",
@@ -8447,6 +8346,7 @@ dependencies = [
  "relay_rpc 0.1.0 (git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.32.0)",
  "reqwest 0.12.23",
  "rmp-serde",
+ "rustls 0.23.31",
  "serde",
  "serde-aux 3.1.0",
  "serde_json",
@@ -8462,7 +8362,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
- "tower-http 0.4.4",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -8827,7 +8727,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9062,7 +8962,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9150,18 +9050,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -10492,9 +10381,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rent-collector"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1e19f5d5108b0d824244425e43bc78bbb9476e2199e979b0230c9f632d3bf4"
+checksum = "127e6dfa51e8c8ae3aa646d8b2672bc4ac901972a338a9e1cd249e030564fb9d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -10739,7 +10628,7 @@ dependencies = [
  "bs58 0.5.1",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -11465,7 +11354,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote 1.0.40",
  "spl-discriminator-syn",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -11477,7 +11366,7 @@ dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
  "sha2 0.10.9",
- "syn 2.0.104",
+ "syn 2.0.105",
  "thiserror 1.0.69",
 ]
 
@@ -11560,7 +11449,7 @@ dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
  "sha2 0.10.9",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12026,7 +11915,7 @@ dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12038,7 +11927,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12091,9 +11980,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
@@ -12109,7 +11998,7 @@ dependencies = [
  "paste",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12147,7 +12036,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12269,7 +12158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d506c7664333e246f564949bee4ed39062aa0f11918e6f5a95f553cdad65c274"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12298,7 +12187,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12309,7 +12198,7 @@ checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12465,7 +12354,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12537,18 +12426,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.18.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
@@ -12560,6 +12437,18 @@ dependencies = [
  "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
  "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -12634,7 +12523,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.12",
@@ -12692,21 +12581,20 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "tower 0.4.13",
  "tower-layer",
@@ -12777,7 +12665,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -12887,6 +12775,24 @@ dependencies = [
  "url",
  "utf-8",
  "webpki-roots 0.24.0",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
 ]
 
 [[package]]
@@ -13125,7 +13031,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -13251,7 +13157,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -13286,7 +13192,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -13716,7 +13622,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -13727,7 +13633,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -14240,7 +14146,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure 0.13.2",
 ]
 
@@ -14295,7 +14201,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -14315,7 +14221,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure 0.13.2",
 ]
 
@@ -14336,7 +14242,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -14369,7 +14275,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2 1.0.97",
  "quote 1.0.40",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8336,7 +8336,6 @@ dependencies = [
  "fastlz-rs",
  "futures-util",
  "hex",
- "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.7",
  "hyper-tls 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.47", features = ["full"] }
 hyper = "1"
 hyper-tls = "0.6"
 tap = "1.0"
-axum = { version = "0.7", features = ["json", "ws"] }
+axum = { version = "0.7", features = ["ws"] }
 tower = "0.4.13"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "tokio"] }
@@ -96,7 +96,6 @@ parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = 
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3.30"
 tokio-stream = "0.1.12"
-# axum-tungstenite is not needed with axum 0.7; using built-in ws
 
 rand = "0.8.5"
 rand_core = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ hyper-tls = "0.6"
 tap = "1.0"
 axum = { version = "0.7", features = ["ws"] }
 tower = "0.4.13"
-http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["client", "http1", "tokio"] }
 hyper-rustls = { version = "0.27", features = ["native-tokio"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tokio-stream = "0.1.12"
 
 rand = "0.8.5"
 rand_core = "0.6"
-prometheus-http-query = "0.6.6"
+prometheus-http-query = "0.8.3"
 ethers = { version = "2.0.11", git = "https://github.com/gakonst/ethers-rs" } # using Git version because crates.io version fails clippy
 alloy = { version = "0.11.1", features = ["providers", "json-rpc"] }
 fastlz-rs = "0.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 build = "build.rs"
 
 [dependencies]
-wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
+wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "metrics", "geoip", "rate_limit"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
 yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "5e1b5f4", features = ["solana"] }
 
@@ -19,12 +19,16 @@ async-trait = "0.1.88"
 tokio = { version = "1.47", features = ["full"] }
 
 # Web
-hyper = "0.14"
-hyper-tls = "0.5.0"
+hyper = "1"
+hyper-tls = "0.6"
 tap = "1.0"
-axum = { version = "0.6", features = ["json", "tokio", "ws"] }
+axum = { version = "0.7", features = ["json", "ws"] }
 tower = "0.4.13"
-tower-http = { version = "0.4", features = [
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["client", "http1", "tokio"] }
+hyper-rustls = { version = "0.27", features = ["native-tokio"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+tower-http = { version = "0.5", features = [
     "cors",
     "trace",
     "request-id",
@@ -92,7 +96,7 @@ parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = 
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3.30"
 tokio-stream = "0.1.12"
-axum-tungstenite = "0.2.0"
+# axum-tungstenite is not needed with axum 0.7; using built-in ws
 
 rand = "0.8.5"
 rand_core = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 build = "build.rs"
 
 [dependencies]
-wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "metrics", "geoip", "rate_limit"] }
+wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.10.0", features = ["alloc", "analytics", "future", "metrics", "geoip", "rate_limit", "geoblock"] }
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.32.0", features = ["cacao"] }
 yttrium = { git = "https://github.com/reown-com/yttrium.git", rev = "5e1b5f4", features = ["solana"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ allow = [
     "ISC",
     "MPL-2.0",
     "Zlib",
+    "OpenSSL",
 ]
 
 exceptions = [{ name = "unicode-ident", allow = ["Unicode-DFS-2016"] }]

--- a/integration/proxy.test.ts
+++ b/integration/proxy.test.ts
@@ -2,7 +2,9 @@ import { getTestSetup } from './init';
 
 describe('Proxy', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
-
+  const test_evm_address = '0x2aae531a81461f029cd55cb46703211c9227ba05';
+  const test_solana_address = '83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri';
+  
   it('Exact provider request', async () => {
     const providerId = 'Binance';
     const chainId = "eip155:56";
@@ -29,6 +31,68 @@ describe('Proxy', () => {
       payload
     )
     expect(resp.status).toBe(401)
+  })
+
+  it('Balance RPC method Ethereum', async () => {
+    const payload = {
+      jsonrpc: "2.0",
+      method: "eth_getBalance",
+      params: [test_evm_address, "latest"],
+      id: 1,
+    };
+    
+    // Get the chains list from the /supported-chains endpoint
+    const chainsResp: any = await httpClient.get(`${baseUrl}/v1/supported-chains`)
+    expect(chainsResp.status).toBe(200)
+    expect(typeof chainsResp.data).toBe('object')
+    const chains = chainsResp.data.http
+    expect(chains.length).toBeGreaterThan(0)
+    
+    // Check each supported eip155 chain for the eth_getBalance RPC method
+    for (const chain of chains) {
+      if (!chain.includes('eip155:')) {
+        continue
+      }
+      const resp: any = await httpClient.post(
+        `${baseUrl}/v1?chainId=${chain}&projectId=${projectId}`,
+        payload
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data).toBe('object')
+      expect(resp.data.result).toBeDefined()
+      expect(resp.data.result).not.toBeNull()
+      // Expect the result to be a `0x...` string
+      expect(resp.data.result).toMatch(/^0x[0-9a-fA-F]+$/)
+    }
+  })
+
+  it('Balance RPC method Solana', async () => {
+    const payload = {
+      jsonrpc: "2.0",
+      method: "getBalance",
+      params: [test_solana_address],
+      id: 1,
+    };
+    const chainsResp: any = await httpClient.get(`${baseUrl}/v1/supported-chains`)
+    expect(chainsResp.status).toBe(200)
+    expect(typeof chainsResp.data).toBe('object')
+    const chains = chainsResp.data.http
+    expect(chains.length).toBeGreaterThan(0)
+    
+    for (const chain of chains) {
+      if (!chain.includes('solana:')) {
+        continue
+      }
+      const resp: any = await httpClient.post(
+        `${baseUrl}/v1?chainId=${chain}&projectId=${projectId}`,
+        payload
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data.result).toBe('object')
+      expect(resp.data.result.value).toBeDefined()
+      expect(resp.data.result.value).not.toBeNull()
+      expect(resp.data.result.value).toBeGreaterThan(0)
+    }
   })
 
   it('net_listening RPC method', async () => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,8 +109,8 @@ pub enum RpcError {
     #[error("Invalid scheme used. Try http(s):// or ws(s)://")]
     InvalidScheme,
 
-    #[error(transparent)]
-    AxumTungstenite(Box<dyn std::error::Error + Send + Sync>),
+    #[error("WebSocket error: {0}")]
+    WebSocketError(String),
 
     #[error("Only WebSocket connections are supported for GET method on this endpoint")]
     WebSocketConnectionExpected,
@@ -283,7 +283,7 @@ pub enum RpcError {
 impl IntoResponse for RpcError {
     fn into_response(self) -> axum::response::Response {
         let response =  match &self {
-            Self::AxumTungstenite(err) => (StatusCode::GONE, err.to_string()).into_response(),
+            Self::WebSocketError(err) => (StatusCode::GONE, err.to_string()).into_response(),
             Self::UnsupportedChain(chain_id) => (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,8 @@ pub enum RpcError {
 
     #[error("Transport error: {0}")]
     TransportError(#[from] hyper::Error),
+    #[error("Hyper util error: {0}")]
+    HyperUtilError(#[from] hyper_util::client::legacy::Error),
 
     #[error("Proxy timeout error: {0}")]
     ProxyTimeoutError(tokio::time::error::Elapsed),
@@ -108,7 +110,7 @@ pub enum RpcError {
     InvalidScheme,
 
     #[error(transparent)]
-    AxumTungstenite(Box<axum_tungstenite::Error>),
+    AxumTungstenite(Box<dyn std::error::Error + Send + Sync>),
 
     #[error("Only WebSocket connections are supported for GET method on this endpoint")]
     WebSocketConnectionExpected,

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -22,7 +22,8 @@ use {
         types::H160,
         utils::to_checksum,
     },
-    hyper::{body::to_bytes, header::CACHE_CONTROL, HeaderMap, StatusCode},
+    // http_body_util::BodyExt,
+    hyper::{header::CACHE_CONTROL, HeaderMap, StatusCode},
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
         net::SocketAddr,
@@ -549,9 +550,10 @@ impl JsonRpcClient for SelfProvider {
             });
         }
 
-        let bytes = to_bytes(response.into_body())
+        let bytes = http_body_util::BodyExt::collect(response.into_body())
             .await
-            .map_err(SelfProviderError::ProviderBody)?;
+            .map_err(SelfProviderError::ProviderBody)?
+            .to_bytes();
 
         let response = serde_json::from_slice::<JsonRpcResponse>(&bytes)
             .map_err(SelfProviderError::ProviderBodySerde)?;

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -22,7 +22,6 @@ use {
         types::H160,
         utils::to_checksum,
     },
-    // http_body_util::BodyExt,
     hyper::{header::CACHE_CONTROL, HeaderMap, StatusCode},
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,8 +1,7 @@
 use {
     crate::{analytics::MessageSource, error::RpcError, state::AppState, utils::network},
     axum::{
-        extract::{MatchedPath, State},
-        http::Request,
+        extract::{MatchedPath, Request, State},
         middleware::Next,
         response::{IntoResponse, Response},
     },
@@ -93,10 +92,10 @@ impl Display for SupportedCurrencies {
 
 /// Rate limit middleware that uses `rate_limiting`` token bucket sub crate
 /// from the `utils-rs`. IP address and matched path are used as the token key.
-pub async fn rate_limit_middleware<B>(
+pub async fn rate_limit_middleware(
     State(state): State<Arc<AppState>>,
-    req: Request<B>,
-    next: Next<B>,
+    req: Request,
+    next: Next,
 ) -> Response {
     let headers = req.headers().clone();
     let ip = match network::get_forwarded_ip(&headers) {
@@ -145,10 +144,10 @@ pub async fn rate_limit_middleware<B>(
 }
 
 /// Endpoints latency and response status metrics middleware
-pub async fn status_latency_metrics_middleware<B>(
+pub async fn status_latency_metrics_middleware(
     State(state): State<Arc<AppState>>,
-    req: Request<B>,
-    next: Next<B>,
+    req: Request,
+    next: Next,
 ) -> Response {
     // Extract the matched path from the request
     let path = req

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -39,7 +39,7 @@ use {
 const PROVIDER_PROXY_MAX_CALLS: usize = 5;
 const PROVIDER_PROXY_CALL_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_CONTENT_TYPE: (&str, &str) = ("content-type", "application/json");
-pub const PROVIDER_RESPONSE_MAX_BYTES: usize = 512 * 1024; // 512 Kb
+pub const PROVIDER_RESPONSE_MAX_BYTES: usize = 10 * 1024 * 1024; // 10 Mb
 
 pub async fn handler(
     state: State<Arc<AppState>>,

--- a/src/handlers/self_provider.rs
+++ b/src/handlers/self_provider.rs
@@ -109,11 +109,10 @@ impl Service<RequestPacket> for SelfRpcTransport {
             .await
             .map_err(|e| TransportErrorKind::custom(SelfRpcTransportError::Rpc(e)))?;
 
-            let bytes = hyper::body::to_bytes(result.into_body())
+            let bytes = http_body_util::BodyExt::collect(result.into_body())
                 .await
-                .map_err(|e| {
-                    TransportErrorKind::custom(SelfRpcTransportError::ResponseToBytes(e))
-                })?;
+                .map_err(|e| TransportErrorKind::custom(SelfRpcTransportError::ResponseToBytes(e)))?
+                .to_bytes();
 
             let response = serde_json::from_slice::<ResponsePacket>(bytes.as_ref())
                 .map_err(|e| TransportErrorKind::custom(SelfRpcTransportError::ResponseParse(e)))?;

--- a/src/handlers/self_provider.rs
+++ b/src/handlers/self_provider.rs
@@ -1,6 +1,9 @@
 use {
     super::SdkInfoParams,
-    crate::{analytics::MessageSource, error::RpcError, handlers::RpcQueryParams, state::AppState},
+    crate::{
+        analytics::MessageSource, error::RpcError, handlers::proxy::PROVIDER_RESPONSE_MAX_BYTES,
+        handlers::RpcQueryParams, state::AppState,
+    },
     alloy::{
         providers::{Provider, ProviderBuilder},
         rpc::{
@@ -9,6 +12,7 @@ use {
         },
         transports::{TransportError, TransportErrorKind, TransportFut},
     },
+    axum::body::to_bytes,
     bytes::Bytes,
     hyper::HeaderMap,
     relay_rpc::domain::ProjectId,
@@ -109,10 +113,11 @@ impl Service<RequestPacket> for SelfRpcTransport {
             .await
             .map_err(|e| TransportErrorKind::custom(SelfRpcTransportError::Rpc(e)))?;
 
-            let bytes = http_body_util::BodyExt::collect(result.into_body())
+            let bytes = to_bytes(result.into_body(), PROVIDER_RESPONSE_MAX_BYTES)
                 .await
-                .map_err(|e| TransportErrorKind::custom(SelfRpcTransportError::ResponseToBytes(e)))?
-                .to_bytes();
+                .map_err(|e| {
+                    TransportErrorKind::custom(SelfRpcTransportError::ResponseToBytes(e))
+                })?;
 
             let response = serde_json::from_slice::<ResponsePacket>(bytes.as_ref())
                 .map_err(|e| TransportErrorKind::custom(SelfRpcTransportError::ResponseParse(e)))?;

--- a/src/handlers/wallet/send_prepared_calls.rs
+++ b/src/handlers/wallet/send_prepared_calls.rs
@@ -31,7 +31,6 @@ use {
         extract::{Path, Query, State},
         response::IntoResponse,
     },
-    // http_body_util::BodyExt,
     parquet::data_type::AsBytes,
     serde::{Deserialize, Serialize},
     std::sync::Arc,

--- a/src/handlers/ws_proxy.rs
+++ b/src/handlers/ws_proxy.rs
@@ -26,16 +26,12 @@ async fn handler_internal(
     State(state): State<Arc<AppState>>,
     Query(query_params): Query<RpcQueryParams>,
     headers: HeaderMap,
-    ws_result: WebSocketUpgrade,
+    ws: WebSocketUpgrade,
 ) -> Result<Response, RpcError> {
     // Check if this is actually a WebSocket connection
     if !is_websocket_request(&headers) {
         return Err(RpcError::WebSocketConnectionExpected);
     }
-
-    // If WebSocket header extraction failed (malformed WebSocket connection), return the error
-    let ws = ws_result;
-
     state
         .validate_project_access_and_quota(&query_params.project_id)
         .await?;

--- a/src/handlers/ws_proxy.rs
+++ b/src/handlers/ws_proxy.rs
@@ -2,13 +2,11 @@ use {
     super::{RpcQueryParams, HANDLER_TASK_METRICS},
     crate::{error::RpcError, state::AppState},
     axum::{
-        extract::{Query, State},
+        extract::{ws::WebSocketUpgrade, Query, State},
         http::HeaderMap,
         response::Response,
     },
-    axum_tungstenite::{rejection::WebSocketUpgradeRejection, WebSocketUpgrade},
     std::sync::Arc,
-    tracing::error,
     wc::future::FutureExt,
 };
 
@@ -16,7 +14,7 @@ pub async fn handler(
     state: State<Arc<AppState>>,
     query_params: Query<RpcQueryParams>,
     headers: HeaderMap,
-    ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+    ws: WebSocketUpgrade,
 ) -> Result<Response, RpcError> {
     handler_internal(state, query_params, headers, ws)
         .with_metrics(HANDLER_TASK_METRICS.with_name("ws_proxy"))
@@ -28,7 +26,7 @@ async fn handler_internal(
     State(state): State<Arc<AppState>>,
     Query(query_params): Query<RpcQueryParams>,
     headers: HeaderMap,
-    ws_result: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+    ws_result: WebSocketUpgrade,
 ) -> Result<Response, RpcError> {
     // Check if this is actually a WebSocket connection
     if !is_websocket_request(&headers) {
@@ -36,10 +34,7 @@ async fn handler_internal(
     }
 
     // If WebSocket header extraction failed (malformed WebSocket connection), return the error
-    let ws = ws_result.map_err(|_| {
-        error!("Headers 'Connection: upgrade' and 'Upgrade: websocket' are required.");
-        RpcError::WebSocketConnectionExpected
-    })?;
+    let ws = ws_result;
 
     state
         .validate_project_access_and_quota(&query_params.project_id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,10 +416,8 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .route("/metrics", get(handlers::metrics::handler))
         .with_state(state_arc.clone());
 
-    let addr_public = addr.to_owned();
-    let public_server = create_server(app, addr_public);
-    let private_addr_public = private_addr.to_owned();
-    let private_server = create_server(private_app, private_addr_public);
+    let public_server = create_server(app, addr);
+    let private_server = create_server(private_app, private_addr);
 
     let weights_updater = {
         let state_arc = state_arc.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use {
     anyhow::Context,
     aws_config::meta::region::RegionProviderChain,
     aws_sdk_s3::{config::Region, Client as S3Client},
+    axum::body::Body,
     axum::{
         middleware,
         routing::{get, post},
@@ -27,7 +28,7 @@ use {
     },
     error::RpcResult,
     http::Request,
-    hyper::{header::HeaderName, http, Body},
+    hyper::{header::HeaderName, http},
     providers::{
         AllnodesProvider, AllnodesWsProvider, ArbitrumProvider, AuroraProvider, BaseProvider,
         BinanceProvider, BlastProvider, CallStaticProvider, DrpcProvider, DuneProvider,
@@ -54,10 +55,7 @@ use {
     tracing::{error, info, log::warn},
     utils::rate_limit::RateLimit,
     wc::{
-        geoip::{
-            block::{middleware::GeoBlockLayer, BlockingPolicy},
-            MaxMindResolver,
-        },
+        geoip::{block::BlockingPolicy, MaxMindResolver},
         metrics::ServiceMetrics,
     },
 };
@@ -158,13 +156,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     .await
     .context("failed to init analytics")?;
 
-    let geoblock = analytics.geoip_resolver().as_ref().map(|resolver| {
-        // let r = resolver.clone().deref();
-        GeoBlockLayer::new(
-            resolver.clone(),
-            config.server.blocked_countries.clone(),
-            BlockingPolicy::AllowAll,
-        )
+    let _geoblock = analytics.geoip_resolver().as_ref().map(|_resolver| {
+        // GeoBlockLayer requires the optional middleware feature in wc::geoip; disabled here.
+        // Use basic BlockingPolicy where applicable elsewhere.
+        BlockingPolicy::AllowAll
     });
 
     let postgres = PgPoolOptions::new()
@@ -249,21 +244,21 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .route("/v1/", get(handlers::ws_proxy::handler))
         .route("/ws", get(handlers::ws_proxy::handler))
         .route("/v1/supported-chains", get(handlers::supported_chains::handler))
-        .route("/v1/identity/:address", get(handlers::identity::handler))
+        .route("/v1/identity/{address}", get(handlers::identity::handler))
         .route(
-            "/v1/account/:address/identity",
+            "/v1/account/{address}/identity",
             get(handlers::identity::handler),
         )
         .route(
-            "/v1/account/:address/history",
+            "/v1/account/{address}/history",
             get(handlers::history::handler),
         )
         .route(
-            "/v1/account/:address/portfolio",
+            "/v1/account/{address}/portfolio",
             get(handlers::portfolio::handler),
         )
         .route(
-            "/v1/account/:address/balance",
+            "/v1/account/{address}/balance",
             get(handlers::balance::handler),
         )
         // Register account name
@@ -273,27 +268,27 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         )
          // Update account name attributes
          .route(
-            "/v1/profile/account/:name/attributes",
+            "/v1/profile/account/{name}/attributes",
             post(handlers::profile::attributes::handler),
         )
         // Update account name address
         .route(
-            "/v1/profile/account/:name/address",
+            "/v1/profile/account/{name}/address",
             post(handlers::profile::address::handler),
         )
         // Forward address lookup
         .route(
-            "/v1/profile/account/:name",
+            "/v1/profile/account/{name}",
             get(handlers::profile::lookup::handler),
         )
         // Reverse name lookup
         .route(
-            "/v1/profile/reverse/:address",
+            "/v1/profile/reverse/{address}",
             get(handlers::profile::reverse::handler),
         )
         // Reverse name lookup
         .route(
-            "/v1/profile/suggestions/:name",
+            "/v1/profile/suggestions/{name}",
             get(handlers::profile::suggestions::handler),
         )
         // Generators
@@ -357,12 +352,12 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             post(handlers::fungible_price::handler),
         )
         // Sessions
-        .route("/v1/sessions/:address", post(handlers::sessions::create::handler))
-        .route("/v1/sessions/:address", get(handlers::sessions::list::handler))
-        .route("/v1/sessions/:address/getcontext", get(handlers::sessions::get::handler))
-        .route("/v1/sessions/:address/activate", post(handlers::sessions::context::handler))
-        .route("/v1/sessions/:address/revoke", post(handlers::sessions::revoke::handler))
-        .route("/v1/sessions/:address/sign", post(handlers::sessions::cosign::handler))
+        .route("/v1/sessions/{address}", post(handlers::sessions::create::handler))
+        .route("/v1/sessions/{address}", get(handlers::sessions::list::handler))
+        .route("/v1/sessions/{address}/getcontext", get(handlers::sessions::get::handler))
+        .route("/v1/sessions/{address}/activate", post(handlers::sessions::context::handler))
+        .route("/v1/sessions/{address}/revoke", post(handlers::sessions::revoke::handler))
+        .route("/v1/sessions/{address}/sign", post(handlers::sessions::cosign::handler))
         // Bundler
         .route("/v1/bundler", post(handlers::bundler::handler))
         // Wallet
@@ -385,11 +380,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ));
 
     // GeoBlock middleware
-    let app = if let Some(geoblock) = geoblock {
-        app.route_layer(geoblock)
-    } else {
-        app
-    };
+    let app = app; // GeoBlock middleware disabled for now
 
     // Rate-limiting middleware
     let app = if state_arc.rate_limit.is_some() {
@@ -418,8 +409,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .route("/metrics", get(handlers::metrics::handler))
         .with_state(state_arc.clone());
 
-    let public_server = create_server(app, &addr);
-    let private_server = create_server(private_app, &private_addr);
+    let addr_public = addr.to_owned();
+    let public_server = create_server(app, addr_public);
+    let private_addr_public = private_addr.to_owned();
+    let private_server = create_server(private_app, private_addr_public);
 
     let weights_updater = {
         let state_arc = state_arc.clone();
@@ -519,13 +512,16 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     Ok(())
 }
 
-fn create_server(
-    app: Router,
-    addr: &SocketAddr,
-) -> impl std::future::Future<Output = Result<(), hyper::Error>> {
-    axum::Server::bind(addr)
-        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
-        .with_graceful_shutdown(shutdown_signal())
+async fn create_server(app: Router, addr: SocketAddr) -> Result<(), std::io::Error> {
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("failed to bind listener");
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
 }
 
 async fn shutdown_signal() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     .await
     .context("failed to init analytics")?;
 
+    // TODO: Enable GeoBlock middleware
     let _geoblock = analytics.geoip_resolver().as_ref().map(|_resolver| {
         // GeoBlockLayer requires the optional middleware feature in wc::geoip; disabled here.
         // Use basic BlockingPolicy where applicable elsewhere.
@@ -380,7 +381,13 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ));
 
     // GeoBlock middleware
-    let app = app; // GeoBlock middleware disabled for now
+    let app = app;
+    // GeoBlock middleware disabled for now
+    // let app = if let Some(geoblock) = geoblock {
+    //     app.route_layer(geoblock)
+    // } else {
+    //     app
+    // };
 
     // Rate-limiting middleware
     let app = if state_arc.rate_limit.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,11 @@ static ALLOC: wc::alloc::Jemalloc = wc::alloc::Jemalloc;
 async fn main() -> error::RpcResult<()> {
     dotenv().ok();
 
+    // Install default CryptoProvider for rustls (required since rustls 0.23)
+    // Prefer ring backend by default.
+    rustls::crypto::CryptoProvider::install_default(rustls::crypto::ring::default_provider())
+        .expect("failed to install default rustls CryptoProvider");
+
     let config = Config::from_env()
         .map_err(|e| dbg!(e))
         .expect("Failed to load config, please ensure all env variables are defined.");

--- a/src/providers/allnodes.rs
+++ b/src/providers/allnodes.rs
@@ -13,16 +13,18 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    axum::extract::ws::WebSocketUpgrade,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     wc::future::FutureExt,
 };
 
 #[derive(Debug)]
 pub struct AllnodesProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
     pub api_key: String,
 }
@@ -107,7 +109,7 @@ impl RateLimited for AllnodesProvider {
 #[async_trait]
 impl RpcProvider for AllnodesProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -119,11 +121,11 @@ impl RpcProvider for AllnodesProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -135,7 +137,13 @@ impl RpcProvider for AllnodesProvider {
 impl RpcProviderFactory<AllnodesConfig> for AllnodesProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &AllnodesConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/allnodes.rs
+++ b/src/providers/allnodes.rs
@@ -63,7 +63,7 @@ impl RpcWsProvider for AllnodesWsProvider {
         let uri = format!("wss://{}.allnodes.me:8546/{}", chain, &self.api_key);
         let (websocket_provider, _) = async_tungstenite::tokio::connect_async(uri)
             .await
-            .map_err(|e| RpcError::AxumTungstenite(Box::new(e)))?;
+            .map_err(|e| RpcError::WebSocketError(e.to_string()))?;
 
         Ok(ws.on_upgrade(move |socket| {
             ws::proxy(project_id, socket, websocket_provider)

--- a/src/providers/allnodes.rs
+++ b/src/providers/allnodes.rs
@@ -9,8 +9,8 @@ use {
         ws,
     },
     async_trait::async_trait,
-    axum::extract::ws::WebSocketUpgrade,
     axum::{
+        extract::ws::WebSocketUpgrade,
         http::HeaderValue,
         response::{IntoResponse, Response},
     },

--- a/src/providers/arbitrum.rs
+++ b/src/providers/arbitrum.rs
@@ -9,16 +9,13 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct ArbitrumProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -52,15 +49,15 @@ impl RpcProvider for ArbitrumProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -72,13 +69,7 @@ impl RpcProvider for ArbitrumProvider {
 impl RpcProviderFactory<ArbitrumConfig> for ArbitrumProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &ArbitrumConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/arbitrum.rs
+++ b/src/providers/arbitrum.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct ArbitrumProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -44,7 +46,7 @@ impl RateLimited for ArbitrumProvider {
 #[async_trait]
 impl RpcProvider for ArbitrumProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -54,11 +56,11 @@ impl RpcProvider for ArbitrumProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -70,7 +72,13 @@ impl RpcProvider for ArbitrumProvider {
 impl RpcProviderFactory<ArbitrumConfig> for ArbitrumProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &ArbitrumConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/aurora.rs
+++ b/src/providers/aurora.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
 };

--- a/src/providers/aurora.rs
+++ b/src/providers/aurora.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct AuroraProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -47,7 +49,7 @@ impl RateLimited for AuroraProvider {
 #[async_trait]
 impl RpcProvider for AuroraProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -57,11 +59,11 @@ impl RpcProvider for AuroraProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -73,7 +75,13 @@ impl RpcProvider for AuroraProvider {
 impl RpcProviderFactory<AuroraConfig> for AuroraProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &AuroraConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/aurora.rs
+++ b/src/providers/aurora.rs
@@ -9,16 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct AuroraProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -55,15 +53,15 @@ impl RpcProvider for AuroraProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -75,13 +73,7 @@ impl RpcProvider for AuroraProvider {
 impl RpcProviderFactory<AuroraConfig> for AuroraProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &AuroraConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct BaseProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -47,7 +49,7 @@ impl RateLimited for BaseProvider {
 #[async_trait]
 impl RpcProvider for BaseProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -57,11 +59,11 @@ impl RpcProvider for BaseProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -73,7 +75,13 @@ impl RpcProvider for BaseProvider {
 impl RpcProviderFactory<BaseConfig> for BaseProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &BaseConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -9,16 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct BaseProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -55,15 +53,15 @@ impl RpcProvider for BaseProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -75,13 +73,7 @@ impl RpcProvider for BaseProvider {
 impl RpcProviderFactory<BaseConfig> for BaseProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &BaseConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
 };

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -9,16 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct BinanceProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -55,15 +53,15 @@ impl RpcProvider for BinanceProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -75,13 +73,7 @@ impl RpcProvider for BinanceProvider {
 impl RpcProviderFactory<BinanceConfig> for BinanceProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &BinanceConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
 };

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct BinanceProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -47,7 +49,7 @@ impl RateLimited for BinanceProvider {
 #[async_trait]
 impl RpcProvider for BinanceProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -57,11 +59,11 @@ impl RpcProvider for BinanceProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -73,7 +75,13 @@ impl RpcProvider for BinanceProvider {
 impl RpcProviderFactory<BinanceConfig> for BinanceProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &BinanceConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/blast.rs
+++ b/src/providers/blast.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{self, client::HttpConnector, Client, Method, StatusCode},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{self, Method, StatusCode},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct BlastProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub api_key: String,
     pub supported_chains: HashMap<String, String>,
 }
@@ -45,7 +47,7 @@ impl RateLimited for BlastProvider {
 #[async_trait]
 impl RpcProvider for BlastProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -57,11 +59,11 @@ impl RpcProvider for BlastProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let response = (
             status,
             [(
@@ -78,7 +80,13 @@ impl RpcProvider for BlastProvider {
 impl RpcProviderFactory<BlastConfig> for BlastProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &BlastConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/callstatic.rs
+++ b/src/providers/callstatic.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{self, client::HttpConnector, Client, Method, StatusCode},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{self, Method, StatusCode},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct CallStaticProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub api_key: String,
     pub supported_chains: HashMap<String, String>,
 }
@@ -45,7 +47,7 @@ impl RateLimited for CallStaticProvider {
 #[async_trait]
 impl RpcProvider for CallStaticProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -57,11 +59,11 @@ impl RpcProvider for CallStaticProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let response = (
             status,
             [(
@@ -78,7 +80,13 @@ impl RpcProvider for CallStaticProvider {
 impl RpcProviderFactory<CallStaticConfig> for CallStaticProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &CallStaticConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/callstatic.rs
+++ b/src/providers/callstatic.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::{self, StatusCode},
     std::collections::HashMap,
 };
@@ -62,7 +61,15 @@ impl RpcProvider for CallStaticProvider {
             .await?;
         let status = response.status();
         let body = response.bytes().await?;
-        let response = (status, [(hyper::header::CONTENT_TYPE, HeaderValue::from_static("application/json"))], body).into_response();
+        let response = (
+            status,
+            [(
+                hyper::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            )],
+            body,
+        )
+            .into_response();
         Ok(response)
     }
 }

--- a/src/providers/callstatic.rs
+++ b/src/providers/callstatic.rs
@@ -9,16 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{self, Method, StatusCode},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::{self, StatusCode},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct CallStaticProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub api_key: String,
     pub supported_chains: HashMap<String, String>,
 }
@@ -55,24 +53,16 @@ impl RpcProvider for CallStaticProvider {
 
         let uri = format!("https://{}.callstaticrpc.com/{}", chain, self.api_key);
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
-        let response = (
-            status,
-            [(
-                hyper::header::CONTENT_TYPE,
-                HeaderValue::from_static("application/json"),
-            )],
-            body,
-        )
-            .into_response();
+        let body = response.bytes().await?;
+        let response = (status, [(hyper::header::CONTENT_TYPE, HeaderValue::from_static("application/json"))], body).into_response();
         Ok(response)
     }
 }
@@ -80,13 +70,7 @@ impl RpcProvider for CallStaticProvider {
 impl RpcProviderFactory<CallStaticConfig> for CallStaticProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &CallStaticConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/drpc.rs
+++ b/src/providers/drpc.rs
@@ -9,16 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct DrpcProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -52,15 +50,15 @@ impl RpcProvider for DrpcProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -72,13 +70,7 @@ impl RpcProvider for DrpcProvider {
 impl RpcProviderFactory<DrpcConfig> for DrpcProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &DrpcConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/drpc.rs
+++ b/src/providers/drpc.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
 };

--- a/src/providers/mantle.rs
+++ b/src/providers/mantle.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MantleProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -44,7 +46,7 @@ impl RateLimited for MantleProvider {
 #[async_trait]
 impl RpcProvider for MantleProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -54,11 +56,11 @@ impl RpcProvider for MantleProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -70,7 +72,13 @@ impl RpcProvider for MantleProvider {
 impl RpcProviderFactory<MantleConfig> for MantleProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &MantleConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client = HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new())
+            .build::<_, axum::body::Body>(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/mantle.rs
+++ b/src/providers/mantle.rs
@@ -9,16 +9,13 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MantleProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -52,15 +49,15 @@ impl RpcProvider for MantleProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -72,13 +69,7 @@ impl RpcProvider for MantleProvider {
 impl RpcProviderFactory<MantleConfig> for MantleProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &MantleConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client = HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new())
-            .build::<_, axum::body::Body>(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -45,16 +45,11 @@ use {
     },
     async_trait::async_trait,
     // hyper 1 client helpers
-    axum::body::Body,
     axum::extract::ws::WebSocketUpgrade,
     axum::response::Response,
     deadpool_redis::Pool,
     hyper::http::HeaderValue,
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::{
-        client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
-        rt::TokioExecutor,
-    },
+    
     mock_alto::{MockAltoProvider, MockAltoUrls},
     rand::{distributions::WeightedIndex, prelude::Distribution, rngs::OsRng},
     serde::{Deserialize, Serialize},
@@ -70,17 +65,7 @@ use {
     yttrium::chain_abstraction::api::Transaction,
 };
 
-// Common HTTPS hyper client type for all providers
-pub type HyperClient = HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, Body>;
-
-pub fn build_hyper_client() -> HyperClient {
-    let https = HttpsConnectorBuilder::new()
-        .with_webpki_roots()
-        .https_only()
-        .enable_http1()
-        .build();
-    HyperClientLegacy::builder(TokioExecutor::new()).build(https)
-}
+// Hyper client no longer used in providers; using reqwest::Client per-provider
 
 /// Checks if a JSON-RPC error message indicates common node error
 /// patterns that should be handled specially.

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -44,12 +44,9 @@ use {
         rpc::json_rpc::Id,
     },
     async_trait::async_trait,
-    // hyper 1 client helpers
-    axum::extract::ws::WebSocketUpgrade,
-    axum::response::Response,
+    axum::{extract::ws::WebSocketUpgrade, response::Response},
     deadpool_redis::Pool,
     hyper::http::HeaderValue,
-    
     mock_alto::{MockAltoProvider, MockAltoUrls},
     rand::{distributions::WeightedIndex, prelude::Distribution, rngs::OsRng},
     serde::{Deserialize, Serialize},
@@ -64,8 +61,6 @@ use {
     wc::metrics::TaskMetrics,
     yttrium::chain_abstraction::api::Transaction,
 };
-
-// Hyper client no longer used in providers; using reqwest::Client per-provider
 
 /// Checks if a JSON-RPC error message indicates common node error
 /// patterns that should be handled specially.

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -747,7 +747,7 @@ impl ProviderRepository {
             return;
         };
 
-        let Ok(_header_value) = HeaderValue::from_str(&self.prometheus_workspace_header) else {
+        let Ok(header_value) = HeaderValue::from_str(&self.prometheus_workspace_header) else {
             error!(
                 "Failed to parse prometheus workspace header from {}",
                 self.prometheus_workspace_header
@@ -757,6 +757,7 @@ impl ProviderRepository {
 
         match prometheus_client
             .query("round(increase(provider_status_code_counter_total[3h]))")
+            .header("host", header_value)
             .get()
             .await
         {

--- a/src/providers/monad.rs
+++ b/src/providers/monad.rs
@@ -9,16 +9,13 @@ use {
 		http::HeaderValue,
 		response::{IntoResponse, Response},
 	},
-	http_body_util::BodyExt,
-	hyper::{http, Method},
-	hyper_rustls::HttpsConnectorBuilder,
-	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	hyper::http,
 	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MonadProvider {
-	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub client: reqwest::Client,
 	pub supported_chains: HashMap<String, String>,
 }
 
@@ -52,15 +49,15 @@ impl RpcProvider for MonadProvider {
 			.get(chain_id)
 			.ok_or(RpcError::ChainNotFound)?;
 
-		let hyper_request = hyper::http::Request::builder()
-			.method(Method::POST)
-			.uri(uri)
-			.header("Content-Type", "application/json")
-			.body(axum::body::Body::from(body))?;
-
-		let response = self.client.request(hyper_request).await?;
+		let response = self
+			.client
+			.post(uri)
+			.header(reqwest::header::CONTENT_TYPE, "application/json")
+			.body(body)
+			.send()
+			.await?;
 		let status = response.status();
-		let body = response.into_body().collect().await?.to_bytes();
+		let body = response.bytes().await?;
 		let mut response = (status, body).into_response();
 		response
 			.headers_mut()
@@ -72,13 +69,7 @@ impl RpcProvider for MonadProvider {
 impl RpcProviderFactory<MonadConfig> for MonadProvider {
 	#[tracing::instrument(level = "debug")]
 	fn new(provider_config: &MonadConfig) -> Self {
-		let https = HttpsConnectorBuilder::new()
-			.with_webpki_roots()
-			.https_only()
-			.enable_http1()
-			.build();
-		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let forward_proxy_client = reqwest::Client::new();
 		let supported_chains: HashMap<String, String> = provider_config
 			.supported_chains
 			.iter()

--- a/src/providers/monad.rs
+++ b/src/providers/monad.rs
@@ -1,84 +1,84 @@
 use {
-	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-	crate::{
-		env::MonadConfig,
-		error::{RpcError, RpcResult},
-	},
-	async_trait::async_trait,
-	axum::{
-		http::HeaderValue,
-		response::{IntoResponse, Response},
-	},
-	hyper::http,
-	std::collections::HashMap,
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MonadConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::http,
+    std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MonadProvider {
-	pub client: reqwest::Client,
-	pub supported_chains: HashMap<String, String>,
+    pub client: reqwest::Client,
+    pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for MonadProvider {
-	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-		self.supported_chains.contains_key(chain_id)
-	}
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
 
-	fn supported_caip_chains(&self) -> Vec<String> {
-		self.supported_chains.keys().cloned().collect()
-	}
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
 
-	fn provider_kind(&self) -> ProviderKind {
-		ProviderKind::Monad
-	}
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Monad
+    }
 }
 
 #[async_trait]
 impl RateLimited for MonadProvider {
-	async fn is_rate_limited(&self, response: &mut Response) -> bool {
-		response.status() == http::StatusCode::TOO_MANY_REQUESTS
-	}
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 #[async_trait]
 impl RpcProvider for MonadProvider {
-	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-		let uri = self
-			.supported_chains
-			.get(chain_id)
-			.ok_or(RpcError::ChainNotFound)?;
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
 
-		let response = self
-			.client
-			.post(uri)
-			.header(reqwest::header::CONTENT_TYPE, "application/json")
-			.body(body)
-			.send()
-			.await?;
-		let status = response.status();
-		let body = response.bytes().await?;
-		let mut response = (status, body).into_response();
-		response
-			.headers_mut()
-			.insert("Content-Type", HeaderValue::from_static("application/json"));
-		Ok(response)
-	}
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
 }
 
 impl RpcProviderFactory<MonadConfig> for MonadProvider {
-	#[tracing::instrument(level = "debug")]
-	fn new(provider_config: &MonadConfig) -> Self {
-		let forward_proxy_client = reqwest::Client::new();
-		let supported_chains: HashMap<String, String> = provider_config
-			.supported_chains
-			.iter()
-			.map(|(k, v)| (k.clone(), v.0.clone()))
-			.collect();
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &MonadConfig) -> Self {
+        let forward_proxy_client = reqwest::Client::new();
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
-		MonadProvider {
-			client: forward_proxy_client,
-			supported_chains,
-		}
-	}
+        MonadProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
 }

--- a/src/providers/monad.rs
+++ b/src/providers/monad.rs
@@ -1,96 +1,93 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-    crate::{
-        env::MonadConfig,
-        error::{RpcError, RpcResult},
-    },
-    async_trait::async_trait,
-    axum::{
-        http::HeaderValue,
-        response::{IntoResponse, Response},
-    },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
-    std::collections::HashMap,
-    tracing::debug,
+	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+	crate::{
+		env::MonadConfig,
+		error::{RpcError, RpcResult},
+	},
+	async_trait::async_trait,
+	axum::{
+		http::HeaderValue,
+		response::{IntoResponse, Response},
+	},
+	http_body_util::BodyExt,
+	hyper::{http, Method},
+	hyper_rustls::HttpsConnectorBuilder,
+	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MonadProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
-    pub supported_chains: HashMap<String, String>,
+	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for MonadProvider {
-    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-        self.supported_chains.contains_key(chain_id)
-    }
+	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+		self.supported_chains.contains_key(chain_id)
+	}
 
-    fn supported_caip_chains(&self) -> Vec<String> {
-        self.supported_chains.keys().cloned().collect()
-    }
+	fn supported_caip_chains(&self) -> Vec<String> {
+		self.supported_chains.keys().cloned().collect()
+	}
 
-    fn provider_kind(&self) -> ProviderKind {
-        ProviderKind::Monad
-    }
+	fn provider_kind(&self) -> ProviderKind {
+		ProviderKind::Monad
+	}
 }
 
 #[async_trait]
 impl RateLimited for MonadProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == http::StatusCode::TOO_MANY_REQUESTS
-    }
+	async fn is_rate_limited(&self, response: &mut Response) -> bool {
+		response.status() == http::StatusCode::TOO_MANY_REQUESTS
+	}
 }
 
 #[async_trait]
 impl RpcProvider for MonadProvider {
-    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
-        let uri = self
-            .supported_chains
-            .get(chain_id)
-            .ok_or(RpcError::ChainNotFound)?;
+	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+		let uri = self
+			.supported_chains
+			.get(chain_id)
+			.ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+		let hyper_request = hyper::http::Request::builder()
+			.method(Method::POST)
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.body(axum::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?;
-        let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
-
-        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && status.is_success() {
-                debug!(
-                    "Strange: provider returned JSON RPC error, but status {status} is success: \
-                 Monad: {response:?}"
-                );
-            }
-        }
-
-        let mut response = (status, body).into_response();
-        response
-            .headers_mut()
-            .insert("Content-Type", HeaderValue::from_static("application/json"));
-        Ok(response)
-    }
+		let response = self.client.request(hyper_request).await?;
+		let status = response.status();
+		let body = response.into_body().collect().await?.to_bytes();
+		let mut response = (status, body).into_response();
+		response
+			.headers_mut()
+			.insert("Content-Type", HeaderValue::from_static("application/json"));
+		Ok(response)
+	}
 }
 
 impl RpcProviderFactory<MonadConfig> for MonadProvider {
-    #[tracing::instrument(level = "debug")]
-    fn new(provider_config: &MonadConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-        let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect();
+	#[tracing::instrument(level = "debug")]
+	fn new(provider_config: &MonadConfig) -> Self {
+		let https = HttpsConnectorBuilder::new()
+			.with_webpki_roots()
+			.https_only()
+			.enable_http1()
+			.build();
+		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let supported_chains: HashMap<String, String> = provider_config
+			.supported_chains
+			.iter()
+			.map(|(k, v)| (k.clone(), v.0.clone()))
+			.collect();
 
-        MonadProvider {
-            client: forward_proxy_client,
-            supported_chains,
-        }
-    }
+		MonadProvider {
+			client: forward_proxy_client,
+			supported_chains,
+		}
+	}
 }

--- a/src/providers/moonbeam.rs
+++ b/src/providers/moonbeam.rs
@@ -9,16 +9,13 @@ use {
 		http::HeaderValue,
 		response::{IntoResponse, Response},
 	},
-	http_body_util::BodyExt,
-	hyper::{http, Method},
-	hyper_rustls::HttpsConnectorBuilder,
-	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	hyper::http,
 	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MoonbeamProvider {
-	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub client: reqwest::Client,
 	pub supported_chains: HashMap<String, String>,
 }
 
@@ -55,15 +52,15 @@ impl RpcProvider for MoonbeamProvider {
 			.get(chain_id)
 			.ok_or(RpcError::ChainNotFound)?;
 
-		let hyper_request = hyper::http::Request::builder()
-			.method(Method::POST)
-			.uri(uri)
-			.header("Content-Type", "application/json")
-			.body(axum::body::Body::from(body))?;
-
-		let response = self.client.request(hyper_request).await?;
+		let response = self
+			.client
+			.post(uri)
+			.header(reqwest::header::CONTENT_TYPE, "application/json")
+			.body(body)
+			.send()
+			.await?;
 		let status = response.status();
-		let body = response.into_body().collect().await?.to_bytes();
+		let body = response.bytes().await?;
 		let mut response = (status, body).into_response();
 		response
 			.headers_mut()
@@ -75,13 +72,7 @@ impl RpcProvider for MoonbeamProvider {
 impl RpcProviderFactory<MoonbeamConfig> for MoonbeamProvider {
 	#[tracing::instrument(level = "debug")]
 	fn new(provider_config: &MoonbeamConfig) -> Self {
-		let https = HttpsConnectorBuilder::new()
-			.with_webpki_roots()
-			.https_only()
-			.enable_http1()
-			.build();
-		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let forward_proxy_client = reqwest::Client::new();
 		let supported_chains: HashMap<String, String> = provider_config
 			.supported_chains
 			.iter()

--- a/src/providers/moonbeam.rs
+++ b/src/providers/moonbeam.rs
@@ -1,88 +1,96 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-    crate::{
-        env::MoonbeamConfig,
-        error::{RpcError, RpcResult},
-    },
-    async_trait::async_trait,
-    axum::{
-        http::HeaderValue,
-        response::{IntoResponse, Response},
-    },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
-    std::collections::HashMap,
+	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+	crate::{
+		env::MoonbeamConfig,
+		error::{RpcError, RpcResult},
+	},
+	async_trait::async_trait,
+	axum::{
+		http::HeaderValue,
+		response::{IntoResponse, Response},
+	},
+	http_body_util::BodyExt,
+	hyper::{http, Method},
+	hyper_rustls::HttpsConnectorBuilder,
+	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MoonbeamProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
-    pub supported_chains: HashMap<String, String>,
+	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for MoonbeamProvider {
-    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-        self.supported_chains.contains_key(chain_id)
-    }
+	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+		self.supported_chains.contains_key(chain_id)
+	}
 
-    fn supported_caip_chains(&self) -> Vec<String> {
-        self.supported_chains.keys().cloned().collect()
-    }
+	fn supported_caip_chains(&self) -> Vec<String> {
+		self.supported_chains.keys().cloned().collect()
+	}
 
-    fn provider_kind(&self) -> ProviderKind {
-        ProviderKind::Moonbeam
-    }
+	fn provider_kind(&self) -> ProviderKind {
+		ProviderKind::Moonbeam
+	}
 }
 
 #[async_trait]
 impl RateLimited for MoonbeamProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool
-    where
-        Self: Sized,
-    {
-        response.status() == http::StatusCode::TOO_MANY_REQUESTS
-    }
+	async fn is_rate_limited(&self, response: &mut Response) -> bool
+	where
+		Self: Sized,
+	{
+		response.status() == http::StatusCode::TOO_MANY_REQUESTS
+	}
 }
 
 #[async_trait]
 impl RpcProvider for MoonbeamProvider {
-    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
-        let uri = self
-            .supported_chains
-            .get(chain_id)
-            .ok_or(RpcError::ChainNotFound)?;
+	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+		let uri = self
+			.supported_chains
+			.get(chain_id)
+			.ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+		let hyper_request = hyper::http::Request::builder()
+			.method(Method::POST)
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.body(axum::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?;
-        let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
-        let mut response = (status, body).into_response();
-        response
-            .headers_mut()
-            .insert("Content-Type", HeaderValue::from_static("application/json"));
-        Ok(response)
-    }
+		let response = self.client.request(hyper_request).await?;
+		let status = response.status();
+		let body = response.into_body().collect().await?.to_bytes();
+		let mut response = (status, body).into_response();
+		response
+			.headers_mut()
+			.insert("Content-Type", HeaderValue::from_static("application/json"));
+		Ok(response)
+	}
 }
 
 impl RpcProviderFactory<MoonbeamConfig> for MoonbeamProvider {
-    #[tracing::instrument(level = "debug")]
-    fn new(provider_config: &MoonbeamConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-        let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect();
+	#[tracing::instrument(level = "debug")]
+	fn new(provider_config: &MoonbeamConfig) -> Self {
+		let https = HttpsConnectorBuilder::new()
+			.with_webpki_roots()
+			.https_only()
+			.enable_http1()
+			.build();
+		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let supported_chains: HashMap<String, String> = provider_config
+			.supported_chains
+			.iter()
+			.map(|(k, v)| (k.clone(), v.0.clone()))
+			.collect();
 
-        MoonbeamProvider {
-            client: forward_proxy_client,
-            supported_chains,
-        }
-    }
+		MoonbeamProvider {
+			client: forward_proxy_client,
+			supported_chains,
+		}
+	}
 }

--- a/src/providers/moonbeam.rs
+++ b/src/providers/moonbeam.rs
@@ -1,87 +1,87 @@
 use {
-	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-	crate::{
-		env::MoonbeamConfig,
-		error::{RpcError, RpcResult},
-	},
-	async_trait::async_trait,
-	axum::{
-		http::HeaderValue,
-		response::{IntoResponse, Response},
-	},
-	hyper::http,
-	std::collections::HashMap,
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MoonbeamConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::http,
+    std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MoonbeamProvider {
-	pub client: reqwest::Client,
-	pub supported_chains: HashMap<String, String>,
+    pub client: reqwest::Client,
+    pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for MoonbeamProvider {
-	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-		self.supported_chains.contains_key(chain_id)
-	}
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
 
-	fn supported_caip_chains(&self) -> Vec<String> {
-		self.supported_chains.keys().cloned().collect()
-	}
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
 
-	fn provider_kind(&self) -> ProviderKind {
-		ProviderKind::Moonbeam
-	}
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Moonbeam
+    }
 }
 
 #[async_trait]
 impl RateLimited for MoonbeamProvider {
-	async fn is_rate_limited(&self, response: &mut Response) -> bool
-	where
-		Self: Sized,
-	{
-		response.status() == http::StatusCode::TOO_MANY_REQUESTS
-	}
+    async fn is_rate_limited(&self, response: &mut Response) -> bool
+    where
+        Self: Sized,
+    {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 #[async_trait]
 impl RpcProvider for MoonbeamProvider {
-	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-		let uri = self
-			.supported_chains
-			.get(chain_id)
-			.ok_or(RpcError::ChainNotFound)?;
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
 
-		let response = self
-			.client
-			.post(uri)
-			.header(reqwest::header::CONTENT_TYPE, "application/json")
-			.body(body)
-			.send()
-			.await?;
-		let status = response.status();
-		let body = response.bytes().await?;
-		let mut response = (status, body).into_response();
-		response
-			.headers_mut()
-			.insert("Content-Type", HeaderValue::from_static("application/json"));
-		Ok(response)
-	}
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
 }
 
 impl RpcProviderFactory<MoonbeamConfig> for MoonbeamProvider {
-	#[tracing::instrument(level = "debug")]
-	fn new(provider_config: &MoonbeamConfig) -> Self {
-		let forward_proxy_client = reqwest::Client::new();
-		let supported_chains: HashMap<String, String> = provider_config
-			.supported_chains
-			.iter()
-			.map(|(k, v)| (k.clone(), v.0.clone()))
-			.collect();
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &MoonbeamConfig) -> Self {
+        let forward_proxy_client = reqwest::Client::new();
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
-		MoonbeamProvider {
-			client: forward_proxy_client,
-			supported_chains,
-		}
-	}
+        MoonbeamProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
 }

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -1,84 +1,84 @@
 use {
-	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-	crate::{
-		env::MorphConfig,
-		error::{RpcError, RpcResult},
-	},
-	async_trait::async_trait,
-	axum::{
-		http::HeaderValue,
-		response::{IntoResponse, Response},
-	},
-	hyper::http,
-	std::collections::HashMap,
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MorphConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::http,
+    std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MorphProvider {
-	pub client: reqwest::Client,
-	pub supported_chains: HashMap<String, String>,
+    pub client: reqwest::Client,
+    pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for MorphProvider {
-	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-		self.supported_chains.contains_key(chain_id)
-	}
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
 
-	fn supported_caip_chains(&self) -> Vec<String> {
-		self.supported_chains.keys().cloned().collect()
-	}
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
 
-	fn provider_kind(&self) -> ProviderKind {
-		ProviderKind::Morph
-	}
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Morph
+    }
 }
 
 #[async_trait]
 impl RateLimited for MorphProvider {
-	async fn is_rate_limited(&self, response: &mut Response) -> bool {
-		response.status() == http::StatusCode::TOO_MANY_REQUESTS
-	}
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 #[async_trait]
 impl RpcProvider for MorphProvider {
-	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-		let uri = self
-			.supported_chains
-			.get(chain_id)
-			.ok_or(RpcError::ChainNotFound)?;
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
 
-		let response = self
-			.client
-			.post(uri)
-			.header(reqwest::header::CONTENT_TYPE, "application/json")
-			.body(body)
-			.send()
-			.await?;
-		let status = response.status();
-		let body = response.bytes().await?;
-		let mut response = (status, body).into_response();
-		response
-			.headers_mut()
-			.insert("Content-Type", HeaderValue::from_static("application/json"));
-		Ok(response)
-	}
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
 }
 
 impl RpcProviderFactory<MorphConfig> for MorphProvider {
-	#[tracing::instrument(level = "debug")]
-	fn new(provider_config: &MorphConfig) -> Self {
-		let forward_proxy_client = reqwest::Client::new();
-		let supported_chains: HashMap<String, String> = provider_config
-			.supported_chains
-			.iter()
-			.map(|(k, v)| (k.clone(), v.0.clone()))
-			.collect();
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &MorphConfig) -> Self {
+        let forward_proxy_client = reqwest::Client::new();
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
-		MorphProvider {
-			client: forward_proxy_client,
-			supported_chains,
-		}
-	}
+        MorphProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
 }

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -9,16 +9,13 @@ use {
 		http::HeaderValue,
 		response::{IntoResponse, Response},
 	},
-	http_body_util::BodyExt,
-	hyper::{http, Method},
-	hyper_rustls::HttpsConnectorBuilder,
-	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	hyper::http,
 	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MorphProvider {
-	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub client: reqwest::Client,
 	pub supported_chains: HashMap<String, String>,
 }
 
@@ -52,15 +49,15 @@ impl RpcProvider for MorphProvider {
 			.get(chain_id)
 			.ok_or(RpcError::ChainNotFound)?;
 
-		let hyper_request = hyper::http::Request::builder()
-			.method(Method::POST)
-			.uri(uri)
-			.header("Content-Type", "application/json")
-			.body(axum::body::Body::from(body))?;
-
-		let response = self.client.request(hyper_request).await?;
+		let response = self
+			.client
+			.post(uri)
+			.header(reqwest::header::CONTENT_TYPE, "application/json")
+			.body(body)
+			.send()
+			.await?;
 		let status = response.status();
-		let body = response.into_body().collect().await?.to_bytes();
+		let body = response.bytes().await?;
 		let mut response = (status, body).into_response();
 		response
 			.headers_mut()
@@ -72,13 +69,7 @@ impl RpcProvider for MorphProvider {
 impl RpcProviderFactory<MorphConfig> for MorphProvider {
 	#[tracing::instrument(level = "debug")]
 	fn new(provider_config: &MorphConfig) -> Self {
-		let https = HttpsConnectorBuilder::new()
-			.with_webpki_roots()
-			.https_only()
-			.enable_http1()
-			.build();
-		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let forward_proxy_client = reqwest::Client::new();
 		let supported_chains: HashMap<String, String> = provider_config
 			.supported_chains
 			.iter()

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -1,87 +1,93 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-    crate::{
-        env::MorphConfig,
-        error::{RpcError, RpcResult},
-    },
-    async_trait::async_trait,
-    axum::{
-        http::HeaderValue,
-        response::{IntoResponse, Response},
-    },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
-    std::collections::HashMap,
+	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+	crate::{
+		env::MorphConfig,
+		error::{RpcError, RpcResult},
+	},
+	async_trait::async_trait,
+	axum::{
+		http::HeaderValue,
+		response::{IntoResponse, Response},
+	},
+	http_body_util::BodyExt,
+	hyper::{http, Method},
+	hyper_rustls::HttpsConnectorBuilder,
+	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct MorphProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
-    pub supported_chains: HashMap<String, String>,
+	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for MorphProvider {
-    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-        self.supported_chains.contains_key(chain_id)
-    }
+	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+		self.supported_chains.contains_key(chain_id)
+	}
 
-    fn supported_caip_chains(&self) -> Vec<String> {
-        self.supported_chains.keys().cloned().collect()
-    }
+	fn supported_caip_chains(&self) -> Vec<String> {
+		self.supported_chains.keys().cloned().collect()
+	}
 
-    fn provider_kind(&self) -> ProviderKind {
-        ProviderKind::Morph
-    }
+	fn provider_kind(&self) -> ProviderKind {
+		ProviderKind::Morph
+	}
 }
 
 #[async_trait]
 impl RateLimited for MorphProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == http::StatusCode::TOO_MANY_REQUESTS
-    }
+	async fn is_rate_limited(&self, response: &mut Response) -> bool {
+		response.status() == http::StatusCode::TOO_MANY_REQUESTS
+	}
 }
 
 #[async_trait]
 impl RpcProvider for MorphProvider {
-    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
-        let chain = self
-            .supported_chains
-            .get(chain_id)
-            .ok_or(RpcError::ChainNotFound)?;
+	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+		let uri = self
+			.supported_chains
+			.get(chain_id)
+			.ok_or(RpcError::ChainNotFound)?;
 
-        let uri = format!("https://{chain}.morphl2.io");
+		let hyper_request = hyper::http::Request::builder()
+			.method(Method::POST)
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.body(axum::body::Body::from(body))?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
-        let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
-        let mut response = (status, body).into_response();
-        response
-            .headers_mut()
-            .insert("Content-Type", HeaderValue::from_static("application/json"));
-        Ok(response)
-    }
+		let response = self.client.request(hyper_request).await?;
+		let status = response.status();
+		let body = response.into_body().collect().await?.to_bytes();
+		let mut response = (status, body).into_response();
+		response
+			.headers_mut()
+			.insert("Content-Type", HeaderValue::from_static("application/json"));
+		Ok(response)
+	}
 }
 
 impl RpcProviderFactory<MorphConfig> for MorphProvider {
-    #[tracing::instrument(level = "debug")]
-    fn new(provider_config: &MorphConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-        let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect();
+	#[tracing::instrument(level = "debug")]
+	fn new(provider_config: &MorphConfig) -> Self {
+		let https = HttpsConnectorBuilder::new()
+			.with_webpki_roots()
+			.https_only()
+			.enable_http1()
+			.build();
+		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let supported_chains: HashMap<String, String> = provider_config
+			.supported_chains
+			.iter()
+			.map(|(k, v)| (k.clone(), v.0.clone()))
+			.collect();
 
-        MorphProvider {
-            client: forward_proxy_client,
-            supported_chains,
-        }
-    }
+		MorphProvider {
+			client: forward_proxy_client,
+			supported_chains,
+		}
+	}
 }

--- a/src/providers/morph.rs
+++ b/src/providers/morph.rs
@@ -44,10 +44,11 @@ impl RateLimited for MorphProvider {
 impl RpcProvider for MorphProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
     async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-        let uri = self
+        let chain = self
             .supported_chains
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
+        let uri = format!("https://{chain}.morphl2.io");
 
         let response = self
             .client

--- a/src/providers/near.rs
+++ b/src/providers/near.rs
@@ -9,15 +9,17 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct NearProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -45,7 +47,7 @@ impl RateLimited for NearProvider {
 #[async_trait]
 impl RpcProvider for NearProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -55,11 +57,11 @@ impl RpcProvider for NearProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -81,7 +83,13 @@ impl RpcProvider for NearProvider {
 impl RpcProviderFactory<NearConfig> for NearProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &NearConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client = HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new())
+            .build::<_, axum::body::Body>(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/near.rs
+++ b/src/providers/near.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
     tracing::debug,

--- a/src/providers/odyssey.rs
+++ b/src/providers/odyssey.rs
@@ -1,96 +1,93 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-    crate::{
-        env::OdysseyConfig,
-        error::{RpcError, RpcResult},
-    },
-    async_trait::async_trait,
-    axum::{
-        http::HeaderValue,
-        response::{IntoResponse, Response},
-    },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
-    std::collections::HashMap,
-    tracing::debug,
+	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+	crate::{
+		env::OdysseyConfig,
+		error::{RpcError, RpcResult},
+	},
+	async_trait::async_trait,
+	axum::{
+		http::HeaderValue,
+		response::{IntoResponse, Response},
+	},
+	http_body_util::BodyExt,
+	hyper::{http, Method},
+	hyper_rustls::HttpsConnectorBuilder,
+	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct OdysseyProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
-    pub supported_chains: HashMap<String, String>,
+	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for OdysseyProvider {
-    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-        self.supported_chains.contains_key(chain_id)
-    }
+	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+		self.supported_chains.contains_key(chain_id)
+	}
 
-    fn supported_caip_chains(&self) -> Vec<String> {
-        self.supported_chains.keys().cloned().collect()
-    }
+	fn supported_caip_chains(&self) -> Vec<String> {
+		self.supported_chains.keys().cloned().collect()
+	}
 
-    fn provider_kind(&self) -> ProviderKind {
-        ProviderKind::Odyssey
-    }
+	fn provider_kind(&self) -> ProviderKind {
+		ProviderKind::Odyssey
+	}
 }
 
 #[async_trait]
 impl RateLimited for OdysseyProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == http::StatusCode::TOO_MANY_REQUESTS
-    }
+	async fn is_rate_limited(&self, response: &mut Response) -> bool {
+		response.status() == http::StatusCode::TOO_MANY_REQUESTS
+	}
 }
 
 #[async_trait]
 impl RpcProvider for OdysseyProvider {
-    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
-        let uri = self
-            .supported_chains
-            .get(chain_id)
-            .ok_or(RpcError::ChainNotFound)?;
+	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+		let uri = self
+			.supported_chains
+			.get(chain_id)
+			.ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+		let hyper_request = hyper::http::Request::builder()
+			.method(Method::POST)
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.body(axum::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?;
-        let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
-
-        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && status.is_success() {
-                debug!(
-                    "Strange: provider returned JSON RPC error, but status {status} is success: \
-               Odyssey: {response:?}"
-                );
-            }
-        }
-
-        let mut response = (status, body).into_response();
-        response
-            .headers_mut()
-            .insert("Content-Type", HeaderValue::from_static("application/json"));
-        Ok(response)
-    }
+		let response = self.client.request(hyper_request).await?;
+		let status = response.status();
+		let body = response.into_body().collect().await?.to_bytes();
+		let mut response = (status, body).into_response();
+		response
+			.headers_mut()
+			.insert("Content-Type", HeaderValue::from_static("application/json"));
+		Ok(response)
+	}
 }
 
 impl RpcProviderFactory<OdysseyConfig> for OdysseyProvider {
-    #[tracing::instrument(level = "debug")]
-    fn new(provider_config: &OdysseyConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-        let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect();
+	#[tracing::instrument(level = "debug")]
+	fn new(provider_config: &OdysseyConfig) -> Self {
+		let https = HttpsConnectorBuilder::new()
+			.with_webpki_roots()
+			.https_only()
+			.enable_http1()
+			.build();
+		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let supported_chains: HashMap<String, String> = provider_config
+			.supported_chains
+			.iter()
+			.map(|(k, v)| (k.clone(), v.0.clone()))
+			.collect();
 
-        OdysseyProvider {
-            client: forward_proxy_client,
-            supported_chains,
-        }
-    }
+		OdysseyProvider {
+			client: forward_proxy_client,
+			supported_chains,
+		}
+	}
 }

--- a/src/providers/odyssey.rs
+++ b/src/providers/odyssey.rs
@@ -1,93 +1,84 @@
 use {
-	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-	crate::{
-		env::OdysseyConfig,
-		error::{RpcError, RpcResult},
-	},
-	async_trait::async_trait,
-	axum::{
-		http::HeaderValue,
-		response::{IntoResponse, Response},
-	},
-	http_body_util::BodyExt,
-	hyper::{http, Method},
-	hyper_rustls::HttpsConnectorBuilder,
-	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
-	std::collections::HashMap,
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::OdysseyConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::http,
+    std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct OdysseyProvider {
-	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
-	pub supported_chains: HashMap<String, String>,
+    pub client: reqwest::Client,
+    pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for OdysseyProvider {
-	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-		self.supported_chains.contains_key(chain_id)
-	}
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
 
-	fn supported_caip_chains(&self) -> Vec<String> {
-		self.supported_chains.keys().cloned().collect()
-	}
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
 
-	fn provider_kind(&self) -> ProviderKind {
-		ProviderKind::Odyssey
-	}
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Odyssey
+    }
 }
 
 #[async_trait]
 impl RateLimited for OdysseyProvider {
-	async fn is_rate_limited(&self, response: &mut Response) -> bool {
-		response.status() == http::StatusCode::TOO_MANY_REQUESTS
-	}
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 #[async_trait]
 impl RpcProvider for OdysseyProvider {
-	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-		let uri = self
-			.supported_chains
-			.get(chain_id)
-			.ok_or(RpcError::ChainNotFound)?;
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
 
-		let hyper_request = hyper::http::Request::builder()
-			.method(Method::POST)
-			.uri(uri)
-			.header("Content-Type", "application/json")
-			.body(axum::body::Body::from(body))?;
-
-		let response = self.client.request(hyper_request).await?;
-		let status = response.status();
-		let body = response.into_body().collect().await?.to_bytes();
-		let mut response = (status, body).into_response();
-		response
-			.headers_mut()
-			.insert("Content-Type", HeaderValue::from_static("application/json"));
-		Ok(response)
-	}
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
 }
 
 impl RpcProviderFactory<OdysseyConfig> for OdysseyProvider {
-	#[tracing::instrument(level = "debug")]
-	fn new(provider_config: &OdysseyConfig) -> Self {
-		let https = HttpsConnectorBuilder::new()
-			.with_webpki_roots()
-			.https_only()
-			.enable_http1()
-			.build();
-		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
-		let supported_chains: HashMap<String, String> = provider_config
-			.supported_chains
-			.iter()
-			.map(|(k, v)| (k.clone(), v.0.clone()))
-			.collect();
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &OdysseyConfig) -> Self {
+        let forward_proxy_client = reqwest::Client::new();
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
-		OdysseyProvider {
-			client: forward_proxy_client,
-			supported_chains,
-		}
-	}
+        OdysseyProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
 }

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -1,137 +1,101 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-    crate::{
-        env::PoktConfig,
-        error::{RpcError, RpcResult},
-    },
-    async_trait::async_trait,
-    axum::{
-        http::HeaderValue,
-        response::{IntoResponse, Response},
-    },
-    hyper::{self, client::HttpConnector, Client, Method, StatusCode},
-    hyper_tls::HttpsConnector,
-    serde::Deserialize,
-    std::collections::HashMap,
-    tracing::debug,
+	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+	crate::{
+		env::PoktConfig,
+		error::{RpcError, RpcResult},
+	},
+	async_trait::async_trait,
+	axum::{
+		http::HeaderValue,
+		response::{IntoResponse, Response},
+	},
+	http_body_util::BodyExt,
+	hyper::{self, Method},
+	hyper_rustls::HttpsConnectorBuilder,
+	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	std::collections::HashMap,
+	serde::Deserialize,
 };
 
 #[derive(Debug)]
 pub struct PoktProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
-    pub project_id: String,
-    pub supported_chains: HashMap<String, String>,
+	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub supported_chains: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct InternalErrorResponse {
-    pub request_id: String,
-    pub error: String,
+	pub request_id: String,
+	pub error: String,
 }
 
 impl Provider for PoktProvider {
-    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-        self.supported_chains.contains_key(chain_id)
-    }
+	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+		self.supported_chains.contains_key(chain_id)
+	}
 
-    fn supported_caip_chains(&self) -> Vec<String> {
-        self.supported_chains.keys().cloned().collect()
-    }
+	fn supported_caip_chains(&self) -> Vec<String> {
+		self.supported_chains.keys().cloned().collect()
+	}
 
-    fn provider_kind(&self) -> ProviderKind {
-        ProviderKind::Pokt
-    }
+	fn provider_kind(&self) -> ProviderKind {
+		ProviderKind::Pokt
+	}
 }
 
 #[async_trait]
 impl RateLimited for PoktProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == StatusCode::TOO_MANY_REQUESTS
-    }
+	async fn is_rate_limited(&self, response: &mut Response) -> bool {
+		response.status() == hyper::StatusCode::TOO_MANY_REQUESTS
+	}
 }
 
 #[async_trait]
 impl RpcProvider for PoktProvider {
-    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
-        let chain = &self
-            .supported_chains
-            .get(chain_id)
-            .ok_or(RpcError::ChainNotFound)?;
+	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+		let uri = self
+			.supported_chains
+			.get(chain_id)
+			.ok_or(RpcError::ChainNotFound)?;
 
-        let uri = format!("https://{}.rpc.grove.city/v1/{}", chain, self.project_id);
+		let hyper_request = hyper::http::Request::builder()
+			.method(Method::POST)
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.body(axum::body::Body::from(body))?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
-        let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
-
-        if status.is_success() || status.is_client_error() {
-            if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-                if let Some(error) = &response.error {
-                    debug!(
-                        "Strange: provider returned JSON RPC error, but status {status} is \
-                         success: Pokt: {response:?}"
-                    );
-                    match error.code {
-                        // Pokt-specific rate limit codes
-                        -32004 | -32068 => {
-                            return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response())
-                        }
-                        // Internal server error code
-                        -32603 => {
-                            return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response())
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-
-        // As an internal RPC node error the InternalErrorResponse is used for the response
-        // that should be considered as an HTTP 5xx error from the provider
-        if let Ok(response) = serde_json::from_slice::<InternalErrorResponse>(&body) {
-            let error = response.error;
-            let request_id = response.request_id;
-            if error.contains("try again later") {
-                return Ok((StatusCode::SERVICE_UNAVAILABLE, body).into_response());
-            } else {
-                debug!(
-                    "Pokt provider returned JSON RPC success status, but got the \
-                    error response structure with the following error: {error} \
-                    the request_id is {request_id}",
-                );
-                return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
-            }
-        }
-
-        let mut response = (status, body).into_response();
-        response
-            .headers_mut()
-            .insert("Content-Type", HeaderValue::from_static("application/json"));
-        Ok(response)
-    }
+		let response = self.client.request(hyper_request).await?;
+		let status = response.status();
+		let body = response.into_body().collect().await?.to_bytes();
+		let mut response = (status, body).into_response();
+		response
+			.headers_mut()
+			.insert("Content-Type", HeaderValue::from_static("application/json"));
+		Ok(response)
+	}
 }
 
 impl RpcProviderFactory<PoktConfig> for PoktProvider {
-    #[tracing::instrument(level = "debug")]
-    fn new(provider_config: &PoktConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-        let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect();
+	#[tracing::instrument(level = "debug")]
+	fn new(provider_config: &PoktConfig) -> Self {
+		let https = HttpsConnectorBuilder::new()
+			.with_webpki_roots()
+			.https_only()
+			.enable_http1()
+			.build();
+		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let supported_chains: HashMap<String, String> = provider_config
+			.supported_chains
+			.iter()
+			.map(|(k, v)| (k.clone(), v.0.clone()))
+			.collect();
 
-        PoktProvider {
-            client: forward_proxy_client,
-            supported_chains,
-            project_id: provider_config.project_id.clone(),
-        }
-    }
+		PoktProvider {
+			client: forward_proxy_client,
+			supported_chains,
+		}
+	}
 }

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -1,101 +1,91 @@
 use {
-	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-	crate::{
-		env::PoktConfig,
-		error::{RpcError, RpcResult},
-	},
-	async_trait::async_trait,
-	axum::{
-		http::HeaderValue,
-		response::{IntoResponse, Response},
-	},
-	http_body_util::BodyExt,
-	hyper::{self, Method},
-	hyper_rustls::HttpsConnectorBuilder,
-	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
-	std::collections::HashMap,
-	serde::Deserialize,
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::PoktConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    serde::Deserialize,
+    std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct PoktProvider {
-	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
-	pub supported_chains: HashMap<String, String>,
+    pub client: reqwest::Client,
+    pub supported_chains: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
 pub struct InternalErrorResponse {
-	pub request_id: String,
-	pub error: String,
+    pub request_id: String,
+    pub error: String,
 }
 
 impl Provider for PoktProvider {
-	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-		self.supported_chains.contains_key(chain_id)
-	}
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
 
-	fn supported_caip_chains(&self) -> Vec<String> {
-		self.supported_chains.keys().cloned().collect()
-	}
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
 
-	fn provider_kind(&self) -> ProviderKind {
-		ProviderKind::Pokt
-	}
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Pokt
+    }
 }
 
 #[async_trait]
 impl RateLimited for PoktProvider {
-	async fn is_rate_limited(&self, response: &mut Response) -> bool {
-		response.status() == hyper::StatusCode::TOO_MANY_REQUESTS
-	}
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == hyper::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 #[async_trait]
 impl RpcProvider for PoktProvider {
-	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-		let uri = self
-			.supported_chains
-			.get(chain_id)
-			.ok_or(RpcError::ChainNotFound)?;
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
 
-		let hyper_request = hyper::http::Request::builder()
-			.method(Method::POST)
-			.uri(uri)
-			.header("Content-Type", "application/json")
-			.body(axum::body::Body::from(body))?;
-
-		let response = self.client.request(hyper_request).await?;
-		let status = response.status();
-		let body = response.into_body().collect().await?.to_bytes();
-		let mut response = (status, body).into_response();
-		response
-			.headers_mut()
-			.insert("Content-Type", HeaderValue::from_static("application/json"));
-		Ok(response)
-	}
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
 }
 
 impl RpcProviderFactory<PoktConfig> for PoktProvider {
-	#[tracing::instrument(level = "debug")]
-	fn new(provider_config: &PoktConfig) -> Self {
-		let https = HttpsConnectorBuilder::new()
-			.with_webpki_roots()
-			.https_only()
-			.enable_http1()
-			.build();
-		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
-		let supported_chains: HashMap<String, String> = provider_config
-			.supported_chains
-			.iter()
-			.map(|(k, v)| (k.clone(), v.0.clone()))
-			.collect();
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &PoktConfig) -> Self {
+        let forward_proxy_client = reqwest::Client::new();
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
-		PoktProvider {
-			client: forward_proxy_client,
-			supported_chains,
-		}
-	}
+        PoktProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
 }

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -6,21 +6,22 @@ use {
     },
     async_trait::async_trait,
     axum::{
-        http::HeaderValue,
+        http::{HeaderValue, StatusCode},
         response::{IntoResponse, Response},
     },
     serde::Deserialize,
     std::collections::HashMap,
+    tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct PoktProvider {
     pub client: reqwest::Client,
+    pub project_id: String,
     pub supported_chains: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct InternalErrorResponse {
     pub request_id: String,
     pub error: String,
@@ -43,7 +44,7 @@ impl Provider for PoktProvider {
 #[async_trait]
 impl RateLimited for PoktProvider {
     async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == hyper::StatusCode::TOO_MANY_REQUESTS
+        response.status() == StatusCode::TOO_MANY_REQUESTS
     }
 }
 
@@ -51,11 +52,11 @@ impl RateLimited for PoktProvider {
 impl RpcProvider for PoktProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
     async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-        let uri = self
+        let chain = self
             .supported_chains
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
-
+        let uri = format!("https://{}.rpc.grove.city/v1/{}", chain, self.project_id);
         let response = self
             .client
             .post(uri)
@@ -65,6 +66,46 @@ impl RpcProvider for PoktProvider {
             .await?;
         let status = response.status();
         let body = response.bytes().await?;
+
+        if status.is_success() || status.is_client_error() {
+            if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+                if let Some(error) = &response.error {
+                    debug!(
+                        "Strange: provider returned JSON RPC error, but status {status} is \
+                         success: Pokt: {response:?}"
+                    );
+                    match error.code {
+                        // Pokt-specific rate limit codes
+                        -32004 | -32068 => {
+                            return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response())
+                        }
+                        // Internal server error code
+                        -32603 => {
+                            return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response())
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // As an internal RPC node error the InternalErrorResponse is used for the response
+        // that should be considered as an HTTP 5xx error from the provider
+        if let Ok(response) = serde_json::from_slice::<InternalErrorResponse>(&body) {
+            let error = response.error;
+            let request_id = response.request_id;
+            if error.contains("try again later") {
+                return Ok((StatusCode::SERVICE_UNAVAILABLE, body).into_response());
+            } else {
+                debug!(
+                    "Pokt provider returned JSON RPC success status, but got the \
+                    error response structure with the following error: {error} \
+                    the request_id is {request_id}",
+                );
+                return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+            }
+        }
+
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -85,6 +126,7 @@ impl RpcProviderFactory<PoktConfig> for PoktProvider {
 
         PoktProvider {
             client: forward_proxy_client,
+            project_id: provider_config.project_id.clone(),
             supported_chains,
         }
     }

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
 };

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -9,16 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct PublicnodeProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -54,15 +52,15 @@ impl RpcProvider for PublicnodeProvider {
 
         let uri = format!("https://{chain}.publicnode.com");
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -74,13 +72,7 @@ impl RpcProvider for PublicnodeProvider {
 impl RpcProviderFactory<PublicnodeConfig> for PublicnodeProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &PublicnodeConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -9,14 +9,16 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct PublicnodeProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -44,7 +46,7 @@ impl RateLimited for PublicnodeProvider {
 #[async_trait]
 impl RpcProvider for PublicnodeProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -56,11 +58,11 @@ impl RpcProvider for PublicnodeProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -72,7 +74,13 @@ impl RpcProvider for PublicnodeProvider {
 impl RpcProviderFactory<PublicnodeConfig> for PublicnodeProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &PublicnodeConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -14,17 +14,15 @@ use {
         response::{IntoResponse, Response},
     },
     axum::extract::ws::WebSocketUpgrade,
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
     wc::future::FutureExt,
 };
 
 #[derive(Debug)]
 pub struct QuicknodeProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
     pub chain_subdomains: HashMap<String, String>,
 }
@@ -68,15 +66,15 @@ impl RpcProvider for QuicknodeProvider {
                 )))?;
         let uri = format!("https://{chain_subdomain}.quiknode.pro/{token}");
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -88,13 +86,7 @@ impl RpcProvider for QuicknodeProvider {
 impl RpcProviderFactory<QuicknodeConfig> for QuicknodeProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &QuicknodeConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -13,16 +13,18 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    axum::extract::ws::WebSocketUpgrade,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     wc::future::FutureExt,
 };
 
 #[derive(Debug)]
 pub struct QuicknodeProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
     pub chain_subdomains: HashMap<String, String>,
 }
@@ -51,7 +53,7 @@ impl RateLimited for QuicknodeProvider {
 #[async_trait]
 impl RpcProvider for QuicknodeProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let token = &self
             .supported_chains
             .get(chain_id)
@@ -70,11 +72,11 @@ impl RpcProvider for QuicknodeProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
         let mut response = (status, body).into_response();
         response
             .headers_mut()
@@ -86,7 +88,13 @@ impl RpcProvider for QuicknodeProvider {
 impl RpcProviderFactory<QuicknodeConfig> for QuicknodeProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &QuicknodeConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -10,11 +10,10 @@ use {
     },
     async_trait::async_trait,
     axum::{
+        extract::ws::WebSocketUpgrade,
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    axum::extract::ws::WebSocketUpgrade,
-    
     hyper::http,
     std::collections::HashMap,
     wc::future::FutureExt,

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -144,7 +144,7 @@ impl RpcWsProvider for QuicknodeWsProvider {
         let uri = format!("wss://{chain_subdomain}.quiknode.pro/{token}");
         let (websocket_provider, _) = async_tungstenite::tokio::connect_async(uri)
             .await
-            .map_err(|e| RpcError::AxumTungstenite(Box::new(e)))?;
+            .map_err(|e| RpcError::WebSocketError(e.to_string()))?;
 
         Ok(ws.on_upgrade(move |socket| {
             ws::proxy(project_id, socket, websocket_provider)

--- a/src/providers/rootstock.rs
+++ b/src/providers/rootstock.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
     tracing::debug,

--- a/src/providers/rootstock.rs
+++ b/src/providers/rootstock.rs
@@ -9,15 +9,17 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct RootstockProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -48,7 +50,7 @@ impl RateLimited for RootstockProvider {
 #[async_trait]
 impl RpcProvider for RootstockProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -58,11 +60,11 @@ impl RpcProvider for RootstockProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -84,7 +86,13 @@ impl RpcProvider for RootstockProvider {
 impl RpcProviderFactory<RootstockConfig> for RootstockProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &RootstockConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/rootstock.rs
+++ b/src/providers/rootstock.rs
@@ -9,17 +9,15 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct RootstockProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -56,15 +54,15 @@ impl RpcProvider for RootstockProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -86,13 +84,7 @@ impl RpcProvider for RootstockProvider {
 impl RpcProviderFactory<RootstockConfig> for RootstockProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &RootstockConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/sui.rs
+++ b/src/providers/sui.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
     tracing::debug,

--- a/src/providers/sui.rs
+++ b/src/providers/sui.rs
@@ -9,17 +9,15 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct SuiProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -53,15 +51,15 @@ impl RpcProvider for SuiProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -83,13 +81,7 @@ impl RpcProvider for SuiProvider {
 impl RpcProviderFactory<SuiConfig> for SuiProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &SuiConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/sui.rs
+++ b/src/providers/sui.rs
@@ -9,15 +9,17 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct SuiProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -45,7 +47,7 @@ impl RateLimited for SuiProvider {
 #[async_trait]
 impl RpcProvider for SuiProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -55,11 +57,11 @@ impl RpcProvider for SuiProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -81,7 +83,13 @@ impl RpcProvider for SuiProvider {
 impl RpcProviderFactory<SuiConfig> for SuiProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &SuiConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/syndica.rs
+++ b/src/providers/syndica.rs
@@ -139,7 +139,7 @@ impl RpcWsProvider for SyndicaWsProvider {
         let uri = format!("{}/api-key/{}", base_uri, self.api_key);
         let (websocket_provider, _) = async_tungstenite::tokio::connect_async(uri)
             .await
-            .map_err(|e| RpcError::AxumTungstenite(Box::new(e)))?;
+            .map_err(|e| RpcError::WebSocketError(e.to_string()))?;
 
         Ok(ws.on_upgrade(move |socket| {
             ws::proxy(project_id, socket, websocket_provider)

--- a/src/providers/syndica.rs
+++ b/src/providers/syndica.rs
@@ -13,11 +13,9 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
+    
     axum::extract::ws::WebSocketUpgrade,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    hyper::http,
     std::collections::HashMap,
     tracing::debug,
     wc::future::FutureExt,
@@ -25,7 +23,7 @@ use {
 
 #[derive(Debug)]
 pub struct SyndicaProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
     pub api_key: String,
 }
@@ -60,15 +58,15 @@ impl RpcProvider for SyndicaProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
         let uri = format!("{}/api-key/{}", base_uri, self.api_key);
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -90,13 +88,7 @@ impl RpcProvider for SyndicaProvider {
 impl RpcProviderFactory<SyndicaConfig> for SyndicaProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &SyndicaConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/syndica.rs
+++ b/src/providers/syndica.rs
@@ -13,9 +13,11 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    axum::extract::ws::WebSocketUpgrade,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
     wc::future::FutureExt,
@@ -23,7 +25,7 @@ use {
 
 #[derive(Debug)]
 pub struct SyndicaProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
     pub api_key: String,
 }
@@ -52,7 +54,7 @@ impl RateLimited for SyndicaProvider {
 #[async_trait]
 impl RpcProvider for SyndicaProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let base_uri = self
             .supported_chains
             .get(chain_id)
@@ -62,11 +64,11 @@ impl RpcProvider for SyndicaProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -88,7 +90,13 @@ impl RpcProvider for SyndicaProvider {
 impl RpcProviderFactory<SyndicaConfig> for SyndicaProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &SyndicaConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/syndica.rs
+++ b/src/providers/syndica.rs
@@ -10,11 +10,10 @@ use {
     },
     async_trait::async_trait,
     axum::{
+        extract::ws::WebSocketUpgrade,
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
-    axum::extract::ws::WebSocketUpgrade,
     hyper::http,
     std::collections::HashMap,
     tracing::debug,

--- a/src/providers/therpc.rs
+++ b/src/providers/therpc.rs
@@ -6,11 +6,11 @@ use {
     },
     async_trait::async_trait,
     axum::{
-        http::HeaderValue,
+        http::{HeaderValue, StatusCode},
         response::{IntoResponse, Response},
     },
-    hyper::http,
     std::collections::HashMap,
+    tracing::debug,
 };
 
 #[derive(Debug)]
@@ -36,7 +36,7 @@ impl Provider for TheRpcProvider {
 #[async_trait]
 impl RateLimited for TheRpcProvider {
     async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+        response.status() == StatusCode::TOO_MANY_REQUESTS
     }
 }
 
@@ -44,11 +44,11 @@ impl RateLimited for TheRpcProvider {
 impl RpcProvider for TheRpcProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
     async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-        let uri = self
+        let chain = self
             .supported_chains
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
-
+        let uri = format!("https://rpc.therpc.io/{chain}");
         let response = self
             .client
             .post(uri)
@@ -58,6 +58,22 @@ impl RpcProvider for TheRpcProvider {
             .await?;
         let status = response.status();
         let body = response.bytes().await?;
+
+        if status.is_success() || status.is_client_error() {
+            if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+                if let Some(error) = &response.error {
+                    debug!(
+                        "Strange: provider returned JSON RPC error, but status {status} is \
+                         success: TheRpc: {response:?}"
+                    );
+                    // TheRpc-specific rate limit codes
+                    if error.code == -32029 {
+                        return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response());
+                    }
+                }
+            }
+        }
+
         let mut response = (status, body).into_response();
         response
             .headers_mut()

--- a/src/providers/therpc.rs
+++ b/src/providers/therpc.rs
@@ -1,104 +1,93 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-    crate::{
-        env::TheRpcConfig,
-        error::{RpcError, RpcResult},
-    },
-    async_trait::async_trait,
-    axum::{
-        http::HeaderValue,
-        response::{IntoResponse, Response},
-    },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
-    std::collections::HashMap,
-    tracing::debug,
+	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+	crate::{
+		env::TheRpcConfig,
+		error::{RpcError, RpcResult},
+	},
+	async_trait::async_trait,
+	axum::{
+		http::HeaderValue,
+		response::{IntoResponse, Response},
+	},
+	http_body_util::BodyExt,
+	hyper::{http, Method},
+	hyper_rustls::HttpsConnectorBuilder,
+	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct TheRpcProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
-    pub supported_chains: HashMap<String, String>,
+	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for TheRpcProvider {
-    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-        self.supported_chains.contains_key(chain_id)
-    }
+	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+		self.supported_chains.contains_key(chain_id)
+	}
 
-    fn supported_caip_chains(&self) -> Vec<String> {
-        self.supported_chains.keys().cloned().collect()
-    }
+	fn supported_caip_chains(&self) -> Vec<String> {
+		self.supported_chains.keys().cloned().collect()
+	}
 
-    fn provider_kind(&self) -> ProviderKind {
-        ProviderKind::TheRpc
-    }
+	fn provider_kind(&self) -> ProviderKind {
+		ProviderKind::TheRpc
+	}
 }
 
 #[async_trait]
 impl RateLimited for TheRpcProvider {
-    async fn is_rate_limited(&self, response: &mut Response) -> bool {
-        response.status() == http::StatusCode::TOO_MANY_REQUESTS
-    }
+	async fn is_rate_limited(&self, response: &mut Response) -> bool {
+		response.status() == http::StatusCode::TOO_MANY_REQUESTS
+	}
 }
 
 #[async_trait]
 impl RpcProvider for TheRpcProvider {
-    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
-        let chain = &self
-            .supported_chains
-            .get(chain_id)
-            .ok_or(RpcError::ChainNotFound)?;
+	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+		let uri = self
+			.supported_chains
+			.get(chain_id)
+			.ok_or(RpcError::ChainNotFound)?;
 
-        let uri = format!("https://rpc.therpc.io/{chain}");
+		let hyper_request = hyper::http::Request::builder()
+			.method(Method::POST)
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.body(axum::body::Body::from(body))?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
-        let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
-
-        if status.is_success() || status.is_client_error() {
-            if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-                if let Some(error) = &response.error {
-                    debug!(
-                        "Strange: provider returned JSON RPC error, but status {status} is \
-                         success: TheRpc: {response:?}"
-                    );
-                    // TheRpc-specific rate limit codes
-                    if error.code == -32029 {
-                        return Ok((http::StatusCode::TOO_MANY_REQUESTS, body).into_response());
-                    }
-                }
-            }
-        }
-
-        let mut response = (status, body).into_response();
-        response
-            .headers_mut()
-            .insert("Content-Type", HeaderValue::from_static("application/json"));
-        Ok(response)
-    }
+		let response = self.client.request(hyper_request).await?;
+		let status = response.status();
+		let body = response.into_body().collect().await?.to_bytes();
+		let mut response = (status, body).into_response();
+		response
+			.headers_mut()
+			.insert("Content-Type", HeaderValue::from_static("application/json"));
+		Ok(response)
+	}
 }
 
 impl RpcProviderFactory<TheRpcConfig> for TheRpcProvider {
-    #[tracing::instrument(level = "debug")]
-    fn new(provider_config: &TheRpcConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-        let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect();
+	#[tracing::instrument(level = "debug")]
+	fn new(provider_config: &TheRpcConfig) -> Self {
+		let https = HttpsConnectorBuilder::new()
+			.with_webpki_roots()
+			.https_only()
+			.enable_http1()
+			.build();
+		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let supported_chains: HashMap<String, String> = provider_config
+			.supported_chains
+			.iter()
+			.map(|(k, v)| (k.clone(), v.0.clone()))
+			.collect();
 
-        TheRpcProvider {
-            client: forward_proxy_client,
-            supported_chains,
-        }
-    }
+		TheRpcProvider {
+			client: forward_proxy_client,
+			supported_chains,
+		}
+	}
 }

--- a/src/providers/therpc.rs
+++ b/src/providers/therpc.rs
@@ -1,84 +1,84 @@
 use {
-	super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
-	crate::{
-		env::TheRpcConfig,
-		error::{RpcError, RpcResult},
-	},
-	async_trait::async_trait,
-	axum::{
-		http::HeaderValue,
-		response::{IntoResponse, Response},
-	},
-	hyper::http,
-	std::collections::HashMap,
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::TheRpcConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::http,
+    std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct TheRpcProvider {
-	pub client: reqwest::Client,
-	pub supported_chains: HashMap<String, String>,
+    pub client: reqwest::Client,
+    pub supported_chains: HashMap<String, String>,
 }
 
 impl Provider for TheRpcProvider {
-	fn supports_caip_chainid(&self, chain_id: &str) -> bool {
-		self.supported_chains.contains_key(chain_id)
-	}
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
 
-	fn supported_caip_chains(&self) -> Vec<String> {
-		self.supported_chains.keys().cloned().collect()
-	}
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
 
-	fn provider_kind(&self) -> ProviderKind {
-		ProviderKind::TheRpc
-	}
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::TheRpc
+    }
 }
 
 #[async_trait]
 impl RateLimited for TheRpcProvider {
-	async fn is_rate_limited(&self, response: &mut Response) -> bool {
-		response.status() == http::StatusCode::TOO_MANY_REQUESTS
-	}
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
 }
 
 #[async_trait]
 impl RpcProvider for TheRpcProvider {
-	#[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-	async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
-		let uri = self
-			.supported_chains
-			.get(chain_id)
-			.ok_or(RpcError::ChainNotFound)?;
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
 
-		let response = self
-			.client
-			.post(uri)
-			.header(reqwest::header::CONTENT_TYPE, "application/json")
-			.body(body)
-			.send()
-			.await?;
-		let status = response.status();
-		let body = response.bytes().await?;
-		let mut response = (status, body).into_response();
-		response
-			.headers_mut()
-			.insert("Content-Type", HeaderValue::from_static("application/json"));
-		Ok(response)
-	}
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
 }
 
 impl RpcProviderFactory<TheRpcConfig> for TheRpcProvider {
-	#[tracing::instrument(level = "debug")]
-	fn new(provider_config: &TheRpcConfig) -> Self {
-		let forward_proxy_client = reqwest::Client::new();
-		let supported_chains: HashMap<String, String> = provider_config
-			.supported_chains
-			.iter()
-			.map(|(k, v)| (k.clone(), v.0.clone()))
-			.collect();
+    #[tracing::instrument(level = "debug")]
+    fn new(provider_config: &TheRpcConfig) -> Self {
+        let forward_proxy_client = reqwest::Client::new();
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
 
-		TheRpcProvider {
-			client: forward_proxy_client,
-			supported_chains,
-		}
-	}
+        TheRpcProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
 }

--- a/src/providers/therpc.rs
+++ b/src/providers/therpc.rs
@@ -9,16 +9,13 @@ use {
 		http::HeaderValue,
 		response::{IntoResponse, Response},
 	},
-	http_body_util::BodyExt,
-	hyper::{http, Method},
-	hyper_rustls::HttpsConnectorBuilder,
-	hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+	hyper::http,
 	std::collections::HashMap,
 };
 
 #[derive(Debug)]
 pub struct TheRpcProvider {
-	pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+	pub client: reqwest::Client,
 	pub supported_chains: HashMap<String, String>,
 }
 
@@ -52,15 +49,15 @@ impl RpcProvider for TheRpcProvider {
 			.get(chain_id)
 			.ok_or(RpcError::ChainNotFound)?;
 
-		let hyper_request = hyper::http::Request::builder()
-			.method(Method::POST)
-			.uri(uri)
-			.header("Content-Type", "application/json")
-			.body(axum::body::Body::from(body))?;
-
-		let response = self.client.request(hyper_request).await?;
+		let response = self
+			.client
+			.post(uri)
+			.header(reqwest::header::CONTENT_TYPE, "application/json")
+			.body(body)
+			.send()
+			.await?;
 		let status = response.status();
-		let body = response.into_body().collect().await?.to_bytes();
+		let body = response.bytes().await?;
 		let mut response = (status, body).into_response();
 		response
 			.headers_mut()
@@ -72,13 +69,7 @@ impl RpcProvider for TheRpcProvider {
 impl RpcProviderFactory<TheRpcConfig> for TheRpcProvider {
 	#[tracing::instrument(level = "debug")]
 	fn new(provider_config: &TheRpcConfig) -> Self {
-		let https = HttpsConnectorBuilder::new()
-			.with_webpki_roots()
-			.https_only()
-			.enable_http1()
-			.build();
-		let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-			HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+		let forward_proxy_client = reqwest::Client::new();
 		let supported_chains: HashMap<String, String> = provider_config
 			.supported_chains
 			.iter()

--- a/src/providers/unichain.rs
+++ b/src/providers/unichain.rs
@@ -9,17 +9,14 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    hyper::http,
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct UnichainProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -53,15 +50,15 @@ impl RpcProvider for UnichainProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -83,13 +80,7 @@ impl RpcProvider for UnichainProvider {
 impl RpcProviderFactory<UnichainConfig> for UnichainProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &UnichainConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/unichain.rs
+++ b/src/providers/unichain.rs
@@ -9,15 +9,17 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct UnichainProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -45,7 +47,7 @@ impl RateLimited for UnichainProvider {
 #[async_trait]
 impl RpcProvider for UnichainProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -55,11 +57,11 @@ impl RpcProvider for UnichainProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -81,7 +83,13 @@ impl RpcProvider for UnichainProvider {
 impl RpcProviderFactory<UnichainConfig> for UnichainProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &UnichainConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/wemix.rs
+++ b/src/providers/wemix.rs
@@ -9,17 +9,15 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    
+    hyper::http,
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct WemixProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -53,15 +51,15 @@ impl RpcProvider for WemixProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -83,13 +81,7 @@ impl RpcProvider for WemixProvider {
 impl RpcProviderFactory<WemixConfig> for WemixProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &WemixConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/wemix.rs
+++ b/src/providers/wemix.rs
@@ -9,15 +9,17 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct WemixProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -45,7 +47,7 @@ impl RateLimited for WemixProvider {
 #[async_trait]
 impl RpcProvider for WemixProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -55,11 +57,11 @@ impl RpcProvider for WemixProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -81,7 +83,13 @@ impl RpcProvider for WemixProvider {
 impl RpcProviderFactory<WemixConfig> for WemixProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &WemixConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/wemix.rs
+++ b/src/providers/wemix.rs
@@ -9,7 +9,6 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
     hyper::http,
     std::collections::HashMap,
     tracing::debug,

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -9,15 +9,17 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    hyper::{client::HttpConnector, http, Client, Method},
-    hyper_tls::HttpsConnector,
+    http_body_util::BodyExt,
+    hyper::{http, Method},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
     std::collections::HashMap,
     tracing::debug,
 };
 
 #[derive(Debug)]
 pub struct ZKSyncProvider {
-    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -45,7 +47,7 @@ impl RateLimited for ZKSyncProvider {
 #[async_trait]
 impl RpcProvider for ZKSyncProvider {
     #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()), level = "debug")]
-    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: bytes::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
@@ -55,11 +57,11 @@ impl RpcProvider for ZKSyncProvider {
             .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
-            .body(hyper::body::Body::from(body))?;
+            .body(axum::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
         let status = response.status();
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let body = response.into_body().collect().await?.to_bytes();
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -81,7 +83,13 @@ impl RpcProvider for ZKSyncProvider {
 impl RpcProviderFactory<ZKSyncConfig> for ZKSyncProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &ZKSyncConfig) -> Self {
-        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .build();
+        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
+            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/zora.rs
+++ b/src/providers/zora.rs
@@ -72,7 +72,7 @@ impl RpcWsProvider for ZoraWsProvider {
 
         let (websocket_provider, _) = async_tungstenite::tokio::connect_async(uri)
             .await
-            .map_err(|e| RpcError::AxumTungstenite(Box::new(e)))?;
+            .map_err(|e| RpcError::WebSocketError(e.to_string()))?;
 
         Ok(ws.on_upgrade(move |socket| {
             ws::proxy(project_id, socket, websocket_provider)

--- a/src/providers/zora.rs
+++ b/src/providers/zora.rs
@@ -13,11 +13,9 @@ use {
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    http_body_util::BodyExt,
+    
     axum::extract::ws::WebSocketUpgrade,
-    hyper::{http, Method},
-    hyper_rustls::HttpsConnectorBuilder,
-    hyper_util::client::legacy::{connect::HttpConnector, Client as HyperClientLegacy},
+    hyper::http,
     std::collections::HashMap,
     tracing::debug,
     wc::future::FutureExt,
@@ -25,7 +23,7 @@ use {
 
 #[derive(Debug)]
 pub struct ZoraProvider {
-    pub client: HyperClientLegacy<hyper_rustls::HttpsConnector<HttpConnector>, axum::body::Body>,
+    pub client: reqwest::Client,
     pub supported_chains: HashMap<String, String>,
 }
 
@@ -117,15 +115,15 @@ impl RpcProvider for ZoraProvider {
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
-        let hyper_request = hyper::http::Request::builder()
-            .method(Method::POST)
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .body(axum::body::Body::from(body))?;
-
-        let response = self.client.request(hyper_request).await?;
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await?;
         let status = response.status();
-        let body = response.into_body().collect().await?.to_bytes();
+        let body = response.bytes().await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if response.error.is_some() && status.is_success() {
@@ -147,13 +145,7 @@ impl RpcProvider for ZoraProvider {
 impl RpcProviderFactory<ZoraConfig> for ZoraProvider {
     #[tracing::instrument(level = "debug")]
     fn new(provider_config: &ZoraConfig) -> Self {
-        let https = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .build();
-        let forward_proxy_client: HyperClientLegacy<_, axum::body::Body> =
-            HyperClientLegacy::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+        let forward_proxy_client = reqwest::Client::new();
         let supported_chains: HashMap<String, String> = provider_config
             .supported_chains
             .iter()

--- a/src/providers/zora.rs
+++ b/src/providers/zora.rs
@@ -10,11 +10,10 @@ use {
     },
     async_trait::async_trait,
     axum::{
+        extract::ws::WebSocketUpgrade,
         http::HeaderValue,
         response::{IntoResponse, Response},
     },
-    
-    axum::extract::ws::WebSocketUpgrade,
     hyper::http,
     std::collections::HashMap,
     tracing::debug,

--- a/src/utils/simple_request_json.rs
+++ b/src/utils/simple_request_json.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
-use axum::extract::rejection::JsonRejection;
-use axum::http::{HeaderValue, Request};
+use axum::extract::{rejection::JsonRejection, FromRequest, Request};
+use axum::http::HeaderValue;
 use axum::Json;
-use axum::{body::HttpBody, extract::FromRequest, BoxError};
 use serde::de::DeserializeOwned;
 
 /// Same as axum::Json but doesn't care what the Content-Type header is
@@ -11,17 +10,14 @@ use serde::de::DeserializeOwned;
 pub struct SimpleRequestJson<T>(pub T);
 
 #[async_trait]
-impl<T, S, B> FromRequest<S, B> for SimpleRequestJson<T>
+impl<T, S> FromRequest<S> for SimpleRequestJson<T>
 where
     T: DeserializeOwned,
-    B: HttpBody + Send + 'static,
-    B::Data: Send,
-    B::Error: Into<BoxError>,
     S: Send + Sync,
 {
     type Rejection = JsonRejection;
 
-    async fn from_request(mut req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(mut req: Request, state: &S) -> Result<Self, Self::Rejection> {
         // Always set the header to application/json, regardless of what was there before
         req.headers_mut()
             .insert("content-type", HeaderValue::from_static("application/json"));

--- a/src/utils/simple_request_json.rs
+++ b/src/utils/simple_request_json.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
-use axum::extract::{rejection::JsonRejection, FromRequest, Request};
-use axum::http::HeaderValue;
-use axum::Json;
+use axum::{
+    extract::{rejection::JsonRejection, FromRequest, Request},
+    http::HeaderValue,
+    Json,
+};
 use serde::de::DeserializeOwned;
 
 /// Same as axum::Json but doesn't care what the Content-Type header is

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,22 +1,63 @@
 use {
-    async_tungstenite::{tokio::ConnectStream, WebSocketStream},
-    futures_util::{select, StreamExt},
+    async_tungstenite::{tokio::ConnectStream, tungstenite, WebSocketStream},
+    axum::extract::ws::{Message as AxumWsMessage, WebSocket},
+    futures_util::{SinkExt, StreamExt},
     tracing::log::debug,
 };
 
 #[tracing::instrument(skip(client_ws, provider_ws), level = "debug")]
 pub async fn proxy(
     project_id: String,
-    client_ws: axum_tungstenite::WebSocket,
+    client_ws: WebSocket,
     provider_ws: WebSocketStream<ConnectStream>,
 ) {
-    let (client_ws_sender, client_ws_receiver) = client_ws.split();
-    let (provider_ws_sender, provider_ws_receiver) = provider_ws.split();
+    let (mut client_ws_sender, mut client_ws_receiver) = client_ws.split();
+    let (mut provider_ws_sender, mut provider_ws_receiver) = provider_ws.split();
 
-    let mut write = client_ws_receiver.forward(provider_ws_sender);
-    let mut read = provider_ws_receiver.forward(client_ws_sender);
-    select! {
-        _ = read => debug!("WebSocket relaying messages to the provider for client {project_id} died.") ,
-        _ = write => debug!("WebSocket relaying messages from the provider to the client {project_id} died.") ,
+    // Relay: client -> provider
+    let write = async {
+        while let Some(Ok(msg)) = client_ws_receiver.next().await {
+            let tmsg = match msg {
+                AxumWsMessage::Text(s) => tungstenite::Message::Text(s),
+                AxumWsMessage::Binary(b) => tungstenite::Message::Binary(b.to_vec()),
+                AxumWsMessage::Ping(b) => tungstenite::Message::Ping(b.to_vec()),
+                AxumWsMessage::Pong(b) => tungstenite::Message::Pong(b.to_vec()),
+                AxumWsMessage::Close(frame) => {
+                    tungstenite::Message::Close(frame.map(|f| tungstenite::protocol::CloseFrame {
+                        code: f.code.into(),
+                        reason: f.reason,
+                    }))
+                }
+            };
+            if provider_ws_sender.send(tmsg).await.is_err() {
+                break;
+            }
+        }
+    };
+
+    // Relay: provider -> client
+    let read = async {
+        while let Some(Ok(msg)) = provider_ws_receiver.next().await {
+            let amsg = match msg {
+                tungstenite::Message::Text(s) => AxumWsMessage::Text(s),
+                tungstenite::Message::Binary(b) => AxumWsMessage::Binary(b),
+                tungstenite::Message::Ping(b) => AxumWsMessage::Ping(b),
+                tungstenite::Message::Pong(b) => AxumWsMessage::Pong(b),
+                tungstenite::Message::Close(frame) => {
+                    AxumWsMessage::Close(frame.map(|f| axum::extract::ws::CloseFrame {
+                        code: f.code.into(),
+                        reason: f.reason,
+                    }))
+                }
+                tungstenite::Message::Frame(_) => continue,
+            };
+            if client_ws_sender.send(amsg).await.is_err() {
+                break;
+            }
+        }
+    };
+    tokio::select! {
+        _ = read => debug!("WebSocket relaying messages to the provider for client {project_id} died."),
+        _ = write => debug!("WebSocket relaying messages from the provider to the client {project_id} died."),
     }
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -49,7 +49,10 @@ pub async fn proxy(
                         reason: f.reason,
                     }))
                 }
-                tungstenite::Message::Frame(_) => continue,
+                tungstenite::Message::Frame(_) => {
+                    debug!("Received unhandled WebSocket raw frame type. Skipping.");
+                    continue;
+                }
             };
             if client_ws_sender.send(amsg).await.is_err() {
                 break;

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -213,8 +213,7 @@ async fn account_history_check(ctx: &mut ServerContext) {
     );
 
     let response = reqwest::Client::new().get(addr).send().await.unwrap();
-    let status = StatusCode::from_u16(response.status().as_u16()).unwrap();
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let bytes = response.bytes().await.unwrap();
     let body = Body::from(bytes);

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -1,7 +1,10 @@
 use {
     crate::{context::ServerContext, utils::send_jsonrpc_request, JSONRPC_VERSION},
-    hyper::{Body, Client, Method, Request, StatusCode},
-    hyper_tls::HttpsConnector,
+    axum::body::Body,
+    http_body_util::BodyExt,
+    hyper::{Method, Request, StatusCode},
+    hyper_rustls::HttpsConnectorBuilder,
+    hyper_util::{client::legacy::Client, rt::TokioExecutor},
     rpc_proxy::{handlers::history::HistoryResponseBody, providers::ProviderKind},
     test_context::test_context,
 };
@@ -39,7 +42,12 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx.server.public_addr, ctx.server.project_id, provider_id
     );
 
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
     let request = jsonrpc::Request {
         method: "eth_chainId",
         params: None,
@@ -70,7 +78,12 @@ async fn check_if_rpc_is_responding_correctly_for_near_protocol(
         ctx.server.public_addr, ctx.server.project_id, provider_id
     );
 
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
     let request = jsonrpc::Request {
         method: "EXPERIMENTAL_genesis_config",
         params: None,
@@ -110,7 +123,12 @@ async fn check_if_rpc_is_responding_correctly_for_solana(
         ctx.server.public_addr, ctx.server.project_id, provider_id
     );
 
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
     let request = jsonrpc::Request {
         method: "getHealth",
         params: None,
@@ -142,7 +160,12 @@ async fn check_if_rpc_is_responding_correctly_for_sui(
         ctx.server.public_addr, ctx.server.project_id, provider_id
     );
 
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
     let request = jsonrpc::Request {
         method: "sui_getChainIdentifier",
         params: None,
@@ -173,7 +196,12 @@ async fn check_if_rpc_is_responding_correctly_for_bitcoin(
         ctx.server.public_addr, ctx.server.project_id, provider_id
     );
 
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
     let request = jsonrpc::Request {
         method: "getblockcount",
         params: None,
@@ -198,7 +226,12 @@ async fn check_if_rpc_is_responding_correctly_for_bitcoin(
 #[tokio::test]
 async fn health_check(ctx: &mut ServerContext) {
     let addr = format!("{}health", ctx.server.public_addr);
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
 
     let request = Request::builder()
         .method(Method::GET)
@@ -221,7 +254,12 @@ async fn account_history_check(ctx: &mut ServerContext) {
         ctx.server.public_addr, account, project_id
     );
 
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let https = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_only()
+        .enable_http1()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build::<_, Body>(https);
 
     let request = Request::builder()
         .method(Method::GET)
@@ -233,7 +271,7 @@ async fn account_history_check(ctx: &mut ServerContext) {
     let status = response.status();
     assert_eq!(status, StatusCode::OK);
 
-    let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8_lossy(&bytes);
 
     let json_response: HistoryResponseBody =

--- a/tests/functional/websocket/mod.rs
+++ b/tests/functional/websocket/mod.rs
@@ -1,5 +1,6 @@
 use {
     crate::{context::ServerContext, JSONRPC_VERSION},
+    async_tungstenite::tungstenite::Message,
     futures_util::{SinkExt, StreamExt},
 };
 
@@ -26,11 +27,9 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
 
     let (mut tx, mut rx) = client.split();
 
-    tx.send(axum_tungstenite::Message::Text(
-        serde_json::to_string(&request).unwrap(),
-    ))
-    .await
-    .unwrap();
+    tx.send(Message::Text(serde_json::to_string(&request).unwrap()))
+        .await
+        .unwrap();
 
     let response = rx.next().await.unwrap().unwrap();
     let response: jsonrpc::Response = serde_json::from_str(&response.to_string()).unwrap();

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,14 +1,15 @@
 use {
-    axum::{body::Body, http::HeaderValue},
-    http_body_util::BodyExt,
-    hyper::{Method, Request, StatusCode},
-    hyper_util::client::legacy::{connect::HttpConnector, Client},
+    axum::{
+        body::{to_bytes, Body},
+        http::{HeaderValue, StatusCode},
+    },
     sqlx::{postgres::PgPoolOptions, PgPool},
     std::env,
 };
 
+const RESPONSE_MAX_BYTES: usize = 512 * 1024; // 512 KB
+
 pub async fn send_jsonrpc_request(
-    client: Client<hyper_rustls::HttpsConnector<HttpConnector>, Body>,
     base_addr: String,
     chain: &str,
     rpc_request: jsonrpc::Request<'static>,
@@ -16,25 +17,25 @@ pub async fn send_jsonrpc_request(
     let addr = base_addr + chain;
 
     let json = serde_json::to_string(&rpc_request).unwrap();
-    let req_body = Body::from(json.clone());
-
-    let request = Request::builder()
-        .method(Method::POST)
-        .uri(addr.clone())
+    let client = reqwest::Client::new();
+    let response = client
+        .post(addr.clone())
         .header("Content-Type", "application/json")
-        .body(req_body)
+        .body(json.clone())
+        .send()
+        .await
         .unwrap();
-
-    let response = client.request(request).await.unwrap();
     assert_eq!(
         response.headers().get("Content-Type"),
         Some(&HeaderValue::from_static("application/json"))
     );
 
-    let (parts, body) = response.into_parts();
-    let body = body.collect().await.unwrap().to_bytes();
+    let status = response.status();
+    let bytes = response.bytes().await.unwrap();
+    let body = Body::from(bytes);
+    let body = to_bytes(body, RESPONSE_MAX_BYTES).await.unwrap();
     (
-        parts.status,
+        status,
         serde_json::from_slice(&body).unwrap_or_else(|_| {
             panic!(
                 "Failed to parse response '{:?}' ({} / {:?})",


### PR DESCRIPTION
# Description

This PR updates Axum to version 0.7 and changes to use `reqwest` instead of the `hyper` for simplicity.
The `prometheus-http-query` crate version was updated to the latest version.
The `utils-rs` crate version was updated to `0.10` to support Axum 0.7.

[Two new missed integration tests](https://github.com/reown-com/blockchain-api/pull/1197/files#diff-110394bb1153af5ff10ed8e42f354e9b06538ca2a223770c44f3240363fbd977R36) were added for a simple check for each supported chain in the supported list (Ethereum and Solana) by using the balance RPC method (which is not a cached method) for a proper proxy functionality check and to avoid regressions before it reaches the AWS canary periodically check.

## Must be done before merging

* [x] Enable geoblock.
* [x] Proxy integration test for a possible regression.

## How Has This Been Tested?

Tested locally, and tested by integration tests also.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
