### PR TITLE
feat(ECS): decreasing deregistration delay and health check timeout, enabling  deployment rollback

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -274,6 +274,12 @@ resource "aws_ecs_service" "app_service" {
   deployment_minimum_healthy_percent = 100 # Keep all healthy tasks running during deployment
   deployment_maximum_percent         = 200 # Allow up to 200% of desired tasks during deployment
 
+  # Automatically rollback if a deployment fails
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   network_configuration {
     subnets          = var.private_subnets
     assign_public_ip = false

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -71,19 +71,20 @@ resource "aws_lb_listener" "listener-http" {
 }
 
 resource "aws_lb_target_group" "target_group" {
-  name        = local.lb_name
-  port        = var.port
-  protocol    = "HTTP"
-  target_type = "ip"
-  vpc_id      = var.vpc_id
-  slow_start  = 30
+  name                 = local.lb_name
+  port                 = var.port
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  slow_start           = 30
+  deregistration_delay = 30
 
   health_check {
     protocol            = "HTTP"
     path                = "/health" # Blockchain-API health path
     port                = var.port
-    interval            = 15
-    timeout             = 10
+    interval            = 10
+    timeout             = 5
     healthy_threshold   = 2
     unhealthy_threshold = 2
   }


### PR DESCRIPTION
# Description

This PR makes the following changes to the ECS tasks deployment process:
* Decreasing the task deregistration default timeout from 5 minutes to 30 seconds. We have a 5-second SIGTERM timeout in the app, so 30 seconds is x5 sufficient for the app to stop, and we shouldn't wait 5 minutes to deregister the task.
* Enabling `deployment_circuit_breaker`. In case the new app can't start or stops during the deployment check it will be rolled back to the previous task.
* Decreases the health check interval to 10 seconds to get the unhealthy status as fast as possible if the problem occurs.


## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
