### PR TITLE
fix: fixing clippy warnings

### DIFF
--- a/src/handlers/json_rpc/exchanges/binance.rs
+++ b/src/handlers/json_rpc/exchanges/binance.rs
@@ -185,11 +185,6 @@ pub struct Customization {
     lock_order_attributes: Option<Vec<i32>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-enum LockOrderAttributeType {
-    All = 1,
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PreOrderResponseData {
@@ -198,38 +193,9 @@ struct PreOrderResponseData {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PaymentMethodListRequest {
-    pub fiat_currency: String,
-    pub crypto_currency: String,
-    pub total_amount: String,
-    pub amount_type: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 enum AmountType {
     Fiat = 1,
     Crypto = 2,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PaymentMethodListResponseData {
-    payment_methods: Vec<PaymentMethod>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PaymentMethod {
-    pay_method_code: Option<String>,
-    pay_method_sub_code: Option<String>,
-    payment_method: Option<String>,
-    fiat_min_limit: Option<String>,
-    fiat_max_limit: Option<String>,
-    crypto_min_limit: Option<String>,
-    crypto_max_limit: Option<String>,
-    p2p: Option<bool>,
-    withdraw_restriction: Option<i32>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/handlers/json_rpc/exchanges/coinbase.rs
+++ b/src/handlers/json_rpc/exchanges/coinbase.rs
@@ -70,49 +70,10 @@ static CHAIN_ID_TO_COINBASE_NETWORK: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 });
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-enum PaymentMethod {
-    Unspecified,
-    Card,
-    AchBankAccount,
-    ApplePay,
-    FiatWallet,
-    CryptoAccount,
-    GuestCheckoutCard,
-    PayPal,
-    Rtp,
-    GuestCheckoutApplePay,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GenerateBuyQuoteRequest {
-    country: String,
-    payment_amount: String,
-    payment_currency: String,
-    payment_method: PaymentMethod,
-    purchase_currency: String,
-    purcase_network: String,
-    #[serde(default)]
-    subdivision: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CurrencyAmount {
     currency: String,
     value: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct GenerateBuyQuoteResponse {
-    coinbase_fee: CurrencyAmount,
-    network_fee: CurrencyAmount,
-    payment_subtotal: CurrencyAmount,
-    payment_total: CurrencyAmount,
-    purchase_amount: CurrencyAmount,
-    quote_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/handlers/json_rpc/wallet/prepare_calls.rs
+++ b/src/handlers/json_rpc/wallet/prepare_calls.rs
@@ -810,7 +810,10 @@ fn decode_and_convert_signature_format(
             Ok(signature)
         } else {
             // Try to split concatenated signatures into array
-            if signature.len() % ECDSA_SIGNATURE_WITH_RECOVERY_LENGTH == 0 && !signature.is_empty()
+            if signature
+                .len()
+                .is_multiple_of(ECDSA_SIGNATURE_WITH_RECOVERY_LENGTH)
+                && !signature.is_empty()
             {
                 let num_sigs = signature.len() / ECDSA_SIGNATURE_WITH_RECOVERY_LENGTH;
 

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -120,12 +120,6 @@ pub struct JsonRpcRequest<T: Serialize + Send + Sync> {
     pub params: T,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-struct BundlerJsonRpcParams {
-    user_op: UserOperation,
-    entry_point: String,
-}
-
 /// ERC-4337 bundler userOperation schema v0.7
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
# Description

This PR fixes Clippy [warnings in the recent Rust version](https://github.com/reown-com/blockchain-api/actions/runs/17914085948/job/50932040123?pr=1242#step:6:2014) by removing dead code parts.

## How Has This Been Tested?

* CI Clippy must pass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
