### PR TITLE
fix: increasing otel memory for staging and jest test timeout

### DIFF
--- a/integration/jestconfig.integration.json
+++ b/integration/jestconfig.integration.json
@@ -5,5 +5,5 @@
   },
   "testRegex": "./.*\\.test\\.ts$",
   "collectCoverageFrom": ["src/**/*.{ts,js}"],
-  "testTimeout": 30000
+  "testTimeout": 60000
 }

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -8,11 +8,11 @@ locals {
 
   otel_port   = var.port + 1
   otel_cpu    = module.this.stage == "prod" ? 128 : 64
-  otel_memory = module.this.stage == "prod" ? 256 : 64
+  otel_memory = module.this.stage == "prod" ? 256 : 128
 
   prometheus_proxy_port   = var.port + 2
   prometheus_proxy_cpu    = module.this.stage == "prod" ? 128 : 64
-  prometheus_proxy_memory = module.this.stage == "prod" ? 256 : 64
+  prometheus_proxy_memory = module.this.stage == "prod" ? 256 : 128
 
   file_descriptor_soft_limit = pow(2, 20) # 1024 x 1024 = 1,048,576 is the Fargate maximum
   file_descriptor_hard_limit = pow(2, 20)


### PR DESCRIPTION
# Description

This PR increases the otel collector memory for staging from 64 Mb to 128 Mb, because the otel collector stops by OOM at staging after tests running, making the staging flaky.
The Jest test timeout was increased from 30 seconds to 60 seconds to cover new proxy tests, because testing each chain for the `eth_getBalance` sometimes takes longer and causes a flaky test.

## How Has This Been Tested?

Tested manually by adjusting these values.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
