### PR TITLE
feat(projects): implementing projects registry fetcher circuit breaker

### DIFF
--- a/src/project/error.rs
+++ b/src/project/error.rs
@@ -10,4 +10,7 @@ pub enum ProjectDataError {
 
     #[error("Registry configuration error")]
     RegistryConfigError,
+
+    #[error("Registry is temporarily unavailable")]
+    RegistryTemporarilyUnavailable,
 }

--- a/src/project/metrics/mod.rs
+++ b/src/project/metrics/mod.rs
@@ -83,6 +83,7 @@ fn response_tag(resp: &ProjectDataResult) -> KeyValue {
         Ok(_) => "ok",
         Err(ProjectDataError::NotFound) => "not_found",
         Err(ProjectDataError::RegistryConfigError) => "registry_config_error",
+        Err(ProjectDataError::RegistryTemporarilyUnavailable) => "registry_temporarily_unavailable",
     };
 
     KeyValue::new("response", value)

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -29,6 +29,8 @@ mod error;
 pub mod metrics;
 pub mod storage;
 
+/// Circuit breaker cooldown period in milliseconds in case of registry internal error
+/// to prevent the registry from being overwhelmed since we don't cache errors
 const CIRCUIT_COOLDOWN_MS: u64 = 1_000;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
# Description

This PR implements a circuit breaker for the projects registry API fetcher by adding a cooldown period of 1 second and not checking the project access and quota during the cooldown period (permissive behavior by default).

The circuit opens if there is an internal error response from the registry API.

## How Has This Been Tested?

Tested manually on the local instance.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
