### PR TITLE
feat(CI): switching to the GitHub release only and the commit hash only

### DIFF
--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -41,7 +41,7 @@ jobs:
   release:
     name: Release
     needs: [ paths_filter ]
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@feat/switch_to_release_only_workflow
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.19
     secrets: inherit
     with:
       task-name: ${{ vars.TASK_NAME }}

--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -41,7 +41,7 @@ jobs:
   release:
     name: Release
     needs: [ paths_filter ]
-    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.2.18
+    uses: WalletConnect/ci_workflows/.github/workflows/release.yml@feat/switch_to_release_only_workflow
     secrets: inherit
     with:
       task-name: ${{ vars.TASK_NAME }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,7 +8322,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-proxy"
-version = "0.300.1"
+version = "0.0.0"
 dependencies = [
  "alloy 0.11.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "rpc-proxy"
-version = "0.300.1"
 edition = "2021"
 authors = [
     "Derek <derek@reown.com>",
@@ -10,6 +9,9 @@ authors = [
 license-file = "LICENSE.md"
 build = "build.rs"
 publish = false
+
+# Using the commit hash instead of the version tagging for the build identification
+version = "0.0.0"
 
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.15.0", features = ["alloc", "analytics", "future", "metrics", "geoip", "rate_limit", "geoblock"] }


### PR DESCRIPTION
# Description

This PR switches to the GitHub release-only workflow instead of the `Cargo.toml` release bump to avoid creating new commits during the release process and using the default `0.0.0` version. 
The build identification will be based only on the commit hash, which is already included in the `/health` endpoint response. 

## How Has This Been Tested?

Not tested.

## Merging requirements

* [x] Change the [WalletConnect/ci_workflows](https://github.com/WalletConnect/ci_workflows/pull/17) branch to the release tag when the dependency merged.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
