### PR TITLE
feat: adding Rootstock tokens pricing by using Lifi

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -90,6 +90,25 @@ describe('Fungible price', () => {
     }
   })
 
+  it('get Rootstock token price', async () => {
+    // RIF on Rootstock
+    const rootstock_token_address = 'eip155:30:0x2AcC95758f8b5F583470ba265EB685a8F45fC9D5';
+    let request_data = {
+      projectId: projectId,
+      currency: currency,
+      addresses: [rootstock_token_address]
+    }
+    let resp: any = await httpClient.post(
+      `${endpoint}`,
+      request_data
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.fungibles).toBe('object')
+    expect(resp.data.fungibles.length).toBe(1)
+    let item = resp.data.fungibles[0]
+    expect(item.name).toBe('RIF')
+  })
+
   it('bad arguments', async () => {
     // Empty addresses
     let request_data = {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -194,6 +194,7 @@ mod test {
             ("RPC_PROXY_PROVIDER_COINBASE_APP_ID", "COINBASE_APP_ID"),
             ("RPC_PROXY_PROVIDER_ONE_INCH_API_KEY", "ONE_INCH_API_KEY"),
             ("RPC_PROXY_PROVIDER_ONE_INCH_REFERRER", "ONE_INCH_REFERRER"),
+            ("RPC_PROXY_PROVIDER_LIFI_API_KEY", "LIFI_API_KEY"),
             ("RPC_PROXY_PROVIDER_PIMLICO_API_KEY", "PIMLICO_API_KEY"),
             (
                 "RPC_PROXY_PROVIDER_SOLSCAN_API_V2_TOKEN",
@@ -337,6 +338,7 @@ mod test {
                     coinbase_app_id: Some("COINBASE_APP_ID".to_owned()),
                     one_inch_api_key: Some("ONE_INCH_API_KEY".to_owned()),
                     one_inch_referrer: Some("ONE_INCH_REFERRER".to_owned()),
+                    lifi_api_key: Some("LIFI_API_KEY".to_owned()),
                     pimlico_api_key: "PIMLICO_API_KEY".to_string(),
                     solscan_api_v2_token: "SOLSCAN_API_V2_TOKEN".to_string(),
                     bungee_api_key: "BUNGEE_API_KEY".to_string(),

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -68,9 +68,14 @@ async fn handler_internal(
         return Err(RpcError::InvalidAddress);
     };
 
-    let (namespace, chain_id, address) = crypto::disassemble_caip10(address)?;
+    let (mut namespace, chain_id, address) = crypto::disassemble_caip10(address)?;
     if !crypto::is_address_valid(&address, &namespace) {
         return Err(RpcError::InvalidAddress);
+    }
+
+    // TODO: Handle Rootstock as a separate namespace to get the correct provider
+    if chain_id == "30" {
+        namespace = crypto::CaipNamespaces::Rootstock;
     }
 
     let provider = state

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -17,6 +17,8 @@ use {
     wc::metrics::{future_metrics, FutureExt},
 };
 
+const ROOTSTOCK_CHAIN_ID: &str = "30";
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceQueryParams {
@@ -74,7 +76,7 @@ async fn handler_internal(
     }
 
     // TODO: Handle Rootstock as a separate namespace to get the correct provider
-    if chain_id == "30" {
+    if chain_id == ROOTSTOCK_CHAIN_ID {
         namespace = crypto::CaipNamespaces::Rootstock;
     }
 

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -61,7 +61,7 @@ async fn handler_internal(
     let project_id = query.project_id.clone();
     state.validate_project_access_and_quota(&project_id).await?;
 
-    if query.addresses.is_empty() && query.addresses.len() > 1 {
+    if query.addresses.is_empty() {
         return Err(RpcError::InvalidAddress);
     }
     let address = if let Some(address) = query.addresses.first() {

--- a/src/providers/dune.rs
+++ b/src/providers/dune.rs
@@ -174,7 +174,7 @@ impl BalanceProvider for DuneProvider {
             .unwrap_or(crypto::CaipNamespaces::Eip155);
 
         let balance_response = match namespace {
-            crypto::CaipNamespaces::Eip155 => {
+            crypto::CaipNamespaces::Eip155 | crypto::CaipNamespaces::Rootstock => {
                 self.get_evm_balance(address, params, metrics.clone())
                     .await?
             }
@@ -198,7 +198,9 @@ impl BalanceProvider for DuneProvider {
                 Some(cid) => format!("{namespace}:{cid}"),
                 None => match namespace {
                     // Use default Mainnet chain IDs if not provided
-                    crypto::CaipNamespaces::Eip155 => format!("{namespace}:1"),
+                    crypto::CaipNamespaces::Eip155 | crypto::CaipNamespaces::Rootstock => {
+                        format!("{namespace}:1")
+                    }
                     crypto::CaipNamespaces::Solana => {
                         format!("{namespace}:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")
                     }
@@ -208,7 +210,7 @@ impl BalanceProvider for DuneProvider {
             // Build the CAIP-10 address
             let caip10_token_address_strict = if f.address == "native" {
                 match namespace {
-                    crypto::CaipNamespaces::Eip155 => {
+                    crypto::CaipNamespaces::Eip155 | crypto::CaipNamespaces::Rootstock => {
                         format!("{caip2_chain_id}:{H160_EMPTY_ADDRESS}")
                     }
                     crypto::CaipNamespaces::Solana => {
@@ -300,7 +302,9 @@ impl BalanceProvider for DuneProvider {
                     // For Solana’s “native” token, we return the Solana native token address.
                     if f.address == "native" {
                         match namespace {
-                            crypto::CaipNamespaces::Eip155 => None,
+                            crypto::CaipNamespaces::Eip155 | crypto::CaipNamespaces::Rootstock => {
+                                None
+                            }
                             crypto::CaipNamespaces::Solana => {
                                 Some(crypto::SOLANA_NATIVE_TOKEN_ADDRESS.to_string())
                             }

--- a/src/providers/lifi.rs
+++ b/src/providers/lifi.rs
@@ -1,0 +1,146 @@
+use {
+    crate::{
+        error::{RpcError, RpcResult},
+        handlers::{fungible_price::FungiblePriceItem, SupportedCurrencies},
+        providers::{
+            FungiblePriceProvider, PriceResponseBody, ProviderKind, TokenMetadataCacheProvider,
+        },
+        utils::crypto,
+        Metrics,
+    },
+    async_trait::async_trait,
+    serde::Deserialize,
+    std::{sync::Arc, time::SystemTime},
+    tracing::log::error,
+    url::Url,
+};
+
+#[derive(Debug)]
+pub struct LifiProvider {
+    pub provider_kind: ProviderKind,
+    pub api_key: Option<String>,
+    pub base_api_url: String,
+    pub http_client: reqwest::Client,
+}
+
+impl LifiProvider {
+    pub fn new(api_key: Option<String>) -> Self {
+        let base_api_url = "https://li.quest/v1".to_string();
+        let http_client = reqwest::Client::new();
+        Self {
+            provider_kind: ProviderKind::Lifi,
+            api_key,
+            base_api_url,
+            http_client,
+        }
+    }
+
+    async fn send_request(&self, url: Url) -> Result<reqwest::Response, reqwest::Error> {
+        if let Some(api_key) = &self.api_key {
+            self.http_client
+                .get(url)
+                .header("x-lifi-api-key", api_key.clone())
+                .send()
+                .await
+        } else {
+            self.http_client.get(url).send().await
+        }
+    }
+
+    pub async fn get_token_info(
+        &self,
+        chain_id: &str,
+        address: &str,
+        _currency: &SupportedCurrencies,
+        metrics: Arc<Metrics>,
+    ) -> Result<LifiTokenItem, RpcError> {
+        let address = address.to_lowercase();
+        let mut url = Url::parse(format!("{}/token", &self.base_api_url).as_str())
+            .map_err(|_| RpcError::ConversionParseURLError)?;
+        url.query_pairs_mut().append_pair("chain", chain_id);
+        url.query_pairs_mut().append_pair("token", &address);
+
+        let latency_start = SystemTime::now();
+        let price_response = self.send_request(url).await.map_err(|e| {
+            error!("Error sending request to Lifi provider for fungible price: {e:?}");
+            RpcError::ConversionProviderError
+        })?;
+        metrics.add_latency_and_status_code_for_provider(
+            &self.provider_kind,
+            price_response.status().into(),
+            latency_start,
+            Some(chain_id.to_string()),
+            Some("token_info".to_string()),
+        );
+
+        if !price_response.status().is_success() {
+            // Passing through error description for the error context
+            // if user parameter is invalid (got 400 status code from the provider)
+            if price_response.status() == reqwest::StatusCode::BAD_REQUEST {
+                return Err(RpcError::ConversionInvalidParameter(
+                    "Invalid token or chain parameter".to_string(),
+                ));
+            }
+            // 404 response is expected when the asset is not supported
+            if price_response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(RpcError::AssetNotSupported(address.clone()));
+            }
+
+            error!(
+                "Error on getting fungible price from Lifi provider. Status is not OK: {:?}",
+                price_response.status(),
+            );
+            return Err(RpcError::ConversionProviderError);
+        }
+        let price_body = price_response.json::<LifiTokenItem>().await?;
+        Ok(price_body)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LifiTokenItem {
+    symbol: String,
+    name: String,
+    decimals: u8,
+    #[serde(alias = "logoURI")]
+    logo_uri: Option<String>,
+    #[serde(alias = "priceUSD")]
+    price_usd: Option<String>,
+}
+
+#[async_trait]
+impl FungiblePriceProvider for LifiProvider {
+    async fn get_price(
+        &self,
+        chain_id: &str,
+        address: &str,
+        currency: &SupportedCurrencies,
+        _metadata_cache: &Arc<dyn TokenMetadataCacheProvider>,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<PriceResponseBody> {
+        let price = self
+            .get_token_info(chain_id, address, currency, metrics.clone())
+            .await?;
+        let response = PriceResponseBody {
+            fungibles: vec![FungiblePriceItem {
+                address: format!(
+                    "{}:{}:{}",
+                    crypto::CaipNamespaces::Eip155,
+                    chain_id,
+                    address
+                ),
+                name: price.name,
+                symbol: price.symbol,
+                icon_url: price.logo_uri.unwrap_or_default(),
+                price: price
+                    .price_usd
+                    .unwrap_or("0.0".to_string())
+                    .parse()
+                    .unwrap_or(0.0),
+                decimals: price.decimals,
+            }],
+        };
+
+        Ok(response)
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -154,6 +154,7 @@ mod drpc;
 mod dune;
 pub mod generic;
 mod hiro;
+mod lifi;
 mod mantle;
 mod meld;
 pub mod mock_alto;
@@ -192,6 +193,7 @@ pub use {
     dune::DuneProvider,
     generic::GenericProvider,
     hiro::HiroProvider,
+    lifi::LifiProvider,
     mantle::MantleProvider,
     meld::MeldProvider,
     monad::MonadProvider,
@@ -240,6 +242,8 @@ pub struct ProvidersConfig {
     pub coinbase_app_id: Option<String>,
     pub one_inch_api_key: Option<String>,
     pub one_inch_referrer: Option<String>,
+    /// Lifi API key
+    pub lifi_api_key: Option<String>,
     /// Pimlico API token key
     pub pimlico_api_key: String,
     /// SolScan API v2 token key
@@ -380,6 +384,7 @@ impl ProviderRepository {
 
         let zerion_provider = Arc::new(ZerionProvider::new(zerion_api_key));
         let one_inch_provider = Arc::new(OneInchProvider::new(one_inch_api_key, one_inch_referrer));
+        let lifi_provider = Arc::new(LifiProvider::new(config.lifi_api_key.clone()));
         let portfolio_provider = zerion_provider.clone();
         let solscan_provider = Arc::new(SolScanProvider::new(
             config.solscan_api_v2_token.clone(),
@@ -418,6 +423,7 @@ impl ProviderRepository {
             HashMap::new();
         fungible_price_providers.insert(CaipNamespaces::Eip155, one_inch_provider.clone());
         fungible_price_providers.insert(CaipNamespaces::Solana, solscan_provider.clone());
+        fungible_price_providers.insert(CaipNamespaces::Rootstock, lifi_provider.clone());
 
         let chain_orchestrator_provider =
             Arc::new(BungeeProvider::new(config.bungee_api_key.clone()));
@@ -825,6 +831,7 @@ pub enum ProviderKind {
     Moonbeam,
     Blast,
     Rootstock,
+    Lifi,
     Generic(String),
 }
 
@@ -867,6 +874,7 @@ impl Display for ProviderKind {
                 ProviderKind::Moonbeam => "Moonbeam",
                 ProviderKind::Blast => "Blast",
                 ProviderKind::Rootstock => "Rootstock",
+                ProviderKind::Lifi => "Lifi",
                 ProviderKind::Generic(name) => name.as_str(),
             }
         )

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -681,7 +681,7 @@ pub fn is_address_valid(address: &str, namespace: &CaipNamespaces) -> bool {
 
 fn is_address_valid_impl(address: &str, namespace: &CaipNamespaces) -> bool {
     match namespace {
-        CaipNamespaces::Eip155 => {
+        CaipNamespaces::Eip155 | CaipNamespaces::Rootstock => {
             if !CAIP_ETH_ADDRESS_REGEX.is_match(address) {
                 return false;
             }
@@ -815,6 +815,7 @@ impl ChainId {
 pub enum CaipNamespaces {
     Eip155,
     Solana,
+    Rootstock, // TODO: A temporary solution to support Rootstock
 }
 
 /// A struct representing a CAIP-2 Chain ID with format:

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -109,6 +109,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_MELD_API_URL", value = var.meld_api_url },
         { name = "RPC_PROXY_PROVIDER_CALLSTATIC_API_KEY", value = var.callstatic_api_key },
         { name = "RPC_PROXY_PROVIDER_BLAST_API_KEY", value = var.blast_api_key },
+        { name = "RPC_PROXY_PROVIDER_LIFI_API_KEY", value = var.lifi_api_key },
 
         { name = "RPC_PROXY_SKIP_QUOTA_CHAINS", value = var.proxy_skip_quota_chains },
 

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -287,6 +287,12 @@ variable "blast_api_key" {
   sensitive   = true
 }
 
+variable "lifi_api_key" {
+  description = "Lifi API key"
+  type        = string
+  sensitive   = true
+}
+
 variable "testing_project_id" {
   description = "Project ID used in a testing suite"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -83,6 +83,7 @@ module "ecs" {
   meld_api_url         = var.meld_api_url
   callstatic_api_key   = var.callstatic_api_key
   blast_api_key        = var.blast_api_key
+  lifi_api_key         = var.lifi_api_key
 
   # RPC Proxy configuration
   proxy_skip_quota_chains = var.proxy_skip_quota_chains

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -217,6 +217,12 @@ variable "blast_api_key" {
   sensitive   = true
 }
 
+variable "lifi_api_key" {
+  description = "Lifi API key"
+  type        = string
+  sensitive   = true
+}
+
 #-------------------------------------------------------------------------------
 # RPC Proxy configuration
 


### PR DESCRIPTION
# Description

This PR adds support for Rootstock tokens price to the fungibles endpoint by using the [Lifi token info API](https://docs.li.fi/api-reference/fetch-information-about-a-token) because the current 1Inch API doesn't support the Rootstock chain, and we are making an exclusion for it.

## How Has This Been Tested?

The new integration test for the Rootstock token price was implemented.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
