### PR TITLE
feat(rpc): wrapping Tron broadcast transaction API into the custom JSON-RPC method

### DIFF
--- a/integration/proxy.test.ts
+++ b/integration/proxy.test.ts
@@ -151,6 +151,32 @@ describe('Proxy', () => {
     }
   })
 
+  it('Tron broadcast transaction wrapped RPC method', async () => {
+    const chainId = "tron:0x2b6653dc";
+    // Expired transaction payload, but we can check if the method is working
+    const payload = {
+      jsonrpc: "2.0",
+      method: "tron_broadcastTransaction",
+      params:[
+        "0x1",
+        "true",
+        "{\"contract\":[{\"parameter\":{\"value\":{\"amount\":1000,\"owner_address\":\"41608f8da72479edc7dd921e4c30bb7e7cddbe722e\",\"to_address\":\"41e9d79cc47518930bc322d9bf7cddd260a0260a8d\"},\"type_url\":\"type.googleapis.com/protocol.TransferContract\"},\"type\":\"TransferContract\"}],\"ref_block_bytes\":\"5e4b\",\"ref_block_hash\":\"47c9dc89341b300d\",\"expiration\":1591089627000,\"timestamp\":1591089567635}",
+        "0a025e4b220847c9dc89341b300d40f8fed3a2a72e5a66080112620a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412310a1541608f8da72479edc7dd921e4c30bb7e7cddbe722e121541e9d79cc47518930bc322d9bf7cddd260a0260a8d18e8077093afd0a2a72e",
+        ["0a025e4b220847c9dc8934"]
+      ],
+      id: 1,
+    };
+
+    const resp: any = await httpClient.post(
+      `${baseUrl}/v1?chainId=${chainId}&projectId=${projectId}`,
+      payload
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data).toBe('object')
+    expect(typeof resp.data.result).toBe('object')
+    expect(typeof resp.data.result.txid).toBe('string')
+  })
+
   it('net_listening RPC method', async () => {
     // Get the chains list from the /supported-chains endpoint
     const chainsResp: any = await httpClient.get(`${baseUrl}/v1/supported-chains`)

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -33,7 +33,7 @@ struct BroadcastTransactionRequest {
 }
 
 #[derive(Debug, Serialize)]
-struct TonApiResult {
+struct TronApiResult {
     pub result: serde_json::Value,
 }
 
@@ -75,7 +75,7 @@ impl QuicknodeProvider {
                 )));
             }
         };
