### PR TITLE
feat: adding validate project ID as TFC variable

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -85,6 +85,8 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_GEOIP_DB_KEY", value = var.geoip_db_key },
         { name = "RPC_PROXY_TESTING_PROJECT_ID", value = var.testing_project_id },
 
+        { name = "RPC_PROXY_VALIDATE_PROJECT_ID", value = tostring(var.validate_project_id) },
+
         { name = "RPC_PROXY_BLOCKED_COUNTRIES", value = var.ofac_countries },
 
         { name = "RPC_PROXY_PROVIDER_POKT_PROJECT_ID", value = var.pokt_project_id },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -293,6 +293,11 @@ variable "testing_project_id" {
   sensitive   = true
 }
 
+variable "validate_project_id" {
+  description = "Project ID and quota validation"
+  type        = bool
+}
+
 #-------------------------------------------------------------------------------
 # RPC Proxy configuration
 variable "proxy_skip_quota_chains" {

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -125,6 +125,9 @@ module "ecs" {
   # Project ID used in a testing suite
   testing_project_id = var.testing_project_id
 
+  # Validate project ID
+  validate_project_id = var.validate_project_id
+
   # Exchanges
   coinbase_project_id     = var.coinbase_project_id
   coinbase_key_name       = var.coinbase_key_name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -175,6 +175,12 @@ variable "testing_project_id" {
   sensitive   = true
 }
 
+variable "validate_project_id" {
+  description = "Project ID and quota validation"
+  type        = bool
+  default     = true
+}
+
 variable "allnodes_api_key" {
   description = "Allnodes API key"
   type        = string


### PR DESCRIPTION
# Description

This PR adds `validate_project_id` boolean variable to the Terraform to pass this parameter from the TFC.
The default value is `true`.

## How Has This Been Tested?

Tested by manually applying this variable in ECS task.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
