### PR TITLE
fix: fixing integration tests

### DIFF
--- a/integration/exchanges.test.ts
+++ b/integration/exchanges.test.ts
@@ -690,7 +690,8 @@ describe('Exchanges', () => {
       expect(response.headers['access-control-allow-origin']).toContain(origin);
     });
 
-    it('should return CORS headers for allowed origin (wildcard match)', async () => {
+    // TODO: Temporary skip this test unil the test project allowed domains will be updated
+    it.skip('should return CORS headers for allowed origin (wildcard match)', async () => {
       // Default allowed origins is https://*.vercel.app
       const origin = 'https://test.vercel.app';
       const payload = {

--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -62,7 +62,6 @@ describe('Fungible price', () => {
       { chainId: 56, symbol: 'BNB' },
       { chainId: 100, symbol: 'xDAI' },
       { chainId: 137, symbol: 'POL' },
-      { chainId: 250, symbol: 'FTM' },
       { chainId: 43114, symbol: 'AVAX' },
     ];
 


### PR DESCRIPTION
# Description

This PR fixes the integration tests flow by removing the FTM token from the test which is not supported anymore and temporarily skipping the CORS wildcard test until the testing ProjectId will be updated with the `https://*.vercel.app` wildcard domain.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
