### PR TITLE
feat: pos tron

### DIFF
--- a/integration/types/pos.ts
+++ b/integration/types/pos.ts
@@ -62,6 +62,27 @@ export interface EvmTransactionParams {
 }
 
 
+
+export interface TronTransactionObject {
+  raw_data: unknown;
+  raw_data_hex: string;
+  signature: string[] | null;
+  txID: string;
+  visible: boolean;
+}
+
+export interface TronTransaction {
+  result: {
+    result: boolean;
+  };
+  transaction: TronTransactionObject;
+}
+
+export interface TronTransactionParams {
+  transaction: TronTransaction;
+  address: string;
+}
+
 export interface BaseTransactionRpc {
   method: string;
   params: unknown;
@@ -77,7 +98,12 @@ export interface SolanaTransactionRpc extends BaseTransactionRpc {
   params: SolanaTransactionParams;
 }
 
-export type TransactionRpc = EvmTransactionRpc | SolanaTransactionRpc;
+export interface TronTransactionRpc extends BaseTransactionRpc {
+  method: 'tron_signTransaction';
+  params: TronTransactionParams;
+}
+
+export type TransactionRpc = EvmTransactionRpc | SolanaTransactionRpc | TronTransactionRpc;
 
 export interface BuildTransactionResult {
   id: string;

--- a/src/handlers/wallet/pos/build_transaction.rs
+++ b/src/handlers/wallet/pos/build_transaction.rs
@@ -4,7 +4,7 @@ use {
         TransactionBuilder,
     },
     crate::{
-        handlers::wallet::pos::{evm::EvmTransactionBuilder, solana::SolanaTransactionBuilder},
+        handlers::wallet::pos::{evm::EvmTransactionBuilder, solana::SolanaTransactionBuilder, tron::TronTransactionBuilder},
         state::AppState,
         utils::crypto::Caip19Asset,
     },
@@ -26,10 +26,9 @@ pub async fn handler(
 
     match namespace {
         SupportedNamespaces::Eip155 => EvmTransactionBuilder.build(state, project_id, params).await,
-        SupportedNamespaces::Solana => {
-            SolanaTransactionBuilder
-                .build(state, project_id, params)
-                .await
-        }
+        SupportedNamespaces::Solana => SolanaTransactionBuilder
+        .build(state, project_id, params)
+        .await,
+        SupportedNamespaces::Tron => TronTransactionBuilder.build(state, project_id, params).await,
     }
 }

--- a/src/handlers/wallet/pos/build_transaction.rs
+++ b/src/handlers/wallet/pos/build_transaction.rs
@@ -4,7 +4,10 @@ use {
         TransactionBuilder,
     },
     crate::{
-        handlers::wallet::pos::{evm::EvmTransactionBuilder, solana::SolanaTransactionBuilder, tron::TronTransactionBuilder},
+        handlers::wallet::pos::{
+            evm::EvmTransactionBuilder, solana::SolanaTransactionBuilder,
+            tron::TronTransactionBuilder,
+        },
         state::AppState,
         utils::crypto::Caip19Asset,
     },
@@ -26,9 +29,15 @@ pub async fn handler(
 
     match namespace {
         SupportedNamespaces::Eip155 => EvmTransactionBuilder.build(state, project_id, params).await,
-        SupportedNamespaces::Solana => SolanaTransactionBuilder
-        .build(state, project_id, params)
-        .await,
-        SupportedNamespaces::Tron => TronTransactionBuilder.build(state, project_id, params).await,
+        SupportedNamespaces::Solana => {
+            SolanaTransactionBuilder
+                .build(state, project_id, params)
+                .await
+        }
+        SupportedNamespaces::Tron => {
+            TronTransactionBuilder
+                .build(state, project_id, params)
+                .await
+        }
     }
 }

--- a/src/handlers/wallet/pos/check_transaction.rs
+++ b/src/handlers/wallet/pos/check_transaction.rs
@@ -13,7 +13,6 @@ use {
     std::{str::FromStr, sync::Arc},
 };
 
-
 pub async fn handler(
     state: State<Arc<AppState>>,
     project_id: String,
@@ -26,14 +25,29 @@ pub async fn handler(
         .map_err(|e| CheckPosTxError::Validation(e.to_string()))?;
 
     match namespace {
-        SupportedNamespaces::Eip155 => {
-            evm_check_transaction(state, &project_id, &params.send_result, transaction_id.chain_id()).await.map_err(|e| CheckPosTxError::Validation(e.to_string()))
-        }
-        SupportedNamespaces::Solana => {
-            solana_check_transaction(state, &project_id, &params.send_result, transaction_id.chain_id()).await.map_err(|e| CheckPosTxError::Validation(e.to_string()))
-        }
-        SupportedNamespaces::Tron => {
-            tron_check_transaction(state, &project_id, &params.send_result, transaction_id.chain_id()).await.map_err(|e| CheckPosTxError::Validation(e.to_string()))
-        }
+        SupportedNamespaces::Eip155 => evm_check_transaction(
+            state,
+            &project_id,
+            &params.send_result,
+            transaction_id.chain_id(),
+        )
+        .await
+        .map_err(|e| CheckPosTxError::Validation(e.to_string())),
+        SupportedNamespaces::Solana => solana_check_transaction(
+            state,
+            &project_id,
+            &params.send_result,
+            transaction_id.chain_id(),
+        )
+        .await
+        .map_err(|e| CheckPosTxError::Validation(e.to_string())),
+        SupportedNamespaces::Tron => tron_check_transaction(
+            state,
+            &project_id,
+            &params.send_result,
+            transaction_id.chain_id(),
+        )
+        .await
+        .map_err(|e| CheckPosTxError::Validation(e.to_string())),
     }
 }

--- a/src/handlers/wallet/pos/check_transaction.rs
+++ b/src/handlers/wallet/pos/check_transaction.rs
@@ -47,7 +47,7 @@ pub async fn handler(
                     check_in: None,
                 }),
             }
-        },
+        }
         SupportedNamespaces::Solana => {
             let status = solana_get_transaction_status(
                 state,
@@ -68,7 +68,7 @@ pub async fn handler(
                     check_in: None,
                 }),
             }
