### PR TITLE
fix(pos): update solana check rpc parsing

### DIFF
--- a/integration/pos.test.ts
+++ b/integration/pos.test.ts
@@ -311,6 +311,27 @@ describe('POS', () => {
       expect(responseData.result).toBeDefined();
       expect(responseData.result.status).toBe('CONFIRMED');
     });
+
+    it('should check the transaction status with full send result', async () => {
+      const payload: CheckTransactionRequest = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wc_pos_checkTransaction',
+        params: {
+          id: solanaMainnetTransactionId,
+          sendResult: JSON.stringify({
+            signature: solanaMainnetSignature
+          }),
+        }
+      };
+
+      const response = await httpClient.post(`${baseUrl}/v1/json-rpc?projectId=${projectId}`, payload);
+
+      expect(response.status).toBe(200);
+      const responseData = response.data as CheckTransactionResponse;
+      expect(responseData.result).toBeDefined();
+      expect(responseData.result.status).toBe('CONFIRMED');
+    });
   });
 
   describe('Tron', () => {


### PR DESCRIPTION
# Description

Currently we are expecting the wallets to provide the entire result in the check RPC, which for `solana_signAndSendTransaction` is `{"signature":"signatureValue"}` however we expected just the string, not the full object.

Updating implementation to parse the full object first, and then fallback to string.


Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [x] Requires a e2e/integration test update
