### PR TITLE
fix: get_exchanges when not enabled should return []

### DIFF
--- a/src/handlers/wallet/exchanges/mod.rs
+++ b/src/handlers/wallet/exchanges/mod.rs
@@ -218,7 +218,5 @@ pub async fn is_feature_enabled_for_project_id(
         return Ok(());
     }
 
-    Err(ExchangeError::FeatureNotEnabled(
-        "Payments feature is not enabled for this project".to_string(),
-    ))
+    Ok(())
 }

--- a/src/handlers/wallet/get_exchanges.rs
+++ b/src/handlers/wallet/get_exchanges.rs
@@ -75,9 +75,12 @@ pub async fn handler(
     query: Query<QueryParams>,
     Json(request): Json<GetExchangesRequest>,
 ) -> Result<GetExchangesResponse, GetExchangesError> {
-    is_feature_enabled_for_project_id(state.clone(), &project_id)
-        .await
-        .map_err(|e| GetExchangesError::ValidationError(e.to_string()))?;
+    if let Err(_e) = is_feature_enabled_for_project_id(state.clone(), &project_id).await {
+        return Ok(GetExchangesResponse {
+            total: 0,
+            exchanges: vec![],
+        });
+    }
     handler_internal(state, connect_info, headers, query, request)
         .with_metrics(HANDLER_TASK_METRICS.with_name("pay_get_exchanges"))
         .await


### PR DESCRIPTION

# Description

- Makes `get_exchanges` return empty array if feature is not enabled instead of throwing

## Due Diligence

* [x] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
