### PR TITLE
fix(CD): adding a delay before TS tests by waiting Rust tests to compile

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -82,6 +82,7 @@ jobs:
 
   integration-tests-ts:
     name: TS Integration Tests - ${{ inputs.stage }}
+    needs: [health-check, integration-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

This PR adds a delay before TS tests run to get some time for old ECS instances to decommission. The delay can be organically added by the requirements to wait until Rust integration tests are built.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