-        },
+        }
         SupportedNamespaces::Tron => {
             let status = tron_get_transaction_status(
                 state,

--- a/src/handlers/wallet/pos/evm.rs
+++ b/src/handlers/wallet/pos/evm.rs
@@ -1,8 +1,8 @@
 use {
     super::{
         AssetNamespaceType, BuildPosTxError, BuildTransactionParams, BuildTransactionResult,
-        TransactionBuilder, TransactionId, TransactionRpc, TransactionStatus, CheckTransactionResult,
-        ValidatedTransactionParams,
+        CheckTransactionResult, TransactionBuilder, TransactionId, TransactionRpc,
+        TransactionStatus, ValidatedTransactionParams,
     },
     crate::{analytics::MessageSource, state::AppState, utils::crypto::Caip2ChainId},
     alloy::{
@@ -281,10 +281,12 @@ pub async fn get_transaction_status(
     }
 }
 
-pub async fn check_transaction( state: State<Arc<AppState>>,
+pub async fn check_transaction(
+    state: State<Arc<AppState>>,
     project_id: &str,
     txid: &str,
-    chain_id: &Caip2ChainId) -> Result<CheckTransactionResult, BuildPosTxError> {
+    chain_id: &Caip2ChainId,
+) -> Result<CheckTransactionResult, BuildPosTxError> {
     let status = get_transaction_status(state, project_id, txid, chain_id).await?;
 
     match status {

--- a/src/handlers/wallet/pos/mod.rs
+++ b/src/handlers/wallet/pos/mod.rs
@@ -8,8 +8,8 @@ use {
     crate::{
         state::AppState,
         utils::crypto::{
-            disassemble_caip10_with_namespace, Caip19Asset, Caip2ChainId, CaipNamespaces, CryptoUitlsError,
-            NamespaceValidator, is_address_valid,
+            disassemble_caip10_with_namespace, is_address_valid, Caip19Asset, Caip2ChainId,
+            CaipNamespaces, CryptoUitlsError, NamespaceValidator,
         },
     },
     axum::extract::State,

--- a/src/handlers/wallet/pos/mod.rs
+++ b/src/handlers/wallet/pos/mod.rs
@@ -2,11 +2,14 @@ pub mod build_transaction;
 pub mod check_transaction;
 pub mod evm;
 pub mod solana;
+pub mod tron;
+
 use {
     crate::{
         state::AppState,
         utils::crypto::{
-            disassemble_caip10, Caip19Asset, Caip2ChainId, CaipNamespaces, CryptoUitlsError,
+            disassemble_caip10_with_namespace, Caip19Asset, Caip2ChainId, CaipNamespaces, CryptoUitlsError,
+            NamespaceValidator, is_address_valid,
         },
     },
     axum::extract::State,
@@ -27,6 +30,17 @@ const TRANSACTION_ID_VERSION: &str = "v1";
 pub enum SupportedNamespaces {
     Eip155,
     Solana,
+    Tron,
+}
+
+impl NamespaceValidator for SupportedNamespaces {
+    fn validate_address(&self, address: &str) -> bool {
+        match self {
+            SupportedNamespaces::Eip155 => is_address_valid(address, &CaipNamespaces::Eip155),
+            SupportedNamespaces::Solana => is_address_valid(address, &CaipNamespaces::Solana),
+            SupportedNamespaces::Tron => true,
+        }
+    }
 }
 
 pub trait AssetNamespaceType: FromStr + Clone + std::fmt::Debug + PartialEq {
@@ -227,18 +241,18 @@ impl<T: AssetNamespaceType> ValidatedTransactionParams<T> {
             .map_err(|e| BuildPosTxError::Validation(format!("Invalid Asset: {e}")))?;
 
         let (recipient_namespace, recipient_chain_id, recipient_address) =
-            disassemble_caip10(&params.recipient)
+            disassemble_caip10_with_namespace::<SupportedNamespaces>(&params.recipient)
                 .map_err(|e| BuildPosTxError::Validation(format!("Invalid Recipient: {e}")))?;
 
         let (sender_namespace, sender_chain_id, sender_address) =
-            disassemble_caip10(&params.sender)
+            disassemble_caip10_with_namespace::<SupportedNamespaces>(&params.sender)
                 .map_err(|e| BuildPosTxError::Validation(format!("Invalid Sender: {e}")))?;
 
         let asset_chain_id = asset.chain_id().reference();
         let asset_namespace = asset
             .chain_id()
             .namespace()
-            .parse::<CaipNamespaces>()
+            .parse::<SupportedNamespaces>()
             .map_err(|e| {
                 BuildPosTxError::Validation(format!("Cannot parse asset namespace: {e}"))
             })?;

--- a/src/handlers/wallet/pos/solana.rs
+++ b/src/handlers/wallet/pos/solana.rs
@@ -1,8 +1,8 @@
 use {
     super::{
         AssetNamespaceType, BuildPosTxError, BuildTransactionParams, BuildTransactionResult,
-        TransactionBuilder, TransactionId, TransactionRpc, TransactionStatus, CheckTransactionResult,
-        ValidatedTransactionParams,
+        CheckTransactionResult, TransactionBuilder, TransactionId, TransactionRpc,
+        TransactionStatus, ValidatedTransactionParams,
     },
     crate::{analytics::MessageSource, state::AppState, utils::crypto::Caip2ChainId},
     alloy::primitives::{utils::parse_units, U256},
@@ -250,11 +250,12 @@ pub async fn get_transaction_status(
     }
 }
 
-
-pub async fn check_transaction( state: State<Arc<AppState>>,
+pub async fn check_transaction(
+    state: State<Arc<AppState>>,
     project_id: &str,
     signature: &str,
-    chain_id: &Caip2ChainId) -> Result<CheckTransactionResult, BuildPosTxError> {
+    chain_id: &Caip2ChainId,
+) -> Result<CheckTransactionResult, BuildPosTxError> {
     let status = get_transaction_status(state, project_id, signature, chain_id).await?;
 
     match status {

--- a/src/handlers/wallet/pos/tron.rs
+++ b/src/handlers/wallet/pos/tron.rs
@@ -274,7 +274,7 @@ async fn build_trx20_transfer(
     let params_hex = &hex::encode(&data[4..]);
 
     let owner_address = tron_b58_to_hex41(&params.sender_address)?;
-    let contract_address = tron_b58_to_hex41(&params.asset.asset_reference())?;
+    let contract_address = tron_b58_to_hex41(params.asset.asset_reference())?;
 
     let trigger_req = TronTriggerSmartContractRequest {
         owner_address,
@@ -387,7 +387,7 @@ fn tron_b58_to_hex41(b58: &str) -> Result<String, BuildPosTxError> {
             "invalid TRON address".to_string(),
         ));
     }
-    Ok(format!("{}", hex::encode(bytes)))
+    Ok(hex::encode(bytes).to_string())
 }
 
 pub async fn check_transaction(

--- a/src/handlers/wallet/pos/tron.rs
+++ b/src/handlers/wallet/pos/tron.rs
@@ -370,7 +370,7 @@ fn compute_fee_limit(energy_required: u128, energy_fee: u128) -> Result<u64, Bui
 #[derive(Debug, Clone, PartialEq, EnumString)]
 #[strum(serialize_all = "lowercase")]
 pub enum AssetNamespace {
-    Trx20,
+    Trc20,
     Slip44,
 }
 
@@ -398,8 +398,8 @@ impl TransactionBuilder for TronTransactionBuilder {
             ValidatedTransactionParams::validate_params(&params)?;
 
         match validated_params.namespace {
-            AssetNamespace::Trx20 => {
-                build_trx20_transfer(state, validated_params, &params.amount, &project_id).await
+            AssetNamespace::Trc20 => {
+                build_trc20_transfer(state, validated_params, &params.amount, &project_id).await
             }
             _ => {
                 return Err(BuildPosTxError::Validation(
@@ -410,7 +410,7 @@ impl TransactionBuilder for TronTransactionBuilder {
     }
 }
 
-async fn build_trx20_transfer(
+async fn build_trc20_transfer(
     state: State<Arc<AppState>>,
     params: ValidatedTransactionParams<AssetNamespace>,
     amount: &str,

--- a/src/handlers/wallet/pos/tron.rs
+++ b/src/handlers/wallet/pos/tron.rs
@@ -1,0 +1,183 @@
+use {
+    super::{AssetNamespaceType, BuildPosTxError, BuildTransactionParams, BuildTransactionResult,
+        TransactionBuilder,
+        ValidatedTransactionParams,
+        TransactionId,
+        TransactionRpc,
+        TransactionStatus,
+    },
+    crate::{state::AppState, utils::crypto::Caip2ChainId},
+    alloy::{
+        primitives::{utils::parse_units, Address as EthAddress, U256},
+        sol,
+        sol_types::SolCall,
+    },
+    async_trait::async_trait,
+    axum::extract::State,
+    bs58,
+    hex,
+    serde::{Deserialize},
+    std::sync::Arc,
+    strum_macros::EnumString,
+    tracing::debug,
+};
+
+const TRON_BASE_URL: &str = "https://nile.trongrid.io";
+const TRON_SIGN_TRANSACTION_METHOD: &str = "tron_signTransaction";
+const DEFAULT_FEE_LIMIT: u64 = 200_000_000;
+
+sol! {
+    function transfer(address to, uint256 value) external returns (bool);
+    function approve(address spender, uint256 value) external returns (bool);
+}
+
+#[derive(Debug, Deserialize)]
+struct TronRpcBuildTransactionResponse {
+    transaction: serde_json::Value,
+}
+
+
+#[derive(Debug, Clone, PartialEq, EnumString)]
+#[strum(serialize_all = "lowercase")]
+pub enum AssetNamespace {
+    Trx20,
+    Slip44,
+}
+
+impl AssetNamespaceType for AssetNamespace {
+    fn is_native(&self) -> bool {
+        matches!(self, AssetNamespace::Slip44)
+    }
+}
+
+pub struct TronTransactionBuilder;
+
+#[async_trait]
+impl TransactionBuilder for TronTransactionBuilder {
+    fn namespace(&self) -> &'static str {
+        "tron"
+    }
+
+    async fn build(
+        &self,
+        state: State<Arc<AppState>>,
+        project_id: String,
+        params: BuildTransactionParams,
+    ) -> Result<BuildTransactionResult, BuildPosTxError> {
+        let validated_params: ValidatedTransactionParams<AssetNamespace> =
+            ValidatedTransactionParams::validate_params(&params)?;
+
+        match validated_params.namespace {
+            AssetNamespace::Trx20 => {
+                build_trx20_transfer(state, validated_params, &params.amount, &project_id).await
+            }
+            _ => {
+                return Err(BuildPosTxError::Validation(
+                    "Unsupported asset namespace".to_string(),
+                ));
+            }
+        }
+    }
+}
+
+async fn build_trx20_transfer(
+    State(state): State<Arc<AppState>>,
+    params: ValidatedTransactionParams<AssetNamespace>,
+    amount: &str,
+    _project_id: &str,
+) -> Result<BuildTransactionResult, BuildPosTxError> {
+    let to_eth = tron_base58_to_eth_address(&params.recipient_address)?;
+    let token_amount = parse_token_amount(amount)?;
+    
+    let data = transferCall {
+        to: to_eth,
+        value: token_amount,
+    }.abi_encode();
+
+    let params_hex = &hex::encode(&data[4..]);
+
+    let owner_address = tron_b58_to_hex41(&params.sender_address)?;
+    let contract_address = tron_b58_to_hex41(&params.asset.asset_reference())?;
+
+
+    let url = format!("{}/wallet/triggersmartcontract", TRON_BASE_URL);
+    let body = serde_json::json!({
+        "owner_address": owner_address,
+        "contract_address": contract_address,
+        "function_selector": "approve(address,uint256)",
+        "parameter": params_hex,
+        "fee_limit": DEFAULT_FEE_LIMIT,
+        "call_value": 0,
+        "visible": false
+    });
+        
+    let resp: TronRpcBuildTransactionResponse = state.http_client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| BuildPosTxError::Internal(format!("Failed to send request: {}", e)))?
+        .error_for_status()
+        .map_err(|e| BuildPosTxError::Internal(format!("HTTP error: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| BuildPosTxError::Internal(format!("Failed to parse response: {}", e)))?;
+    
+    debug!("tron build transaction resp: {:?}", resp);
+
+    let transaction_rpc = TransactionRpc {
+        method: TRON_SIGN_TRANSACTION_METHOD.to_string(),
+        params: serde_json::json!({
+            "address": params.sender_address,
+            "transaction": {
+                "result": {
+                    "result": true
+                },
+                "transaction": resp.transaction
+            }
+        }),
+    };
+    
+    let id = TransactionId::new(params.asset.chain_id()).to_string();
+    
+    Ok(BuildTransactionResult {
+        transaction_rpc,
+        id,
+    })
+}
+
+fn parse_token_amount(amount: &str) -> Result<U256, BuildPosTxError> {
+    let parsed_value = parse_units(amount, 6).map_err(|e| {
+        BuildPosTxError::Validation(format!(
+            "Unable to parse amount with 6 decimals: {}",
+            e
+        ))
+    })?;
+
+    Ok(parsed_value.into())
+}
+
+pub async fn get_transaction_status(
+    _state: State<Arc<AppState>>,
+    _project_id: &str,
+    _signature: &str,
+    _chain_id: &Caip2ChainId,
+) -> Result<TransactionStatus, BuildPosTxError> {
+    Ok(TransactionStatus::Pending)
+}
+
+fn tron_base58_to_eth_address(b58: &str) -> Result<EthAddress, BuildPosTxError> {
+    let bytes = bs58::decode(b58).with_check(None).into_vec().map_err(|e| BuildPosTxError::Validation(format!("Failed to decode TRON address: {}", e)))?;
+    if bytes.len() != 21 || bytes[0] != 0x41 {
+        return Err(BuildPosTxError::Validation("invalid TRON address payload".to_string()));
+    }
+    Ok(EthAddress::from_slice(&bytes[1..21]))
+}
+
+fn tron_b58_to_hex41(b58: &str) -> Result<String, BuildPosTxError> {
+    let bytes = bs58::decode(b58).with_check(None).into_vec().map_err(|e| BuildPosTxError::Validation(format!("Failed to decode TRON address: {}", e)))?;
+    if bytes.len() != 21 || bytes[0] != 0x41 {
+        return Err(BuildPosTxError::Validation("invalid TRON address".to_string()));
+    }
+    Ok(format!("{}", hex::encode(bytes))) 
+}

--- a/src/handlers/wallet/pos/tron.rs
+++ b/src/handlers/wallet/pos/tron.rs
@@ -1,8 +1,8 @@
 use {
     super::{
         AssetNamespaceType, BuildPosTxError, BuildTransactionParams, BuildTransactionResult,
-        TransactionBuilder, TransactionId, TransactionRpc, TransactionStatus, CheckTransactionResult,
-        ValidatedTransactionParams,
+        CheckTransactionResult, TransactionBuilder, TransactionId, TransactionRpc,
+        TransactionStatus, ValidatedTransactionParams,
     },
     crate::{state::AppState, utils::crypto::Caip2ChainId},
     alloy::{
@@ -390,11 +390,12 @@ fn tron_b58_to_hex41(b58: &str) -> Result<String, BuildPosTxError> {
     Ok(format!("{}", hex::encode(bytes)))
 }
 
-
-pub async fn check_transaction( state: State<Arc<AppState>>,
+pub async fn check_transaction(
+    state: State<Arc<AppState>>,
     project_id: &str,
     response: &str,
-    chain_id: &Caip2ChainId) -> Result<CheckTransactionResult, BuildPosTxError> {
+    chain_id: &Caip2ChainId,
+) -> Result<CheckTransactionResult, BuildPosTxError> {
     let status = get_transaction_status(state, project_id, response, chain_id).await?;
 
     match status {


### PR DESCRIPTION
# Description

- Added Tron support to the POS flow, including building TRC20 transfers and checking transaction status.
- Extended the JSON-RPC response to return `tron_signTransaction` with strongly typed params and transaction payload (`raw_data_hex`, `txID`, `visible`) and no signature pre-sign.
- Wired Tron into the transaction builder routing so Tron assets resolve via namespace to `TronTransactionBuilder`.
- Implemented a Tron-specific check path and hooked it into `reown_pos_checkTransaction`.
- Refactored the check pipeline to delegate status checks to chain modules and return a unified `CheckTransactionResult` with `check_in` when pending.
- Moved polling intervals into chain modules and set chain defaults (EVM: 1000ms, Solana: 400ms).
- Switched CAIP-10 parsing to the namespace-aware variant and introduced `NamespaceValidator` for address checks, enabling Tron addresses.
- Introduced `SupportedNamespaces::Tron` and the tron module alongside existing EVM and Solana modules.
- Updated POS type definitions to include Tron transaction types and RPC shape.
- Expanded integration tests to cover Tron transaction building and status confirmation on Nile testnet.

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [x] Requires a e2e/integration test update
