### PR TITLE
feat(TON): adding `ton_sendBoc` wrapped method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 license-file = "LICENSE.md"
 build = "build.rs"
+default-run = "rpc-proxy"
 publish = false
 
 # Using the commit hash instead of the version tagging for the build identification


### PR DESCRIPTION
# Description

This PR implements TON JSOn-RPC `ton_sendBoc` custom method wrapper to send request to the [TON HTTP API sendBoc](https://www.quicknode.com/docs/ton/sendBoc) endpoint to allow send transactions since TON native JSON-RPC methods are read-only.

The `boc` parameter is mapped to the first json-rpc's `param` value.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
