### PR TITLE
fix(tests): adding a small delay before check for names count

### DIFF
--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -380,6 +380,8 @@ async fn insert_and_check_names_count() {
     )
     .await;
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+    // Add a delay to ensure the count is updated
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Check the count of names AFTER inserting
     let stats_after_insert = get_account_names_stats(&pg_pool).await.unwrap().count;


### PR DESCRIPTION
# Description

This PR adds a second delay before inserting and checking for the new name to fix [the flaky tests](https://github.com/reown-com/blockchain-api/actions/runs/17576728308/job/49924047237#step:5:2036).

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
