### PR TITLE
fix(ECR): applying images retention policy

### DIFF
--- a/terraform/res_ecr.tf
+++ b/terraform/res_ecr.tf
@@ -1,5 +1,9 @@
+data "aws_ecr_repository" "blockchain" {
+  name = "blockchain"
+}
+
 resource "aws_ecr_lifecycle_policy" "blockchain_keep_30" {
-  repository = "blockchain"
+  repository = data.aws_ecr_repository.blockchain.name
 
   policy = jsonencode({
     rules = [

--- a/terraform/res_ecr.tf
+++ b/terraform/res_ecr.tf
@@ -1,0 +1,20 @@
+resource "aws_ecr_lifecycle_policy" "blockchain_keep_30" {
+  repository = "blockchain"
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire images beyond the last 30"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 30
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/res_ecr.tf
+++ b/terraform/res_ecr.tf
@@ -1,9 +1,5 @@
-data "aws_ecr_repository" "blockchain" {
-  name = "blockchain"
-}
-
 resource "aws_ecr_lifecycle_policy" "blockchain_keep_30" {
-  repository = data.aws_ecr_repository.blockchain.name
+  repository = var.ecr_repository_name
 
   policy = jsonencode({
     rules = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,6 +56,12 @@ variable "ofac_countries" {
   default     = ""
 }
 
+variable "ecr_repository_name" {
+  description = "Name of the ECR repository"
+  type        = string
+  default     = "blockchain"
+}
+
 #-------------------------------------------------------------------------------
 # Project Registry
 


### PR DESCRIPTION
# Description

This PR adds an ECR images retention policy for the `blockchain` repository to keep the last 30 images only.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
