### PR TITLE
feat(CORS): populate CORS headers for the `/json-rpc` exchanges endpoint

### DIFF
--- a/integration/exchanges.test.ts
+++ b/integration/exchanges.test.ts
@@ -635,4 +635,24 @@ describe('Exchanges', () => {
       });
     });
   });
+
+  describe('CORS headers', () => {
+    it('should not return CORS headers if not allowed', async () => {
+      const response = await httpClient.get(
+        `${baseUrl}/v1/json-rpc?projectId=${projectId}`
+      );
+      // Dont have an access-control-allow-origin header if not allowed
+      expect(response.headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('should return CORS headers for specific origin', async () => {
+      const origin = 'https://demo.reown.com';
+      const response = await httpClient.get(
+        `${baseUrl}/v1/json-rpc?projectId=${projectId}`,
+        { headers: { 'Origin': origin } }
+      );
+      
+      expect(response.headers['access-control-allow-origin']).toBe(origin);
+    });
+  });
 }); 


### PR DESCRIPTION
# Description

This PR populates CORS headers for the `/json-rpc` exchanges endpoint.

Per-project CORS driven by the `projectId` query param and the project’s registry data. 
Preflight and actual responses now set CORS headers only if the request `Origin` matches the project’s `allowed_origins`.

### How it works:

* OPTIONS → json_rpc_preflight
* POST → json_rpc_with_dynamic_cors

Both handlers read `projectId` query param, fetch project data and:

* Allow if `Origin` matches any `allowed_origins` (case-insensitive exact match) or a hostname entry in allowed_origins.
* Preflight returns `204` with `Access-Control-Allow-*` headers when allowed, otherwise `403`.
* `POST` adds `Access-Control-Allow-Origin` and related headers to the normal response when allowed. Otherwise, it returns the normal response *without CORS headers* (browser will block).

## How Has This Been Tested?

Two integration tests were implemented: CORS header allow and deny (no header).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
