### PR TITLE
fix(1Inch): respond with the asset is not supported instead of provider is not available

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,9 @@ pub enum RpcError {
     #[error("invalid parameter: {0}")]
     InvalidParameter(String),
 
+    #[error("Asset is not supported: {0}")]
+    AssetNotSupported(String),
+
     // Conversion errors
     #[error("Failed to reach the conversion provider")]
     ConversionProviderError,
@@ -467,6 +470,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response_with_code(
                     code.to_string(),
                     format!("Conversion parameter error: {message}"),
+                )),
+            )
+                .into_response(),
+            Self::AssetNotSupported(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "asset".to_string(),
+                    format!("Asset is not supported: {e}"),
                 )),
             )
                 .into_response(),

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -108,6 +108,10 @@ impl OneInchProvider {
                 };
                 return Err(RpcError::ConversionInvalidParameter(response_error));
             }
+            // 404 response is expected when the asset is not supported
+            if price_response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(RpcError::AssetNotSupported(address.clone()));
+            }
 
             error!(
                 "Error on getting fungible price from 1inch provider. Status is not OK: {:?}",
@@ -170,6 +174,10 @@ impl OneInchProvider {
                     }
                 };
                 return Err(RpcError::ConversionInvalidParameter(response_error));
+            }
+            // 404 response is expected when the asset is not supported
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(RpcError::AssetNotSupported(address.clone()));
             }
 
             error!(
@@ -300,6 +308,14 @@ impl ConversionProvider for OneInchProvider {
         );
 
         if !response.status().is_success() {
+            // 404 response is expected when the chain ID is not supported
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(RpcError::ConversionInvalidParameter(format!(
+                    "Chain ID {} is not supported",
+                    params.chain_id
+                )));
+            };
+
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)
             if response.status() == reqwest::StatusCode::BAD_REQUEST {
@@ -313,13 +329,6 @@ impl ConversionProvider for OneInchProvider {
                 };
                 return Err(RpcError::ConversionInvalidParameter(response_error));
             }
-            // 404 response is expected when the chain ID is not supported
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
-                return Err(RpcError::ConversionInvalidParameter(format!(
-                    "Chain ID {} is not supported",
-                    params.chain_id
-                )));
-            };
 
             error!(
                 "Error on getting tokens list for conversion from 1inch provider. Status is not \
@@ -671,6 +680,14 @@ impl ConversionProvider for OneInchProvider {
         );
 
         if !response.status().is_success() {
+            // 404 response is expected when the chain ID is not supported
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(RpcError::ConversionInvalidParameter(format!(
+                    "Chain ID {} is not supported",
+                    params.chain_id
+                )));
+            };
+
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)
             if response.status() == reqwest::StatusCode::BAD_REQUEST {
@@ -684,13 +701,6 @@ impl ConversionProvider for OneInchProvider {
                 };
                 return Err(RpcError::ConversionInvalidParameter(response_error));
             }
-            // 404 response is expected when the chain ID is not supported
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
-                return Err(RpcError::ConversionInvalidParameter(format!(
-                    "Chain ID {} is not supported",
-                    params.chain_id
-                )));
-            };
 
             error!(
                 "Error on getting gas price for conversion from 1inch provider. Status is not OK: \


### PR DESCRIPTION
# Description

This PR fixes the response in case the asset is not supported for the token price request in 1Inch.
The 1inch price endpoint returns `HTTP 404` if the asset is not supported. We are catching this case and responding correctly.

## How Has This Been Tested?

Tested locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
