### PR TITLE
fix(identity): increasing identity provider response size cap

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -43,8 +43,8 @@ const CACHE_TTL_STD: Duration = Duration::from_secs(CACHE_TTL);
 const SELF_PROVIDER_ERROR_PREFIX: &str = "SelfProviderError: ";
 const EMPTY_RPC_RESPONSE: &str = "0x";
 pub const ETHEREUM_MAINNET: &str = "eip155:1";
-/// Cap to 50 Kb max size for the identity response
-const IDENTITY_RESPONSE_MAX_BYTES: usize = 50 * 1024;
+/// Cap to 150 Kb max size for the identity response
+const IDENTITY_RESPONSE_MAX_BYTES: usize = 150 * 1024;
 
 /// Error codes that reflect an `execution reverted` and should proceed with Ok() during
 /// the identity avatar lookup because of an absence of the ERC-721 contract address or


### PR DESCRIPTION
# Description

This PR increases the identity RPC provider response body size cap from 50 KB to 150 KB.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
