### PR TITLE
chore: change check transaction field

### DIFF
--- a/integration/pos.test.ts
+++ b/integration/pos.test.ts
@@ -180,7 +180,7 @@ describe('POS', () => {
         method: 'reown_pos_checkTransaction',
         params: {
           id: txIdBaseSepolia,
-          txid: confirmedTxId,
+          sendResult: confirmedTxId,
         }
       };
 

--- a/integration/types/pos.ts
+++ b/integration/types/pos.ts
@@ -33,7 +33,7 @@ export type BuildTransactionParams = EvmBuildTransactionParams;
 
 export type CheckTransactionParams = {
   id: string;
-  txid: string;
+  sendResult: string;
 };
 
 export interface BuildTransactionRequest extends BaseJsonRpcRequest {

--- a/src/handlers/wallet/pos/check_transaction.rs
+++ b/src/handlers/wallet/pos/check_transaction.rs
@@ -24,10 +24,14 @@ pub async fn handler(
 
     match namespace {
         SupportedNamespaces::Eip155 => {
-            let status =
-                get_transaction_status(state, &project_id, &params.send_result, transaction_id.chain_id())
-                    .await
-                    .map_err(|e| CheckPosTxError::Validation(e.to_string()))?;
+            let status = get_transaction_status(
+                state,
+                &project_id,
+                &params.send_result,
+                transaction_id.chain_id(),
+            )
+            .await
+            .map_err(|e| CheckPosTxError::Validation(e.to_string()))?;
 
             match status {
                 TransactionStatus::Pending => Ok(CheckTransactionResult {

--- a/src/handlers/wallet/pos/check_transaction.rs
+++ b/src/handlers/wallet/pos/check_transaction.rs
@@ -25,7 +25,7 @@ pub async fn handler(
     match namespace {
         SupportedNamespaces::Eip155 => {
             let status =
-                get_transaction_status(state, &project_id, &params.txid, transaction_id.chain_id())
+                get_transaction_status(state, &project_id, &params.send_result, transaction_id.chain_id())
                     .await
                     .map_err(|e| CheckPosTxError::Validation(e.to_string()))?;
 

--- a/src/handlers/wallet/pos/mod.rs
+++ b/src/handlers/wallet/pos/mod.rs
@@ -103,7 +103,7 @@ pub enum TransactionStatus {
 #[serde(rename_all = "camelCase")]
 pub struct CheckTransactionParams {
     pub id: String,
-    pub txid: String,
+    pub send_result: String,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
# Description

Changing the `txid` field in the `reown_pos_checkTransaction` to `sendResult` instead.
For EVM chains the result of the send RPC (`eth_sendTransaction`) is going to be the TXID, but for other chains like Tron for example its going to be a signed transaction. In that case we will broadcast it and we will handle all the logic server side. The client should only forward the response from the RPC sent to the wallet and obtained by `reown_pos_buildTransaction`

Resolves # (issue)

## How Has This Been Tested?

Changed the test to cover this

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [x] Requires a e2e/integration test update
