### PR TITLE
feat: pos transaction builder

### DIFF
--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -97,6 +97,8 @@ pub enum MessageSource {
     WalletGetCallsStatus,
     WalletGetAssets,
     ChainAgnosticCheck,
+    WalletBuildPosTx,
+    WalletSendPosTx,
 }
 
 #[cfg(test)]

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -130,6 +130,12 @@ mod tests {
 
         let source = MessageSource::ChainAgnosticCheck;
         assert_eq!(source.to_string(), "chain_agnostic_check");
+
+        let source = MessageSource::WalletBuildPosTx;
+        assert_eq!(source.to_string(), "wallet_build_pos_tx");
+
+        let source = MessageSource::WalletSendPosTx;
+        assert_eq!(source.to_string(), "wallet_send_pos_tx");
     }
 
     #[test]

--- a/src/handlers/wallet/handler.rs
+++ b/src/handlers/wallet/handler.rs
@@ -3,8 +3,8 @@ use super::get_calls_status::{self, GetCallsStatusError};
 use super::get_exchange_buy_status::{self, GetExchangeBuyStatusError};
 use super::get_exchange_url::{self, GetExchangeUrlError};
 use super::get_exchanges::{self, GetExchangesError};
-use super::prepare_calls::{self, PrepareCallsError};
 use super::pos::{self, BuildPosTxError, CheckPosTxError};