-        let wrapped_response = TonApiResult {
+        let wrapped_response = TronApiResult {
             result: original_result,
         };
         serde_json::to_vec(&wrapped_response).map_err(|e| {
@@ -114,7 +114,11 @@ impl QuicknodeProvider {
         } else if let Some(s) = params[4].as_str() {
             let trimmed = s.trim();
             if trimmed.starts_with('[') && trimmed.ends_with(']') {
-                serde_json::from_str::<Vec<String>>(trimmed).unwrap_or_else(|_| vec![s.to_string()])
+                serde_json::from_str::<Vec<String>>(trimmed).map_err(|e| {
+                    RpcError::InvalidParameter(format!(
+                        "Signature must be a JSON array of strings when provided as a string: {e}"
+                    ))
+                })?
             } else {
                 vec![s.to_string()]
             }

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -109,8 +109,8 @@ impl QuicknodeProvider {
             false
         };
         let raw_data = if let Some(s) = params[2].as_str() {
-            serde_json::from_str(s).map_err(|e| {
-                RpcError::InvalidParameter(format!("Invalid JSON in raw_data parameter: {e}"))
+            serde_json::from_str(s).map_err(|_| {
+                RpcError::InvalidParameter("Invalid JSON in raw_data parameter".to_string())
             })?
         } else {
             params[2].clone()

--- a/src/providers/quicknode.rs
+++ b/src/providers/quicknode.rs
@@ -6,6 +6,7 @@ use {
     crate::{
         env::QuicknodeConfig,
         error::{RpcError, RpcResult},
+        json_rpc::JsonRpcRequest,
         ws,
     },
     async_trait::async_trait,
@@ -15,9 +16,31 @@ use {
         response::{IntoResponse, Response},
     },
     hyper::http,
+    serde::Serialize,
     std::collections::HashMap,
+    tracing::debug,
     wc::metrics::{future_metrics, FutureExt},
 };
+
+#[derive(Debug, Serialize)]
+struct BroadcastTransactionRequest {
+    #[serde(rename = "txID")]
+    pub txid: String,
+    pub visible: bool,
+    pub raw_data: serde_json::Value,
+    pub raw_data_hex: String,
+    pub signature: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TonApiResult {
+    pub result: serde_json::Value,
+}
+
+const TRON_CHAIN_ID: &str = "tron:0x2b6653dc";
+
+/// The method name for the tron broadcast transaction wrapper method
+const TRON_BROADCAST_TRANSACTION_METHOD: &str = "tron_broadcastTransaction";
 
 #[derive(Debug)]
 pub struct QuicknodeProvider {
@@ -37,6 +60,133 @@ impl Provider for QuicknodeProvider {
 
     fn provider_kind(&self) -> ProviderKind {
         ProviderKind::Quicknode
+    }
+}
+
+impl QuicknodeProvider {
+    /// Helper function to wrap response body in JSON-RPC format
+    /// that uses the `result` field to wrap the non-JSON-RPC response body.
+    fn wrap_response_in_result(&self, body: &[u8]) -> Result<Vec<u8>, RpcError> {
+        let original_result = match serde_json::from_slice::<serde_json::Value>(body) {
+            Ok(value) => value,
+            Err(e) => {
+                return Err(RpcError::InvalidParameter(format!(
+                    "Failed to deserialize Quicknode non-JSON-RPC response: {e}"
+                )));
+            }
+        };
+        let wrapped_response = TonApiResult {
+            result: original_result,
+        };
+        serde_json::to_vec(&wrapped_response).map_err(|e| {
+            RpcError::InvalidParameter(format!(
+                "Failed to serialize wrapped Quicknode response: {e}"
+            ))
+        })
+    }
+
+    async fn handle_tron_broadcast_transaction(
+        &self,
+        params_value: serde_json::Value,
+    ) -> RpcResult<Response> {
+        // params array must be 5 elements for this method
+        let params = params_value.as_array().ok_or(RpcError::InvalidParameter(
+            "Params must be an array for tron_broadcastTransaction method".to_string(),
+        ))?;
+        if params.len() != 5 {
+            return Err(RpcError::InvalidParameter(
+                "Params array must be 5 elements for tron_broadcastTransaction method".to_string(),
+            ));
+        }
+        let txid = params[0]
+            .as_str()
+            .ok_or_else(|| RpcError::InvalidParameter("TxID is not a string".to_string()))?;
+        let visible = params[1].as_bool().unwrap_or(false);
+        let raw_data = params[2].clone();
+        let raw_data_hex = params[3].as_str().ok_or_else(|| {
+            RpcError::InvalidParameter("Raw data hex is not a string".to_string())
+        })?;
+        // Signature can be an array or a JSON-encoded string array
+        let signature_owned: Vec<String> = if let Some(arr) = params[4].as_array() {
+            arr.iter()
+                .map(|v| v.as_str().unwrap_or_default().to_string())
+                .collect()
+        } else if let Some(s) = params[4].as_str() {
+            let trimmed = s.trim();
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                serde_json::from_str::<Vec<String>>(trimmed).unwrap_or_else(|_| vec![s.to_string()])
+            } else {
+                vec![s.to_string()]
+            }
+        } else {
+            return Err(RpcError::InvalidParameter(
+                "Signature must be an array of strings or JSON-encoded array string".to_string(),
+            ));
+        };
+        let signature: Vec<&str> = signature_owned.iter().map(|s| s.as_str()).collect();
+
+        self.tron_broadcast_transaction(txid, visible, raw_data, raw_data_hex, signature)
+            .await
+    }
+
+    // Send request to the Tron broadcast transaction `/wallet/broadcasttransaction` API endpoint
+    async fn tron_broadcast_transaction(
+        &self,
+        txid: &str,
+        visible: bool,
+        raw_data: serde_json::Value,
+        raw_data_hex: &str,
+        signature: Vec<&str>,
+    ) -> RpcResult<Response> {
+        let token = &self
+            .supported_chains
+            .get(TRON_CHAIN_ID)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let chain_subdomain =
+            self.chain_subdomains
+                .get(TRON_CHAIN_ID)
+                .ok_or(RpcError::InvalidConfiguration(
+                    "Quicknode subdomain not found for Tron chain".to_string(),
+                ))?;
+
+        let uri =
+            format!("https://{chain_subdomain}.quiknode.pro/{token}/wallet/broadcasttransaction");
+
+        let transactions_request = serde_json::to_string(&BroadcastTransactionRequest {
+            txid: txid.to_string(),
+            visible,
+            raw_data,
+            raw_data_hex: raw_data_hex.to_string(),
+            signature: signature.iter().map(|s| s.to_string()).collect(),
+        })
+        .map_err(|e| RpcError::InvalidParameter(format!("Failed to serialize transaction: {e}")))?;
+
+        let response = self
+            .client
+            .post(uri)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(transactions_request)
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.bytes().await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                debug!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                 Quicknode transactions: {response:?}"
+                );
+            }
+        }
+
+        let wrapped_body = self.wrap_response_in_result(&body)?;
+        let mut response = (status, wrapped_body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 
@@ -63,6 +213,16 @@ impl RpcProvider for QuicknodeProvider {
                 .ok_or(RpcError::InvalidConfiguration(format!(
                     "Quicknode subdomain not found for chainId: {chain_id}"
                 )))?;
+
+        // Check for the tron broadcast transaction method exclusion
+        let json_rpc_request: JsonRpcRequest = serde_json::from_slice(&body)
+            .map_err(|_| RpcError::InvalidParameter("Invalid JSON-RPC schema provided".into()))?;
+        let method = json_rpc_request.method.to_string();
+        let params = json_rpc_request.params;
+        // Handle the tron broadcast transaction wrapped method and pass the parameters form an array
+        if method == TRON_BROADCAST_TRANSACTION_METHOD {
+            return self.handle_tron_broadcast_transaction(params).await;
+        }
 
         // Add /jsonrpc prefix for the Tron and /jsonRPC prefix for the Ton
         let uri = match chain_id {


### PR DESCRIPTION
# Description

This PR implements wrapping of the [Tron broadcast transaction HTTP API endpoint](https://www.quicknode.com/docs/tron/wallet-broadcasttransaction) into the custom `tron_broadcastTransaction` JSON-RPC method for the SDK compatibility.
HTTP API parameters: `txId, visible, raw_data, raw_data_hex, signature` are passed in the `params` JSON-RPC array in the same order.

## How Has This Been Tested?

A new integration test was created.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
