### PR TITLE
feat(o11y): adding exchanges, pos, wallet service o11y charts

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -236,6 +236,11 @@ dashboard.new(
   row.new('Swaps'),
     panels.swaps.availability(ds, vars)           { gridPos: pos._1 },
 
+  row.new('Exchanges / Wallet / POS'),
+    panels.rpc.availability(ds, vars)             { gridPos: pos._3 },
+    panels.rpc.calls_by_method(ds, vars)          { gridPos: pos._3 },
+    panels.rpc.latency_by_method(ds, vars)        { gridPos: pos._3 },
+
   row.new('Redis'),
     panels.redis.cpu(ds, vars)                    { gridPos: pos._2 },
     panels.redis.memory(ds, vars)                 { gridPos: pos._2 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -113,6 +113,12 @@ local redis  = panels.aws.redis;
     availability: (import 'swaps/availability.libsonnet').new,
   },
 
+  rpc: {
+    availability: (import 'rpc/availability.libsonnet').new,
+    calls_by_method: (import 'rpc/calls_by_method.libsonnet').new,
+    latency_by_method: (import 'rpc/latency_by_method.libsonnet').new,
+  },
+
   chain_rpc_router: {
     panels: (import 'chain_rpc_router/chain_rpc_router.libsonnet').new,
   },

--- a/terraform/monitoring/panels/rpc/availability.libsonnet
+++ b/terraform/monitoring/panels/rpc/availability.libsonnet
@@ -22,7 +22,7 @@ local targets        = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/json-rpc"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/json-rpc"}[$__rate_interval]))))*100',
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/json-rpc"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/json-rpc"}[$__rate_interval])) or vector(0)))*100',
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/rpc/availability.libsonnet
+++ b/terraform/monitoring/panels/rpc/availability.libsonnet
@@ -1,0 +1,29 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels         = grafana.panels;
+local targets        = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Availability',
+      datasource  = ds.prometheus,
+    )
+    .configure(
+      defaults.configuration.timeseries
+        .withUnit('percent')
+        .withSoftLimit(
+          axisSoftMin = 98,
+          axisSoftMax = 100,
+        )
+        .withSpanNulls(true)
+    )
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-9]", route="/v1/json-rpc"}[$__rate_interval])) or vector(0))/(sum(rate(http_call_counter_total{route="/v1/json-rpc"}[$__rate_interval]))))*100',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    ))
+}

--- a/terraform/monitoring/panels/rpc/calls_by_method.libsonnet
+++ b/terraform/monitoring/panels/rpc/calls_by_method.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(method) (increase(json_rpc_call_counter_total{}[$__rate_interval]))',
+      expr          = 'sum by(method) (rate(json_rpc_call_counter_total{}[$__rate_interval]))',
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/rpc/calls_by_method.libsonnet
+++ b/terraform/monitoring/panels/rpc/calls_by_method.libsonnet
@@ -1,0 +1,21 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Calls by method',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = 'sum by(method) (increase(json_rpc_call_counter_total{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    ))
+}

--- a/terraform/monitoring/panels/rpc/latency_by_method.libsonnet
+++ b/terraform/monitoring/panels/rpc/latency_by_method.libsonnet
@@ -1,0 +1,24 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('s');
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Methods latency',
+      datasource  = ds.prometheus,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(method) (rate(json_rpc_call_latency_tracker_sum[$__rate_interval])) / sum by(method) (rate(json_rpc_call_latency_tracker_count[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    ))
+}


### PR DESCRIPTION
# Description

This PR adds the following o11y charts for the `/v1/json-rpc` endpoint for POS, Exchanges and Wallet service:

* Total % endpoint availability calculated by the successful responses divided by all requests;
* Endpoint latency by method;
* Total calls by method.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