+use super::prepare_calls::{self, PrepareCallsError};
 use super::send_prepared_calls::{self, SendPreparedCallsError};
 use crate::error::RpcError;
 use crate::json_rpc::{

--- a/src/handlers/wallet/mod.rs
+++ b/src/handlers/wallet/mod.rs
@@ -1,5 +1,6 @@
 pub mod call_id;
 pub mod exchanges;
+pub mod pos;
 pub mod get_assets;
 pub mod get_calls_status;
 pub mod get_exchange_buy_status;

--- a/src/handlers/wallet/mod.rs
+++ b/src/handlers/wallet/mod.rs
@@ -1,12 +1,12 @@
 pub mod call_id;
 pub mod exchanges;
-pub mod pos;
 pub mod get_assets;
 pub mod get_calls_status;
 pub mod get_exchange_buy_status;
 pub mod get_exchange_url;
 pub mod get_exchanges;
 pub mod handler;
+pub mod pos;
 pub mod prepare_calls;
 pub mod send_prepared_calls;
 mod types;

--- a/src/handlers/wallet/pos/build_transaction.rs
+++ b/src/handlers/wallet/pos/build_transaction.rs
@@ -1,15 +1,12 @@
 use {
     super::{BuildPosTxError, BuildTransactionParams, BuildTransactionResult, TransactionBuilder},
     crate::{
-        state::AppState,
+        handlers::wallet::pos::evm::EvmTransactionBuilder, state::AppState,
         utils::crypto::Caip19Asset,
-        handlers::wallet::pos::evm::EvmTransactionBuilder
     },
     axum::extract::State,
     std::sync::Arc,
 };
-
-
 
 #[tracing::instrument(skip(_state), level = "debug")]
 pub async fn handler(
@@ -21,9 +18,13 @@ pub async fn handler(
         .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
 
     match asset.chain_id().namespace() {
-        "eip155" => EvmTransactionBuilder.build(_state, project_id, params).await,
-        ns => Err(BuildPosTxError::Validation(format!("Unsupported namespace: {ns}"))),
+        "eip155" => {
+            EvmTransactionBuilder
+                .build(_state, project_id, params)
+                .await
+        }
+        ns => Err(BuildPosTxError::Validation(format!(
+            "Unsupported namespace: {ns}"
+        ))),
     }
 }
-
-

--- a/src/handlers/wallet/pos/build_transaction.rs
+++ b/src/handlers/wallet/pos/build_transaction.rs
@@ -1,0 +1,29 @@
+use {
+    super::{BuildPosTxError, BuildTransactionParams, BuildTransactionResult, TransactionBuilder},
+    crate::{
+        state::AppState,
+        utils::crypto::Caip19Asset,
+        handlers::wallet::pos::evm::EvmTransactionBuilder
+    },
+    axum::extract::State,
+    std::sync::Arc,
+};
+
+
+
+#[tracing::instrument(skip(_state), level = "debug")]
+pub async fn handler(
+    _state: State<Arc<AppState>>,
+    project_id: String,
+    params: BuildTransactionParams,
+) -> Result<BuildTransactionResult, BuildPosTxError> {
+    let asset = Caip19Asset::parse(&params.asset)
+        .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
+
+    match asset.chain_id().namespace() {
+        "eip155" => EvmTransactionBuilder.build(_state, project_id, params).await,
+        ns => Err(BuildPosTxError::Validation(format!("Unsupported namespace: {ns}"))),
+    }
+}
+
+

--- a/src/handlers/wallet/pos/check_transaction.rs
+++ b/src/handlers/wallet/pos/check_transaction.rs
@@ -1,0 +1,32 @@
+use {
+    super::CheckPosTxError,
+    crate::state::AppState,
+    axum::extract::State,
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckTransactionParams {
+    pub id: String,
+    pub txid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckTransactionResult {
+    pub status: String,
+}
+
+pub async fn handler(
+    _state: State<Arc<AppState>>,
+    _project_id: String,
+    _params: CheckTransactionParams,
+) -> Result<CheckTransactionResult, CheckPosTxError> {
+    Ok(CheckTransactionResult {
+        status: "CONFIRMED".into(),
+    })
+}
+
+

--- a/src/handlers/wallet/pos/check_transaction.rs
+++ b/src/handlers/wallet/pos/check_transaction.rs
@@ -28,5 +28,3 @@ pub async fn handler(
         status: "CONFIRMED".into(),
     })
 }
-
-

--- a/src/handlers/wallet/pos/evm.rs
+++ b/src/handlers/wallet/pos/evm.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         analytics::MessageSource,
         state::AppState,
-        utils::crypto::{disassemble_caip10, Caip19Asset, CaipNamespaces, Caip2ChainId},
+        utils::crypto::{disassemble_caip10, Caip19Asset, Caip2ChainId, CaipNamespaces},
     },
     alloy::{
         network::TransactionBuilder as AlloyTransactionBuilder,
@@ -56,6 +56,137 @@ pub struct EthTx {
     pub data: String,
 }
 
+#[derive(Debug)]
+pub struct TxBuilder {
+    to: Address,
+    from: Address,
+    tx_request: TransactionRequest,
+    project_id: String,
+    chain_id: Caip2ChainId,
+}
+
+impl TxBuilder {
+    fn new(
+        project_id: &str,
+        chain_id: &Caip2ChainId,
+        recipient: &str,
+        sender: &str,
+    ) -> Result<Self, BuildPosTxError> {
+        let to = recipient
+            .parse::<Address>()
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid recipient: {}", e)))?;
+
+        let from = sender
+            .parse::<Address>()
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid sender: {}", e)))?;
+
+        Ok(Self {
+            to,
+            from,
+            tx_request: TransactionRequest::default(),
+            project_id: project_id.to_string(),
+            chain_id: chain_id.clone(),
+        })
+    }
+
+    async fn with_native_transfer(mut self, amount: &str) -> Result<Self, BuildPosTxError> {
+        let value = parse_units(amount, "ether").map_err(|e| {
+            BuildPosTxError::Validation(format!("Unable to parse amount in ether: {}", e))
+        })?;
+
+        let amount: U256 = value
+            .try_into()
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid amount: {}", e)))?;
+
+        self.tx_request = self
+            .tx_request
+            .with_to(self.to)
+            .with_value(amount)
+            .with_from(self.from);
+
+        Ok(self)
+    }
+
+    async fn with_erc20_transfer(
+        mut self,
+        asset_address: &str,
+        amount: &str,
+    ) -> Result<Self, BuildPosTxError> {
+        let token_address = asset_address
+            .parse::<Address>()
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid asset address: {}", e)))?;
+
+        let provider = get_provider(&self.chain_id, &self.project_id)?;
+        let erc20 = ERC20Token::new(token_address, provider);
+
+        let decimals_call_result =
+            erc20.decimals().call().await.map_err(|e| {
+                BuildPosTxError::Validation(format!("Failed to get decimals: {}", e))
+            })?;
+
+        let decimals = decimals_call_result._0;
+        debug!("decimals: {:?}", decimals);
+
+        let value = parse_units(amount, decimals).map_err(|e| {
+            BuildPosTxError::Validation(format!(
+                "Unable to parse amount with {} decimals: {}",
+                decimals, e
+            ))
+        })?;
+
+        let token_amount: U256 = value
+            .try_into()
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid token amount: {}", e)))?;
+
+        let transfer_data = erc20.transfer(self.to, token_amount);
+
+        self.tx_request = self
+            .tx_request
+            .with_to(token_address)
+            .with_value(U256::ZERO)
+            .with_input(transfer_data.calldata().clone())
+            .with_from(self.from);
+
+        Ok(self)
+    }
+
+    async fn finalize(mut self) -> Result<BuildTransactionResult, BuildPosTxError> {
+        let provider = get_provider(&self.chain_id, &self.project_id)?;
+
+        let fees = provider
+            .estimate_eip1559_fees(None)
+            .await
+            .map_err(|e| BuildPosTxError::Validation(format!("Failed to estimate fees: {}", e)))?;
+
+        self.tx_request = self
+            .tx_request
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
+
+        let has_data =
+            self.tx_request.input.data.is_some() || self.tx_request.input.input.is_some();
+        let gas_limit = if !has_data {
+            21000u64
+        } else {
+            provider.estimate_gas(&self.tx_request).await.map_err(|e| {
+                BuildPosTxError::Validation(format!("Failed to estimate gas: {}", e))
+            })?
+        };
+
+        self.tx_request = self.tx_request.with_gas_limit(gas_limit);
+
+        debug!("finalized tx: {:?}", self.tx_request);
+
+        Ok(BuildTransactionResult {
+            transaction_rpc: TransactionRpc {
+                method: "eth_sendTransaction".to_string(),
+                params: serde_json::json!([self.tx_request]),
+            },
+            id: Uuid::new_v4().to_string(),
+        })
+    }
+}
+
 #[async_trait]
 impl TransactionBuilder for EvmTransactionBuilder {
     fn namespace(&self) -> &'static str {
@@ -89,9 +220,9 @@ impl TransactionBuilder for EvmTransactionBuilder {
             })?;
 
         if asset_namespace != recipient_namespace || asset_namespace != sender_namespace {
-            return Err(BuildPosTxError::Validation(format!(
-                "Asset namespace must match recipient and sender namespaces"
-            )));
+            return Err(BuildPosTxError::Validation(
+                "Asset namespace must match recipient and sender namespaces".to_string(),
+            ));
         }
 
         debug!("asset_chain_id: {}", asset_chain_id);
@@ -99,9 +230,9 @@ impl TransactionBuilder for EvmTransactionBuilder {
         debug!("sender_chain_id: {}", sender_chain_id);
 
         if asset_chain_id != recipient_chain_id || asset_chain_id != sender_chain_id {
-            return Err(BuildPosTxError::Validation(format!(
-                "Asset chain ID must match recipient and sender chain IDs"
-            )));
+            return Err(BuildPosTxError::Validation(
+                "Asset chain ID must match recipient and sender chain IDs".to_string(),
+            ));
         }
 
         let namespace = asset
@@ -109,27 +240,27 @@ impl TransactionBuilder for EvmTransactionBuilder {
             .parse::<AssetNamespace>()
             .map_err(|e| BuildPosTxError::Validation(format!("Invalid asset namespace: {}", e)))?;
 
+        let builder = TxBuilder::new(
+            &project_id,
+            &asset.chain_id(),
+            &recipient_address,
+            &sender_address,
+        )?;
+
         let tx = match namespace {
             AssetNamespace::Slip44 => {
-                build_native_transaction(
-                    &project_id,
-                    &asset.chain_id(),
-                    &recipient_address,
-                    &sender_address,
-                    &params.amount,
-                )
-                .await?
+                builder
+                    .with_native_transfer(&params.amount)
+                    .await?
+                    .finalize()
+                    .await?
             }
             AssetNamespace::Erc20 => {
-                build_erc20_transaction(
-                    &project_id,
-                    &asset.chain_id(),
-                    &recipient_address,
-                    &sender_address,
-                    &asset.asset_reference(),
-                    &params.amount,
-                )
-                .await?
+                builder
+                    .with_erc20_transfer(&asset.asset_reference(), &params.amount)
+                    .await?
+                    .finalize()
+                    .await?
             }
         };
 
@@ -137,130 +268,18 @@ impl TransactionBuilder for EvmTransactionBuilder {
     }
 }
 
-async fn build_native_transaction(
-    project_id: &str,
+fn get_provider(
     chain_id: &Caip2ChainId,
-    recipient: &str,
-    sender: &str,
-    amount: &str,
-) -> Result<BuildTransactionResult, BuildPosTxError> {
-    let provider = get_provider(chain_id, project_id)?;
-
-    let to = recipient
-        .parse::<Address>()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid recipient: {}", e)))?;
-
-    let from = sender
-        .parse::<Address>()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid sender: {}", e)))?;
-
-    let value = parse_units(amount, "ether").map_err(|e| {
-        BuildPosTxError::Validation(format!("Unable to parse amount in ether: {}", e))
-    })?;
-
-    let amount: U256 = value
-        .try_into()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid amount: {}", e)))?;
-
-    let fees = provider
-        .estimate_eip1559_fees(None)
-        .await
-        .map_err(|e| BuildPosTxError::Validation(format!("Failed to estimate fees: {}", e)))?;
-
-    let tx = TransactionRequest::default()
-        .with_to(to)
-        .with_value(amount)
-        .with_gas_limit(21000)
-        .with_from(from)
-        .with_max_fee_per_gas(fees.max_fee_per_gas)
-        .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
-    
-
-    debug!("native tx: {:?}", tx);
-    Ok(BuildTransactionResult {
-        transaction_rpc: TransactionRpc {
-            method: "eth_sendTransaction".to_string(),
-            params: serde_json::json!([tx]),
-        },
-        id: Uuid::new_v4().to_string(),
-    })
-}
-
-async fn build_erc20_transaction(
     project_id: &str,
-    chain_id: &Caip2ChainId,
-    recipient: &str,
-    sender: &str,
-    asset_address: &str,
-    amount: &str,
-) -> Result<BuildTransactionResult, BuildPosTxError> {
-    let to = recipient
-    .parse::<Address>()
-    .map_err(|e| BuildPosTxError::Validation(format!("Invalid recipient: {}", e)))?;
-
-    let from = sender
-        .parse::<Address>()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid sender: {}", e)))?;
-
-    let token_address = asset_address
-        .parse::<Address>()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid asset address: {}", e)))?;
-
-    let erc20 = ERC20Token::new(token_address, get_provider(chain_id, project_id)?);
-
-    let decimals_call_result = erc20.decimals().call().await.map_err(|e| BuildPosTxError::Validation(format!("Failed to get decimals: {}", e)))?;
-    
-    let decimals = decimals_call_result._0;
-    
-    debug!("decimals: {:?}", decimals);
-    
-    let value = parse_units(amount, decimals).map_err(|e| {
-        BuildPosTxError::Validation(format!("Unable to parse amount with {} decimals: {}", decimals, e))
-    })?;
-    
-    let token_amount: U256 = value
-        .try_into()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid token amount: {}", e)))?;
-    
-
-    let transfer_data = erc20.transfer(to, token_amount);
-    
-    let fees = get_provider(chain_id, project_id)?
-        .estimate_eip1559_fees(None)
-        .await
-        .map_err(|e| BuildPosTxError::Validation(format!("Failed to estimate fees: {}", e)))?;
-
-    let tx = TransactionRequest::default()
-        .with_to(token_address)
-        .with_value(U256::ZERO)
-        .with_input(transfer_data.calldata().clone())
-        .with_from(from)
-        .with_max_fee_per_gas(fees.max_fee_per_gas)
-        .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
-    
-    let gas_limit = get_provider(chain_id, project_id)?.estimate_gas(&tx).await.map_err(|e| BuildPosTxError::Validation(format!("Failed to estimate gas: {}", e)))?;
-
-    let tx = tx.with_gas_limit(gas_limit);
-
-    debug!("erc20 tx: {:?}", tx);
-    
-    Ok(BuildTransactionResult {
-        transaction_rpc: TransactionRpc {
-            method: "eth_sendTransaction".to_string(),
-            params: serde_json::json!([tx]),
-        },
-        id: Uuid::new_v4().to_string(),
-    })
-}
-
-
-fn get_provider(chain_id: &Caip2ChainId, project_id: &str) -> Result<impl Provider, BuildPosTxError> {
+) -> Result<impl Provider, BuildPosTxError> {
     let url = format!(
         "http://localhost:3080/v1?chainId={}&projectId={}&source={}",
         chain_id,
         project_id,
         MessageSource::WalletBuildPosTx,
-    ).parse().map_err(|_| BuildPosTxError::Validation("Invalid provider URL".to_string()))?;
+    )
+    .parse()
+    .map_err(|_| BuildPosTxError::Validation("Invalid provider URL".to_string()))?;
 
     Ok(ProviderBuilder::new().on_http(url))
 }

--- a/src/handlers/wallet/pos/evm.rs
+++ b/src/handlers/wallet/pos/evm.rs
@@ -1,0 +1,110 @@
+use {
+    super::{BuildPosTxError, BuildTransactionParams, BuildTransactionResult, TransactionBuilder, TransactionRpc},
+    crate::state::AppState,
+    alloy::{
+        sol,
+    },
+    axum::extract::State,
+    serde::{Serialize},
+    async_trait::async_trait,
+    std::{sync::Arc},
+    strum_macros::EnumString,
+    crate::utils::crypto::{disassemble_caip10, Caip19Asset},
+};
+
+sol! {
+    #[sol(rpc)]
+    interface ERC20Token {
+        function transfer(address to, uint256 value) external returns (bool);
+        function decimals() external view returns (uint8);
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EvmTransactionType {
+    Erc20,
+    Slip44,
+}
+
+#[derive(Debug, Clone, PartialEq, EnumString)]
+#[strum(serialize_all = "lowercase")]
+pub enum AssetNamespace {
+    Erc20,
+    Slip44,
+}
+
+
+pub struct EvmTransactionBuilder;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EthTx {
+    pub to: String,
+    pub from: Option<String>,
+    pub value: String,
+    pub data: String,
+}
+
+
+#[async_trait]
+impl TransactionBuilder for EvmTransactionBuilder {
+    fn namespace(&self) -> &'static str { "eip155" }
+
+    async fn build(
+        &self,
+        _state: State<Arc<AppState>>,
+        project_id: String,
+        params: BuildTransactionParams,
+    ) -> Result<BuildTransactionResult, BuildPosTxError> {
+        let asset = Caip19Asset::parse(&params.asset)
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
+
+        let (recipient_namespace, recipient_chain_id, recipient_address) = disassemble_caip10(&params.recipient)
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid Recipient: {e}")))?;
+
+        let (sender_namespace, sender_chain_id, sender_address) = disassemble_caip10(&params.sender)
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid Sender: {e}")))?;
+
+        let (asset_namespace, asset_chain_id, asset_address) = disassemble_caip10(&params.asset)
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
+
+
+        if asset_namespace != recipient_namespace || asset_namespace != sender_namespace {
+            return Err(BuildPosTxError::Validation(format!("Asset namespace must match recipient and sender namespaces")));
+        }
+
+        if asset_chain_id != recipient_chain_id || asset_chain_id != sender_chain_id {
+            return Err(BuildPosTxError::Validation(format!("Asset chain ID must match recipient and sender chain IDs")));
+        }
+
+        let namespace = asset.asset_namespace().parse::<AssetNamespace>()
+            .map_err(|e| BuildPosTxError::Validation(format!("Invalid asset namespace: {}", e)))?;
+
+        let tx = match namespace {
+            AssetNamespace::Erc20 => {
+                Ok(BuildTransactionResult {
+                    transaction_rpc: TransactionRpc {
+                        method: "eth_sendTransaction".to_string(),
+                        params: serde_json::json!([tx]),
+                    },
+                    id: "1".to_string(),
+                })
+            },
+            AssetNamespace::Slip44 => {
+                Ok(BuildTransactionResult {
+                    transaction_rpc: TransactionRpc {
+                        method: "eth_sendTransaction".to_string(),
+                        params: serde_json::json!([tx]),
+                    },
+                    id: "1".to_string(),
+                })
+            },
+        };
+        
+    }
+}
+
+
+
+

--- a/src/handlers/wallet/pos/evm.rs
+++ b/src/handlers/wallet/pos/evm.rs
@@ -23,7 +23,7 @@ use {
 
 const NATIVE_GAS_LIMIT: u64 = 21_000;
 const ETH_SEND_TRANSACTION_METHOD: &str = "eth_sendTransaction";
-const BASE_URL: &str = "http://localhost:3080/v1";
+const BASE_URL: &str = "https://rpc.walletconnect.org/v1";
 
 sol! {
     #[sol(rpc)]

--- a/src/handlers/wallet/pos/evm.rs
+++ b/src/handlers/wallet/pos/evm.rs
@@ -220,7 +220,7 @@ impl TransactionBuilder for EvmTransactionBuilder {
 
         let builder = EvmTxBuilder::new(
             &project_id,
-            &validated_params.asset.chain_id(),
+            validated_params.asset.chain_id(),
             &validated_params.recipient_address,
             &validated_params.sender_address,
         )?;
@@ -235,7 +235,7 @@ impl TransactionBuilder for EvmTransactionBuilder {
             }
             AssetNamespace::Erc20 => {
                 builder
-                    .with_erc20_transfer(&validated_params.asset.asset_reference(), &params.amount)
+                    .with_erc20_transfer(validated_params.asset.asset_reference(), &params.amount)
                     .await?
                     .finalize()
                     .await?
@@ -251,9 +251,7 @@ fn parse_ether_amount(amount: &str) -> Result<U256, BuildPosTxError> {
         BuildPosTxError::Validation(format!("Unable to parse amount in ether: {e}"))
     })?;
 
-    value
-        .try_into()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid amount: {e}")))
+    Ok(value.into())
 }
 
 fn has_transaction_data(tx_request: &TransactionRequest) -> bool {
@@ -282,9 +280,7 @@ async fn get_erc20_transfer_amount(
         ))
     })?;
 
-    value
-        .try_into()
-        .map_err(|e| BuildPosTxError::Validation(format!("Invalid token amount: {e}")))
+    Ok(value.into())
 }
 
 async fn create_erc20_transfer_calldata(

--- a/src/handlers/wallet/pos/evm.rs
+++ b/src/handlers/wallet/pos/evm.rs
@@ -1,15 +1,25 @@
 use {
-    super::{BuildPosTxError, BuildTransactionParams, BuildTransactionResult, TransactionBuilder, TransactionRpc},
-    crate::state::AppState,
+    super::{
+        BuildPosTxError, BuildTransactionParams, BuildTransactionResult, TransactionBuilder,
+        TransactionRpc,
+    },
+    crate::{
+        analytics::MessageSource,
+        state::AppState,
+        utils::crypto::{disassemble_caip10, Caip19Asset},
+    },
     alloy::{
+        network::TransactionBuilder as AlloyTransactionBuilder,
+        primitives::{utils::parse_units, Address, U256},
+        providers::{Provider, ProviderBuilder},
+        rpc::types::TransactionRequest,
         sol,
     },
-    axum::extract::State,
-    serde::{Serialize},
     async_trait::async_trait,
-    std::{sync::Arc},
+    axum::extract::State,
+    serde::Serialize,
+    std::sync::Arc,
     strum_macros::EnumString,
-    crate::utils::crypto::{disassemble_caip10, Caip19Asset},
 };
 
 sol! {
@@ -34,22 +44,21 @@ pub enum AssetNamespace {
     Slip44,
 }
 
-
 pub struct EvmTransactionBuilder;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EthTx {
     pub to: String,
-    pub from: Option<String>,
     pub value: String,
     pub data: String,
 }
 
-
 #[async_trait]
 impl TransactionBuilder for EvmTransactionBuilder {
-    fn namespace(&self) -> &'static str { "eip155" }
+    fn namespace(&self) -> &'static str {
+        "eip155"
+    }
 
     async fn build(
         &self,
@@ -60,51 +69,138 @@ impl TransactionBuilder for EvmTransactionBuilder {
         let asset = Caip19Asset::parse(&params.asset)
             .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
 
-        let (recipient_namespace, recipient_chain_id, recipient_address) = disassemble_caip10(&params.recipient)
-            .map_err(|e| BuildPosTxError::Validation(format!("Invalid Recipient: {e}")))?;
+        let (recipient_namespace, recipient_chain_id, recipient_address) =
+            disassemble_caip10(&params.recipient)
+                .map_err(|e| BuildPosTxError::Validation(format!("Invalid Recipient: {e}")))?;
 
-        let (sender_namespace, sender_chain_id, sender_address) = disassemble_caip10(&params.sender)
-            .map_err(|e| BuildPosTxError::Validation(format!("Invalid Sender: {e}")))?;
+        let (sender_namespace, sender_chain_id, sender_address) =
+            disassemble_caip10(&params.sender)
+                .map_err(|e| BuildPosTxError::Validation(format!("Invalid Sender: {e}")))?;
 
         let (asset_namespace, asset_chain_id, asset_address) = disassemble_caip10(&params.asset)
             .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
 
-
         if asset_namespace != recipient_namespace || asset_namespace != sender_namespace {
-            return Err(BuildPosTxError::Validation(format!("Asset namespace must match recipient and sender namespaces")));
+            return Err(BuildPosTxError::Validation(format!(
+                "Asset namespace must match recipient and sender namespaces"
+            )));
         }
 
         if asset_chain_id != recipient_chain_id || asset_chain_id != sender_chain_id {
-            return Err(BuildPosTxError::Validation(format!("Asset chain ID must match recipient and sender chain IDs")));
+            return Err(BuildPosTxError::Validation(format!(
+                "Asset chain ID must match recipient and sender chain IDs"
+            )));
         }
 
-        let namespace = asset.asset_namespace().parse::<AssetNamespace>()
+        let namespace = asset
+            .asset_namespace()
+            .parse::<AssetNamespace>()
             .map_err(|e| BuildPosTxError::Validation(format!("Invalid asset namespace: {}", e)))?;
 
         let tx = match namespace {
-            AssetNamespace::Erc20 => {
-                Ok(BuildTransactionResult {
-                    transaction_rpc: TransactionRpc {
-                        method: "eth_sendTransaction".to_string(),
-                        params: serde_json::json!([tx]),
-                    },
-                    id: "1".to_string(),
-                })
-            },
             AssetNamespace::Slip44 => {
-                Ok(BuildTransactionResult {
-                    transaction_rpc: TransactionRpc {
-                        method: "eth_sendTransaction".to_string(),
-                        params: serde_json::json!([tx]),
-                    },
-                    id: "1".to_string(),
-                })
-            },
+                build_native_transaction(
+                    &project_id,
+                    &asset_chain_id,
+                    &recipient_address,
+                    &sender_address,
+                    &params.amount,
+                )
+                .await?
+            }
+            AssetNamespace::Erc20 => {
+                build_erc20_transaction(
+                    &project_id,
+                    &asset_chain_id,
+                    &recipient_address,
+                    &asset_address,
+                    &params.amount,
+                )
+                .await?
+            }
         };
-        
+
+        Ok(tx)
     }
 }
 
+async fn build_native_transaction(
+    project_id: &str,
+    chain_id: &str,
+    recipient: &str,
+    sender: &str,
+    amount: &str,
+) -> Result<BuildTransactionResult, BuildPosTxError> {
+    let provider = ProviderBuilder::new().on_http(
+        format!(
+            "https://rpc.walletconnect.org/v1?chainId={}&projectId={}&source={}",
+            chain_id,
+            project_id,
+            MessageSource::WalletBuildPosTx,
+        )
+        .parse()
+        .unwrap(),
+    );
+    let to = recipient
+        .parse::<Address>()
+        .map_err(|e| BuildPosTxError::Validation(format!("Invalid recipient: {}", e)))?;
 
+    let from = sender
+        .parse::<Address>()
+        .map_err(|e| BuildPosTxError::Validation(format!("Invalid sender: {}", e)))?;
 
+    let value = parse_units(amount, "ether").map_err(|e| {
+        BuildPosTxError::Validation(format!("Unable to parse amount in ether: {}", e))
+    })?;
 
+    let amount: U256 = value
+        .try_into()
+        .map_err(|e| BuildPosTxError::Validation(format!("Invalid amount: {}", e)))?;
+
+    let fees = provider
+        .estimate_eip1559_fees(None)
+        .await
+        .map_err(|e| BuildPosTxError::Validation(format!("Failed to estimate fees: {}", e)))?;
+
+    let tx = TransactionRequest::default()
+        .with_to(to)
+        .with_value(amount)
+        .with_gas_limit(21000)
+        .with_from(from)
+        .with_max_fee_per_gas(fees.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas);
+
+    Ok(BuildTransactionResult {
+        transaction_rpc: TransactionRpc {
+            method: "eth_sendTransaction".to_string(),
+            params: serde_json::json!(tx),
+        },
+        id: "1".to_string(),
+    })
+}
+
+async fn build_erc20_transaction(
+    project_id: &str,
+    chain_id: &str,
+    recipient_address: &str,
+    asset_address: &str,
+    amount: &str,
+) -> Result<BuildTransactionResult, BuildPosTxError> {
+    // let provider = ProviderBuilder::default().on_http(
+    //     format!(
+    //         "https://rpc.walletconnect.org/v1?chainId={}&projectId={}&source={}",
+    //         chain_id,
+    //         project_id,
+    //         MessageSource::WalletBuildPosTx,
+    //     )
+    //     .parse()
+    //     .unwrap(),
+    // );
+    Ok(BuildTransactionResult {
+        transaction_rpc: TransactionRpc {
+            method: "eth_sendTransaction".to_string(),
+            params: serde_json::json!([]),
+        },
+        id: "1".to_string(),
+    })
+}

--- a/src/handlers/wallet/pos/mod.rs
+++ b/src/handlers/wallet/pos/mod.rs
@@ -3,13 +3,28 @@ pub mod check_transaction;
 pub mod evm;
 
 use {
-    crate::state::AppState,
+    crate::{
+        state::AppState,
+        utils::crypto::{Caip2ChainId, CryptoUitlsError},
+    },
     axum::extract::State,
+    base64::{engine::general_purpose, DecodeError, Engine as _},
     serde::{Deserialize, Serialize},
     serde_json::Value,
-    std::sync::Arc,
+    std::{convert::TryFrom, fmt::Display, sync::Arc},
+    strum_macros::EnumString,
     thiserror::Error,
+    uuid::Uuid,
 };
+
+const TRANSACTION_ID_DELIMITER: &str = "|";
+const TRANSACTION_ID_VERSION: &str = "v1";
+
+#[derive(Debug, Clone, PartialEq, EnumString, Deserialize, Serialize)]
+#[strum(serialize_all = "lowercase")]
+pub enum SupportedNamespaces {
+    Eip155,
+}
 
 #[derive(Debug, Error)]
 pub enum BuildPosTxError {
@@ -41,6 +56,18 @@ impl CheckPosTxError {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum TransactionIdError {
+    #[error("Invalid transaction encoding: {0}")]
+    InvalidBase64(#[from] DecodeError),
+
+    #[error("Invalid transaction format: '{0}'")]
+    InvalidFormat(String),
+
+    #[error("Invalid chain ID: {0}")]
+    InvalidChainId(#[from] CryptoUitlsError),
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildTransactionParams {
@@ -64,6 +91,26 @@ pub struct TransactionRpc {
     pub params: Value,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TransactionStatus {
+    Pending,
+    Confirmed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckTransactionParams {
+    pub id: String,
+    pub txid: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckTransactionResult {
+    pub status: TransactionStatus,
+}
 #[async_trait::async_trait]
 pub trait TransactionBuilder {
     fn namespace(&self) -> &'static str;
@@ -73,4 +120,87 @@ pub trait TransactionBuilder {
         project_id: String,
         params: BuildTransactionParams,
     ) -> Result<BuildTransactionResult, BuildPosTxError>;
+}
+
+pub struct TransactionId {
+    id: String,
+    chain_id: Caip2ChainId,
+    version: String,
+}
+
+impl TransactionId {
+    pub fn new(chain_id: &Caip2ChainId) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            chain_id: chain_id.clone(),
+            version: TRANSACTION_ID_VERSION.to_string(),
+        }
+    }
+    pub fn chain_id(&self) -> &Caip2ChainId {
+        &self.chain_id
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn from(id: &str, chain_id: &Caip2ChainId) -> Self {
+        Self {
+            id: id.to_string(),
+            chain_id: chain_id.clone(),
+            version: TRANSACTION_ID_VERSION.to_string(),
+        }
+    }
+}
+
+impl Display for TransactionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let formatted = [
+            self.version.as_str(),
+            self.chain_id.to_string().as_str(),
+            &self.id,
+        ]
+        .join(TRANSACTION_ID_DELIMITER);
+        write!(f, "{}", general_purpose::STANDARD_NO_PAD.encode(formatted))
+    }
+}
+
+impl TryFrom<String> for TransactionId {
+    type Error = TransactionIdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for TransactionId {
+    type Error = TransactionIdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let decoded = general_purpose::STANDARD_NO_PAD.decode(value)?;
+        let decoded_str = String::from_utf8(decoded)
+            .map_err(|_| TransactionIdError::InvalidFormat(value.to_string()))?;
+
+        let mut parts = decoded_str.splitn(3, TRANSACTION_ID_DELIMITER);
+        let version = parts
+            .next()
+            .ok_or_else(|| TransactionIdError::InvalidFormat(decoded_str.clone()))?;
+
+        if version != TRANSACTION_ID_VERSION {
+            return Err(TransactionIdError::InvalidFormat(decoded_str.clone()));
+        }
+
+        let chain_id_str = parts
+            .next()
+            .ok_or_else(|| TransactionIdError::InvalidFormat(decoded_str.clone()))?;
+
+        let chain_id =
+            Caip2ChainId::parse(chain_id_str).map_err(TransactionIdError::InvalidChainId)?;
+
+        let id = parts
+            .next()
+            .ok_or_else(|| TransactionIdError::InvalidFormat(decoded_str.clone()))?;
+
+        Ok(TransactionId::from(id, &chain_id))
+    }
 }

--- a/src/handlers/wallet/pos/mod.rs
+++ b/src/handlers/wallet/pos/mod.rs
@@ -1,0 +1,79 @@
+pub mod build_transaction;
+pub mod check_transaction;
+pub mod evm;
+
+use {
+    crate::state::AppState,
+    axum::extract::State,
+    serde::{Deserialize, Serialize},
+    serde_json::Value,
+    std::sync::Arc,
+    thiserror::Error,
+};
+
+#[derive(Debug, Error)]
+pub enum BuildPosTxError {
+    #[error("Validation error: {0}")]
+    Validation(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl BuildPosTxError {
+    pub fn is_internal(&self) -> bool {
+        matches!(self, BuildPosTxError::Internal(_))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CheckPosTxError {
+    #[error("Validation error: {0}")]
+    Validation(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl CheckPosTxError {
+    pub fn is_internal(&self) -> bool {
+        matches!(self, CheckPosTxError::Internal(_))
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildTransactionParams {
+    pub asset: String,
+    pub amount: String,
+    pub recipient: String,
+    pub sender: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildTransactionResult {
+    pub transaction_rpc: TransactionRpc,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionRpc {
+    pub method: String,
+    pub params: Value,
+}
+
+#[async_trait::async_trait]
+pub trait TransactionBuilder {
+    fn namespace(&self) -> &'static str;
+    async fn build(
+        &self,
+        state: State<Arc<AppState>>,
+        project_id: String,
+        params: BuildTransactionParams,
+    ) -> Result<BuildTransactionResult, BuildPosTxError>;
+}
+
+
+    

--- a/src/handlers/wallet/pos/mod.rs
+++ b/src/handlers/wallet/pos/mod.rs
@@ -74,6 +74,3 @@ pub trait TransactionBuilder {
         params: BuildTransactionParams,
     ) -> Result<BuildTransactionResult, BuildPosTxError>;
 }
-
-
-    


### PR DESCRIPTION
# Description

- Add POS transaction RPC methods `reown_pos_buildTransaction` and `reown_pos_checkTransaction`
- Implement EVM transaction builder with support for native ETH and ERC20 transfers
- Add CAIP validation for asset, sender, and recipient addresses with proper namespace/chain ID matching
- Extensible `TransactionBuilder` trait for multi-chain support 
- Add transaction status checking. Implementation is querying transaction confirmation status via receipt lookup
- Added WalletBuildPosTx and WalletSendPosTx message sources

Resolves # (issue)

## How Has This Been Tested?
Manually
Current version of `alloy` that we use doesn't support mocked transport unfortunately. I'll be upgrading `alloy` across the implementation and implementing mocked transport testing in the follow up pr.

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
