### PR TITLE
fix(CD): ignoring the flaky test

### DIFF
--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -348,6 +348,8 @@ async fn insert_delete_two_addresses() {
     assert!(delete_result.is_ok(), "Deleting name should succeed");
 }
 
+/// This test is ignored because because of the flakiness until the fix
+/// We are also testing names in `/integration/names.test.ts`
 #[tokio::test]
 #[ignore]
 async fn insert_and_check_names_count() {

--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -349,6 +349,7 @@ async fn insert_delete_two_addresses() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn insert_and_check_names_count() {
     let pg_pool = get_postgres_pool().await;
 


### PR DESCRIPTION
# Description

This PR adds ignoring the flaky names count test until the fix. 
We are already cross-checking names in [separate integration tests](https://github.com/reown-com/blockchain-api/blob/master/integration/names.test.ts).

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
