### PR TITLE
feat(proxy): always return `true` for the `net_listening` method

### DIFF
--- a/integration/proxy.test.ts
+++ b/integration/proxy.test.ts
@@ -30,4 +30,34 @@ describe('Proxy', () => {
     )
     expect(resp.status).toBe(401)
   })
+
+  it('net_listening RPC method', async () => {
+    // Get the chains list from the /supported-chains endpoint
+    const chainsResp: any = await httpClient.get(`${baseUrl}/v1/supported-chains`)
+    expect(chainsResp.status).toBe(200)
+    expect(typeof chainsResp.data).toBe('object')
+    const chains = chainsResp.data.http
+    expect(chains.length).toBeGreaterThan(0)
+  
+    // Check each supported eip155 chain for the net_listening RPC method
+    for (const chain of chains) {
+      if (!chain.includes('eip155:')) {
+        continue
+      }
+      const payload = {
+        jsonrpc: "2.0",
+        method: "net_listening",
+        params: [],
+        id: 1,
+      };
+
+      let resp: any = await httpClient.post(
+        `${baseUrl}/v1?chainId=${chain}&projectId=${projectId}`,
+        payload
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data).toBe('object')
+      expect(resp.data.result).toBe(true)
+    }
+  })
 })

--- a/src/utils/json_rpc_cache.rs
+++ b/src/utils/json_rpc_cache.rs
@@ -13,6 +13,8 @@ use {
 pub enum CachedMethods {
     #[strum(serialize = "eth_chainId")]
     EthChainId,
+    #[strum(serialize = "net_listening")]
+    NetListening,
 }
 
 /// Check if the response is cached and apply caching
@@ -26,6 +28,9 @@ pub async fn is_cached_response(
         match method {
             CachedMethods::EthChainId => {
                 handle_eth_chain_id(caip2_chain_id, request, moka_cache, metrics).await
+            }
+            CachedMethods::NetListening => {
+                handle_net_listening(caip2_chain_id, request, moka_cache, metrics).await
             }
         }
     } else {
@@ -94,7 +99,7 @@ async fn check_cached_chain_id_response(
     })
 }
 
-/// Handle the eth_chainId RPC method caching
+/// Handle the `eth_chainId` RPC method caching
 async fn handle_eth_chain_id(
     caip2_chain_id: &str,
     request: &JsonRpcRequest,
@@ -136,6 +141,21 @@ async fn handle_eth_chain_id(
     metrics.add_rpc_cached_call(
         caip2_chain_id.to_string(),
         CachedMethods::EthChainId.to_string(),
+    );
+    Some(response)
+}
+
+/// Handle the `net_listening` RPC method by always returning `true` as a result
+async fn handle_net_listening(
+    caip2_chain_id: &str,
+    request: &JsonRpcRequest,
+    _moka_cache: &Cache<String, String>, // We don't need to cache the result for this method
+    metrics: &Metrics,
+) -> Option<JsonRpcResponse> {
+    let response = JsonRpcResponse::Result(JsonRpcResult::new(request.id.clone(), true.into()));
+    metrics.add_rpc_cached_call(
+        caip2_chain_id.to_string(),
+        CachedMethods::NetListening.to_string(),
     );
     Some(response)
 }


### PR DESCRIPTION
# Description

This PR adds a hardcoded response with the `true` result instead of proxying the request for `net_listening` JSON-RPC method.

## How Has This Been Tested?

New integration test implemented in this PR.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
